### PR TITLE
feat(sync): add kimi as a sync target

### DIFF
--- a/cmd/gale-task/context.ts
+++ b/cmd/gale-task/context.ts
@@ -1,0 +1,95 @@
+import { promises as fs } from "fs"
+import path from "path"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CurrentTask {
+  task_id: string
+  started_at: string
+  skill: string
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution — relative to the project being worked on (process.cwd()),
+// NOT relative to the GaleHarnessCLI repo itself.
+// ---------------------------------------------------------------------------
+
+export const CONTEXT_FILE = path.join(
+  process.cwd(),
+  ".context",
+  "galeharness-cli",
+  "current-task.json",
+)
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isExpired(startedAt: string): boolean {
+  try {
+    const started = new Date(startedAt).getTime()
+    if (Number.isNaN(started)) return true
+    return Date.now() - started > TWENTY_FOUR_HOURS_MS
+  } catch {
+    return true
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API (default path)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the current task from `.context/galeharness-cli/current-task.json`
+ * in the working directory.
+ *
+ * Returns null if:
+ * - The file does not exist
+ * - The file is malformed
+ * - The `started_at` timestamp is older than 24 hours
+ */
+export async function readCurrentTask(): Promise<CurrentTask | null> {
+  return readCurrentTaskFrom(CONTEXT_FILE)
+}
+
+/**
+ * Write a task record to `.context/galeharness-cli/current-task.json`
+ * in the working directory, creating parent directories as needed.
+ */
+export async function writeCurrentTask(task: CurrentTask): Promise<void> {
+  return writeCurrentTaskTo(CONTEXT_FILE, task)
+}
+
+// ---------------------------------------------------------------------------
+// Testable variants — accept explicit file paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a current-task record from an explicit file path.
+ * Returns null if absent, malformed, or older than 24 hours.
+ */
+export async function readCurrentTaskFrom(filePath: string): Promise<CurrentTask | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8")
+    const parsed = JSON.parse(raw) as CurrentTask
+    if (!parsed.task_id || !parsed.started_at || !parsed.skill) return null
+    if (isExpired(parsed.started_at)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write a current-task record to an explicit file path,
+ * creating parent directories as needed.
+ */
+export async function writeCurrentTaskTo(filePath: string, task: CurrentTask): Promise<void> {
+  const dir = path.dirname(filePath)
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(filePath, JSON.stringify(task, null, 2) + "\n", "utf8")
+}

--- a/cmd/gale-task/index.ts
+++ b/cmd/gale-task/index.ts
@@ -1,0 +1,270 @@
+/**
+ * gale-task CLI entry point
+ *
+ * Usage:
+ *   gale-task log <event_type> [flags]
+ *
+ * Supported event types:
+ *   skill_started   --skill <name> [--title <title>] [--task-id <id>]
+ *   skill_completed --skill <name> [--title <title>] [--task-id <id>]
+ *   skill_failed    --skill <name> [--error <msg>]   [--task-id <id>]
+ *   memory_linked   --skill <name> [--memory-id <id>] [--memory-title <t>] [--task-id <id>]
+ *   pr_linked       --skill <name> [--pr-url <url>] [--pr-number <n>]      [--task-id <id>]
+ *
+ * Contract: all errors are caught, logged to stderr, process.exit(0).
+ * The writer MUST never block skills.
+ */
+
+import { spawn } from "node:child_process"
+import path from "path"
+import { appendEvent, type TaskEvent } from "../../src/utils/task-writer.js"
+import { readCurrentTask, writeCurrentTask, CONTEXT_FILE } from "./context.js"
+
+// ---------------------------------------------------------------------------
+// Arg parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseFlags(argv: string[]): Record<string, string> {
+  const flags: Record<string, string> = {}
+  let i = 0
+  while (i < argv.length) {
+    const arg = argv[i]
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2)
+      const next = argv[i + 1]
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next
+        i += 2
+      } else {
+        flags[key] = "true"
+        i += 1
+      }
+    } else {
+      i += 1
+    }
+  }
+  return flags
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+function spawnCapture(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve) => {
+    let stdout = ""
+    let stderr = ""
+    const proc = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] })
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
+    proc.on("error", () => resolve(""))
+    proc.on("close", (code) => {
+      if (code === 0) resolve(stdout.trim())
+      else resolve("")
+    })
+  })
+}
+
+function extractRepoName(remoteUrl: string): string {
+  // Handle various URL formats:
+  //   git@github.com:org/repo.git
+  //   https://github.com/org/repo.git
+  //   https://github.com/org/repo
+  try {
+    const cleaned = remoteUrl.replace(/\.git$/, "")
+    const parts = cleaned.split(/[/:]/g)
+    const last = parts[parts.length - 1]
+    return last || path.basename(process.cwd())
+  } catch {
+    return path.basename(process.cwd())
+  }
+}
+
+async function detectProject(): Promise<{ project: string; project_path: string }> {
+  const cwd = process.cwd()
+
+  const [remoteUrl, toplevel] = await Promise.all([
+    spawnCapture("git", ["remote", "get-url", "origin"], cwd),
+    spawnCapture("git", ["rev-parse", "--show-toplevel"], cwd),
+  ])
+
+  const project = remoteUrl ? extractRepoName(remoteUrl) : path.basename(cwd)
+  const project_path = toplevel || cwd
+
+  return { project, project_path }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+
+  // Expect: log <event_type> [flags]
+  if (argv[0] !== "log" || !argv[1]) {
+    process.stderr.write("Usage: gale-task log <event_type> [--skill <name>] [...flags]\n")
+    process.exit(0)
+    return
+  }
+
+  const eventType = argv[1] as string
+  const flags = parseFlags(argv.slice(2))
+
+  const skill = flags["skill"] ?? ""
+  const title = flags["title"]
+  const error = flags["error"]
+  const memoryId = flags["memory-id"]
+  const memoryTitle = flags["memory-title"]
+  const prUrl = flags["pr-url"]
+  const prNumber = flags["pr-number"]
+  const flagTaskId = flags["task-id"]
+
+  const timestamp = new Date().toISOString()
+
+  try {
+    if (eventType === "skill_started") {
+      // ------------------------------------------------------------------
+      // skill_started: generate new task_id, detect project, chain parent
+      // ------------------------------------------------------------------
+      const existingTask = await readCurrentTask()
+      const parentTaskId = existingTask?.task_id ?? undefined
+
+      const taskId = flagTaskId ?? crypto.randomUUID()
+      const { project, project_path } = await detectProject()
+
+      // Write new current-task.json in the working project
+      await writeCurrentTask({
+        task_id: taskId,
+        started_at: timestamp,
+        skill,
+      })
+
+      const event: TaskEvent = {
+        task_id: taskId,
+        event_type: "skill_started",
+        timestamp,
+        project,
+        project_path,
+        skill,
+        ...(title !== undefined ? { title } : {}),
+        ...(parentTaskId !== undefined ? { parent_task_id: parentTaskId } : {}),
+      }
+
+      await appendEvent(event)
+
+      // Print the generated task_id to stdout for callers to capture
+      process.stdout.write(taskId + "\n")
+
+    } else if (eventType === "skill_completed" || eventType === "skill_failed") {
+      // ------------------------------------------------------------------
+      // skill_completed / skill_failed: resolve task_id from context if needed
+      // ------------------------------------------------------------------
+      const currentTask = await readCurrentTask()
+      const taskId = flagTaskId ?? currentTask?.task_id
+      const resolvedSkill = skill || (currentTask?.skill ?? "")
+
+      if (!taskId) {
+        process.stderr.write("[gale-task] No task_id available for event: " + eventType + "\n")
+        process.exit(0)
+        return
+      }
+
+      const { project, project_path } = await detectProject()
+
+      let event: TaskEvent
+      if (eventType === "skill_completed") {
+        event = {
+          task_id: taskId,
+          event_type: "skill_completed",
+          timestamp,
+          project,
+          project_path,
+          skill: resolvedSkill,
+          ...(title !== undefined ? { title } : {}),
+        }
+      } else {
+        event = {
+          task_id: taskId,
+          event_type: "skill_failed",
+          timestamp,
+          project,
+          project_path,
+          skill: resolvedSkill,
+          ...(error !== undefined ? { error } : {}),
+        }
+      }
+
+      await appendEvent(event)
+
+    } else if (eventType === "memory_linked") {
+      // ------------------------------------------------------------------
+      // memory_linked
+      // ------------------------------------------------------------------
+      const currentTask = await readCurrentTask()
+      const taskId = flagTaskId ?? currentTask?.task_id
+      const resolvedSkill = skill || (currentTask?.skill ?? "")
+
+      if (!taskId) {
+        process.stderr.write("[gale-task] No task_id available for event: memory_linked\n")
+        process.exit(0)
+        return
+      }
+
+      const { project, project_path } = await detectProject()
+
+      const event: TaskEvent = {
+        task_id: taskId,
+        event_type: "memory_linked",
+        timestamp,
+        project,
+        project_path,
+        skill: resolvedSkill,
+        ...(memoryId !== undefined ? { memory_id: memoryId } : {}),
+        ...(memoryTitle !== undefined ? { memory_title: memoryTitle } : {}),
+      }
+
+      await appendEvent(event)
+
+    } else if (eventType === "pr_linked") {
+      // ------------------------------------------------------------------
+      // pr_linked
+      // ------------------------------------------------------------------
+      const currentTask = await readCurrentTask()
+      const taskId = flagTaskId ?? currentTask?.task_id
+      const resolvedSkill = skill || (currentTask?.skill ?? "")
+
+      if (!taskId) {
+        process.stderr.write("[gale-task] No task_id available for event: pr_linked\n")
+        process.exit(0)
+        return
+      }
+
+      const { project, project_path } = await detectProject()
+
+      const event: TaskEvent = {
+        task_id: taskId,
+        event_type: "pr_linked",
+        timestamp,
+        project,
+        project_path,
+        skill: resolvedSkill,
+        ...(prUrl !== undefined ? { pr_url: prUrl } : {}),
+        ...(prNumber !== undefined ? { pr_number: prNumber } : {}),
+      }
+
+      await appendEvent(event)
+
+    } else {
+      process.stderr.write("[gale-task] Unknown event_type: " + eventType + "\n")
+      process.exit(0)
+    }
+  } catch (err) {
+    process.stderr.write(
+      "[gale-task] Unexpected error: " + (err instanceof Error ? err.message : String(err)) + "\n",
+    )
+    process.exit(0)
+  }
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test": "bun test",
     "release:preview": "bun run scripts/release/preview.ts",
     "release:sync-metadata": "bun run scripts/release/sync-metadata.ts --write",
-    "release:validate": "bun run scripts/release/validate.ts"
+    "release:validate": "bun run scripts/release/validate.ts",
+    "build:gale-task": "bun build --compile cmd/gale-task/index.ts --outfile gale-task --target bun",
+    "install-gale-task": "bun run build:gale-task && mv gale-task ~/.local/bin/gale-task && echo 'gale-task installed to ~/.local/bin/gale-task'"
   },
   "dependencies": {
     "citty": "^0.1.6",

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -47,6 +47,19 @@ Do not proceed until you have a feature description from the user.
 
 ## Execution Flow
 
+<!-- HKT-PATCH:gale-task-start -->
+### Phase -1: Task Lifecycle Start
+
+Before any other action, log the skill start event so this execution appears on the task board:
+
+```bash
+gale-task log skill_started --skill gh:brainstorm --title "${ARGUMENTS:-brainstorm}" 2>/dev/null || true
+```
+
+If `gale-task` is not on PATH, skip silently — this must never block the skill.
+
+<!-- /HKT-PATCH:gale-task-start -->
+
 ### Phase 0: Resume, Assess, and Route
 
 #### 0.1 Resume Existing Work When Appropriate
@@ -196,3 +209,11 @@ When document-review returns "Review complete", proceed to Phase 4.
 ### Phase 4: Handoff
 
 Present next-step options and execute the user's selection. Read `references/handoff.md` for the option logic, dispatch instructions, and closing summary format.
+
+<!-- HKT-PATCH:gale-task-end -->
+After presenting handoff options and completing this skill, log the completion event:
+
+```bash
+gale-task log skill_completed 2>/dev/null || true
+```
+<!-- /HKT-PATCH:gale-task-end -->

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -32,6 +32,17 @@ When spawning subagents, pass the relevant file contents into the task prompt so
 
 ## Execution Strategy
 
+<!-- HKT-PATCH:gale-task-start -->
+Before presenting mode options to the user, log the skill start event so this execution appears on the task board:
+
+```bash
+gale-task log skill_started --skill gh:compound --title "${ARGUMENTS:-compound}" 2>/dev/null || true
+```
+
+If `gale-task` is not on PATH, skip silently — this must never block the skill.
+
+<!-- /HKT-PATCH:gale-task-start -->
+
 Present the user with two options before proceeding, using the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the options and wait for the user's reply.
 
 ```
@@ -263,6 +274,13 @@ After successfully writing the solution doc to `docs/solutions/`:
      --layer all
    ```
 4. Log: `Stored to HKTMemory: [title]` on success, or note the error (non-blocking — do not fail the compound workflow if HKTMemory is unavailable).
+
+<!-- HKT-PATCH:gale-task-memory -->
+5. After a successful HKTMemory store, log the memory_linked event (use the same `<frontmatter title>` as the `--memory-title` value):
+   ```bash
+   gale-task log memory_linked --memory-title "<frontmatter title>" 2>/dev/null || true
+   ```
+<!-- /HKT-PATCH:gale-task-memory -->
 
 ### Phase 2.5: Selective Refresh Check
 
@@ -568,3 +586,15 @@ Based on problem type, these agents can enhance documentation:
 
 - `/research [topic]` - Deep investigation (searches docs/solutions/ for patterns)
 - `/gh:plan` - Planning workflow (references documented solutions)
+
+<!-- HKT-PATCH:gale-task-end -->
+## Task Lifecycle End
+
+After the compound workflow is fully complete (documentation written, discoverability check done), log the completion event:
+
+```bash
+gale-task log skill_completed 2>/dev/null || true
+```
+
+If `gale-task` is not on PATH, skip silently — this must never block the skill.
+<!-- /HKT-PATCH:gale-task-end -->

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -56,6 +56,19 @@ A plan is ready when an implementer can start confidently without needing the pl
 
 ## Workflow
 
+<!-- HKT-PATCH:gale-task-start -->
+### Phase -1: Task Lifecycle Start
+
+Before any other action, log the skill start event so this execution appears on the task board:
+
+```bash
+gale-task log skill_started --skill gh:plan --title "${ARGUMENTS:-plan}" 2>/dev/null || true
+```
+
+If `gale-task` is not on PATH, skip silently — this must never block the skill.
+
+<!-- /HKT-PATCH:gale-task-start -->
+
 ### Phase 0: Resume, Source, and Scope
 
 #### 0.1 Resume Existing Plan Work When Appropriate
@@ -735,3 +748,11 @@ When deepening is warranted, read `references/deepening-workflow.md` for confide
 When reaching this phase, read `references/plan-handoff.md` for document review instructions (5.3.8), final checks and cleanup (5.3.9), post-generation options menu (5.4), and issue creation. Do not load this file earlier. Document review is mandatory — do not skip it even if the confidence check already ran.
 
 NEVER CODE! Research, decide, and write the plan.
+
+<!-- HKT-PATCH:gale-task-end -->
+After the plan document is written and all phases are complete, log the completion event:
+
+```bash
+gale-task log skill_completed 2>/dev/null || true
+```
+<!-- /HKT-PATCH:gale-task-end -->

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -42,6 +42,19 @@ Determine how to proceed based on what was provided in `<input_document>`.
 
 ---
 
+<!-- HKT-PATCH:gale-task-start -->
+### Phase 0.5: Task Lifecycle Start
+
+Before Phase 1, log the skill start event so this execution appears on the task board:
+
+```bash
+gale-task log skill_started --skill gh:work --title "${ARGUMENTS:-work}" 2>/dev/null || true
+```
+
+If `gale-task` is not on PATH, skip silently — this must never block the skill.
+
+<!-- /HKT-PATCH:gale-task-start -->
+
 ### Phase 1: Quick Start
 
 1. **Read Plan and Clarify** _(skip if arriving from Phase 0 with a bare prompt)_

--- a/plugins/galeharness-cli/skills/gh-work/references/shipping-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-work/references/shipping-workflow.md
@@ -82,6 +82,22 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
    - Note any follow-up work needed
    - Suggest next steps if applicable
 
+<!-- HKT-PATCH:gale-task-end -->
+5. **Log Task Completion**
+
+   After the PR is created (or commits are made if no PR), log the completion event. If a PR URL is available from `git-commit-push-pr`, also log `pr_linked`:
+
+   ```bash
+   # If a PR was created, extract the URL from git-commit-push-pr output and log it:
+   # PR_URL="<url returned by git-commit-push-pr>"
+   # gale-task log pr_linked --pr-url "$PR_URL" 2>/dev/null || true
+
+   gale-task log skill_completed 2>/dev/null || true
+   ```
+
+   If `gale-task` is not on PATH, skip silently — this must never block the skill.
+<!-- /HKT-PATCH:gale-task-end -->
+
 ## Quality Checklist
 
 Before creating PR, verify:

--- a/src/sync/kimi.ts
+++ b/src/sync/kimi.ts
@@ -1,0 +1,57 @@
+import path from "path"
+import type { ClaudeHomeConfig } from "../parsers/claude-home"
+import type { ClaudeMcpServer } from "../types/claude"
+import { mergeJsonConfigAtKey } from "./json-config"
+import { syncSkills } from "./skills"
+
+export async function syncToKimi(
+  config: ClaudeHomeConfig,
+  outputRoot: string,
+): Promise<void> {
+  await syncSkills(config.skills, path.join(outputRoot, "skills"))
+
+  if (config.commands && config.commands.length > 0) {
+    console.warn(
+      "Warning: Kimi personal command sync is skipped because Kimi currently uses skills (skill:xxx) as its primary command surface.",
+    )
+  }
+
+  if (Object.keys(config.mcpServers).length > 0) {
+    const mcpPath = path.join(outputRoot, "mcp.json")
+    const converted = convertMcpForKimi(config.mcpServers)
+    await mergeJsonConfigAtKey({
+      configPath: mcpPath,
+      key: "mcpServers",
+      incoming: converted,
+    })
+  }
+}
+
+function convertMcpForKimi(
+  servers: Record<string, ClaudeMcpServer>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [name, server] of Object.entries(servers)) {
+    if (server.command) {
+      const entry: Record<string, unknown> = {
+        command: server.command,
+      }
+      if (server.args && server.args.length > 0) {
+        entry.args = server.args
+      }
+      if (server.env && Object.keys(server.env).length > 0) {
+        entry.env = server.env
+      }
+      result[name] = entry
+    } else if (server.url) {
+      const entry: Record<string, unknown> = {
+        url: server.url,
+      }
+      if (server.headers && Object.keys(server.headers).length > 0) {
+        entry.headers = server.headers
+      }
+      result[name] = entry
+    }
+  }
+  return result
+}

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -5,6 +5,7 @@ import { syncToCodex } from "./codex"
 import { syncToCopilot } from "./copilot"
 import { syncToDroid } from "./droid"
 import { syncToGemini } from "./gemini"
+import { syncToKimi } from "./kimi"
 import { syncToKiro } from "./kiro"
 import { syncToOpenClaw } from "./openclaw"
 import { syncToOpenCode } from "./opencode"
@@ -31,6 +32,7 @@ export type SyncTargetName =
   | "kiro"
   | "qwen"
   | "openclaw"
+  | "kimi"
 
 export type SyncTargetDefinition = {
   name: SyncTargetName
@@ -119,6 +121,12 @@ export const syncTargets: SyncTargetDefinition[] = [
     detectPaths: (home) => [path.join(home, ".openclaw")],
     resolveOutputRoot: (home) => path.join(home, ".openclaw"),
     sync: syncToOpenClaw,
+  },
+  {
+    name: "kimi",
+    detectPaths: (home) => [path.join(home, ".kimi")],
+    resolveOutputRoot: (home) => path.join(home, ".kimi"),
+    sync: syncToKimi,
   },
 ]
 

--- a/src/utils/task-writer.ts
+++ b/src/utils/task-writer.ts
@@ -1,0 +1,97 @@
+import { appendFile, mkdir } from "node:fs/promises"
+import path from "path"
+import os from "os"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EventType =
+  | "skill_started"
+  | "skill_completed"
+  | "skill_failed"
+  | "memory_linked"
+  | "pr_linked"
+
+export interface TaskEventBase {
+  task_id: string
+  event_type: EventType
+  timestamp: string
+  project: string
+  project_path: string
+  skill: string
+}
+
+export interface SkillStartedEvent extends TaskEventBase {
+  event_type: "skill_started"
+  title?: string
+  parent_task_id?: string
+}
+
+export interface SkillCompletedEvent extends TaskEventBase {
+  event_type: "skill_completed"
+  title?: string
+}
+
+export interface SkillFailedEvent extends TaskEventBase {
+  event_type: "skill_failed"
+  error?: string
+}
+
+export interface MemoryLinkedEvent extends TaskEventBase {
+  event_type: "memory_linked"
+  memory_id?: string
+  memory_title?: string
+}
+
+export interface PrLinkedEvent extends TaskEventBase {
+  event_type: "pr_linked"
+  pr_url?: string
+  pr_number?: string | number
+}
+
+export type TaskEvent =
+  | SkillStartedEvent
+  | SkillCompletedEvent
+  | SkillFailedEvent
+  | MemoryLinkedEvent
+  | PrLinkedEvent
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+const GALEHARNESS_DIR = path.join(os.homedir(), ".galeharness")
+export const EVENTS_PATH = path.join(GALEHARNESS_DIR, "tasks.jsonl")
+
+// ---------------------------------------------------------------------------
+// Core append utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Low-level append to an explicit file path. Exported for testing only.
+ *
+ * Contract: NEVER throws, NEVER calls process.exit().
+ * All errors are swallowed and logged to stderr.
+ */
+export async function appendEventToPath(event: TaskEvent, filePath: string): Promise<void> {
+  try {
+    await mkdir(path.dirname(filePath), { recursive: true })
+    const line = JSON.stringify(event) + "\n"
+    await appendFile(filePath, line, { encoding: "utf8", flag: "a" })
+  } catch (err) {
+    process.stderr.write(
+      `[gale-task] appendEvent error: ${err instanceof Error ? err.message : String(err)}\n`,
+    )
+  }
+}
+
+/**
+ * Append a single TaskEvent as a JSON line to ~/.galeharness/tasks.jsonl.
+ *
+ * Contract: NEVER throws, NEVER calls process.exit().
+ * All errors are swallowed and logged to stderr so the writer never blocks skills.
+ */
+export async function appendEvent(event: TaskEvent): Promise<void> {
+  await appendEventToPath(event, EVENTS_PATH)
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -651,6 +651,7 @@ describe("CLI", () => {
     await fs.mkdir(path.join(tempHome, ".kiro"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".qwen"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".openclaw"), { recursive: true })
+    await fs.mkdir(path.join(tempHome, ".kimi"), { recursive: true })
     await fs.mkdir(path.join(tempCwd, ".cursor"), { recursive: true })
 
     const proc = Bun.spawn([
@@ -688,6 +689,7 @@ describe("CLI", () => {
     expect(stdout).toContain("Synced to openclaw")
     expect(stdout).toContain("Synced to copilot")
     expect(stdout).toContain("Synced to gemini")
+    expect(stdout).toContain("Synced to kimi")
     expect(stdout).not.toContain("cursor")
 
     expect(await exists(path.join(tempHome, ".config", "opencode", "commands", "workflows", "plan.md"))).toBe(true)

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -50,7 +50,7 @@ describe("detectInstalledTools", () => {
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
-    expect(results.length).toBe(10)
+    expect(results.length).toBe(11)
     for (const tool of results) {
       expect(tool.detected).toBe(false)
       expect(tool.reason).toBe("not found")

--- a/tests/sync-kimi.test.ts
+++ b/tests/sync-kimi.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+import type { ClaudeHomeConfig } from "../src/parsers/claude-home"
+import { syncToKimi } from "../src/sync/kimi"
+
+describe("syncToKimi", () => {
+  test("symlinks skills and writes MCP servers to mcp.json", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sync-kimi-"))
+    const fixtureSkillDir = path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one")
+
+    const config: ClaudeHomeConfig = {
+      skills: [
+        {
+          name: "skill-one",
+          sourceDir: fixtureSkillDir,
+          skillPath: path.join(fixtureSkillDir, "SKILL.md"),
+        },
+      ],
+      mcpServers: {
+        local: { command: "echo", args: ["hello"], env: { KEY: "VALUE" } },
+        remote: { url: "https://example.com/mcp", headers: { Authorization: "Bearer token" } },
+      },
+    }
+
+    await syncToKimi(config, tempRoot)
+
+    const skillPath = path.join(tempRoot, "skills", "skill-one")
+    expect((await fs.lstat(skillPath)).isSymbolicLink()).toBe(true)
+
+    const mcpPath = path.join(tempRoot, "mcp.json")
+    const mcpContent = await fs.readFile(mcpPath, "utf8")
+    const mcpJson = JSON.parse(mcpContent)
+    expect(mcpJson.mcpServers.local.command).toBe("echo")
+    expect(mcpJson.mcpServers.local.args).toEqual(["hello"])
+    expect(mcpJson.mcpServers.local.env).toEqual({ KEY: "VALUE" })
+    expect(mcpJson.mcpServers.remote.url).toBe("https://example.com/mcp")
+    expect(mcpJson.mcpServers.remote.headers).toEqual({ Authorization: "Bearer token" })
+
+    const perms = (await fs.stat(mcpPath)).mode & 0o777
+    expect(perms).toBe(0o600)
+  })
+
+  test("warns when commands are present", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sync-kimi-cmds-"))
+    const fixtureSkillDir = path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one")
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message))
+    }
+
+    try {
+      const config: ClaudeHomeConfig = {
+        skills: [
+          {
+            name: "skill-one",
+            sourceDir: fixtureSkillDir,
+            skillPath: path.join(fixtureSkillDir, "SKILL.md"),
+          },
+        ],
+        commands: [
+          {
+            name: "workflows:plan",
+            description: "Planning command",
+            body: "Plan the work.",
+            sourcePath: "/tmp/workflows/plan.md",
+          },
+        ],
+        mcpServers: {},
+      }
+
+      await syncToKimi(config, tempRoot)
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warnings.some((w) => w.includes("Kimi personal command sync is skipped"))).toBe(true)
+  })
+})

--- a/tests/task-writer.test.ts
+++ b/tests/task-writer.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for task-writer utility and context manager.
+ *
+ * Uses Bun's built-in test runner and node:fs temp directories for isolation.
+ * The appendEvent / readCurrentTask / writeCurrentTask functions are tested
+ * via their path-parameterised variants to avoid touching real system paths.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, readFile, chmod } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "path"
+
+import {
+  appendEvent,
+  appendEventToPath,
+  type TaskEvent,
+} from "../src/utils/task-writer.js"
+import {
+  readCurrentTaskFrom,
+  writeCurrentTaskTo,
+  type CurrentTask,
+} from "../cmd/gale-task/context.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<TaskEvent> = {}): TaskEvent {
+  return {
+    task_id: crypto.randomUUID(),
+    event_type: "skill_started",
+    timestamp: new Date().toISOString(),
+    project: "test-project",
+    project_path: "/tmp/test-project",
+    skill: "test-skill",
+    ...overrides,
+  } as TaskEvent
+}
+
+function recentTimestamp(): string {
+  return new Date().toISOString()
+}
+
+function oldTimestamp(): string {
+  // 25 hours ago — definitely expired
+  return new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// appendEvent / appendEventToPath
+// ---------------------------------------------------------------------------
+
+describe("appendEventToPath", () => {
+  let tmpDir: string
+  let eventsFile: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "gale-task-test-"))
+    eventsFile = path.join(tmpDir, "tasks.jsonl")
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("writes a valid JSON line to the specified file", async () => {
+    const event = makeEvent()
+    await appendEventToPath(event, eventsFile)
+
+    const raw = await readFile(eventsFile, "utf8")
+    const lines = raw.trim().split("\n").filter(Boolean)
+    expect(lines).toHaveLength(1)
+
+    const parsed = JSON.parse(lines[0])
+    expect(parsed.task_id).toBe(event.task_id)
+    expect(parsed.event_type).toBe("skill_started")
+    expect(parsed.project).toBe("test-project")
+    expect(parsed.skill).toBe("test-skill")
+  })
+
+  test("creates parent directory if absent", async () => {
+    const deepFile = path.join(tmpDir, "nested", "deep", "tasks.jsonl")
+    const event = makeEvent({ event_type: "skill_completed" })
+    await appendEventToPath(event, deepFile)
+
+    const raw = await readFile(deepFile, "utf8")
+    const parsed = JSON.parse(raw.trim())
+    expect(parsed.event_type).toBe("skill_completed")
+  })
+
+  test("does not throw on permission error (swallows error)", async () => {
+    // Write to a read-only directory
+    const roDir = path.join(tmpDir, "readonly")
+    await mkdtemp(path.join(tmpdir(), "ro-")).then(async (d) => {
+      await chmod(d, 0o444)
+      const badFile = path.join(d, "tasks.jsonl")
+      // Must not throw — contract is to swallow all errors
+      await expect(appendEventToPath(makeEvent(), badFile)).resolves.toBeUndefined()
+      // Restore permissions so cleanup works
+      await chmod(d, 0o755)
+      await rm(d, { recursive: true, force: true })
+    })
+  })
+
+  test("two concurrent appendEvent calls produce two distinct valid JSON lines", async () => {
+    const event1 = makeEvent({ task_id: "aaa-111" })
+    const event2 = makeEvent({ task_id: "bbb-222" })
+
+    await Promise.all([
+      appendEventToPath(event1, eventsFile),
+      appendEventToPath(event2, eventsFile),
+    ])
+
+    const raw = await readFile(eventsFile, "utf8")
+    const lines = raw.trim().split("\n").filter(Boolean)
+    expect(lines).toHaveLength(2)
+
+    const parsed = lines.map((l) => JSON.parse(l))
+    const ids = new Set(parsed.map((p: { task_id: string }) => p.task_id))
+    expect(ids.size).toBe(2)
+    expect(ids.has("aaa-111")).toBe(true)
+    expect(ids.has("bbb-222")).toBe(true)
+  })
+})
+
+describe("appendEvent (real path variant — smoke test)", () => {
+  test("appendEvent does not throw", async () => {
+    const event = makeEvent()
+    await expect(appendEvent(event)).resolves.toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readCurrentTaskFrom / writeCurrentTaskTo
+// ---------------------------------------------------------------------------
+
+describe("readCurrentTaskFrom", () => {
+  let tmpDir: string
+  let contextFile: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "gale-ctx-test-"))
+    contextFile = path.join(tmpDir, "current-task.json")
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("returns null for absent file", async () => {
+    const result = await readCurrentTaskFrom(contextFile)
+    expect(result).toBeNull()
+  })
+
+  test("returns null for file older than 24 hours", async () => {
+    const task: CurrentTask = {
+      task_id: "old-task-123",
+      started_at: oldTimestamp(),
+      skill: "some-skill",
+    }
+    await writeCurrentTaskTo(contextFile, task)
+
+    const result = await readCurrentTaskFrom(contextFile)
+    expect(result).toBeNull()
+  })
+
+  test("returns the task for a recent file", async () => {
+    const task: CurrentTask = {
+      task_id: "recent-task-456",
+      started_at: recentTimestamp(),
+      skill: "my-skill",
+    }
+    await writeCurrentTaskTo(contextFile, task)
+
+    const result = await readCurrentTaskFrom(contextFile)
+    expect(result).not.toBeNull()
+    expect(result!.task_id).toBe("recent-task-456")
+    expect(result!.skill).toBe("my-skill")
+  })
+
+  test("returns null for malformed JSON", async () => {
+    const { promises: fs } = await import("node:fs")
+    await fs.writeFile(contextFile, "{ not valid json", "utf8")
+
+    const result = await readCurrentTaskFrom(contextFile)
+    expect(result).toBeNull()
+  })
+
+  test("returns null for JSON missing required fields", async () => {
+    const { promises: fs } = await import("node:fs")
+    await fs.writeFile(contextFile, JSON.stringify({ task_id: "x" }), "utf8")
+
+    const result = await readCurrentTaskFrom(contextFile)
+    expect(result).toBeNull()
+  })
+})
+
+describe("writeCurrentTaskTo + readCurrentTaskFrom round-trip", () => {
+  let tmpDir: string
+  let contextFile: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "gale-ctx-rt-"))
+    contextFile = path.join(tmpDir, "subdir", "current-task.json")
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("write then read returns identical task", async () => {
+    const task: CurrentTask = {
+      task_id: crypto.randomUUID(),
+      started_at: recentTimestamp(),
+      skill: "round-trip-skill",
+    }
+
+    await writeCurrentTaskTo(contextFile, task)
+    const result = await readCurrentTaskFrom(contextFile)
+
+    expect(result).not.toBeNull()
+    expect(result!.task_id).toBe(task.task_id)
+    expect(result!.skill).toBe(task.skill)
+    // started_at should survive serialisation
+    expect(result!.started_at).toBe(task.started_at)
+  })
+
+  test("creates nested parent directories as needed", async () => {
+    const deepFile = path.join(tmpDir, "a", "b", "c", "current-task.json")
+    const task: CurrentTask = {
+      task_id: "deep-task",
+      started_at: recentTimestamp(),
+      skill: "deep-skill",
+    }
+    await writeCurrentTaskTo(deepFile, task)
+
+    const result = await readCurrentTaskFrom(deepFile)
+    expect(result!.task_id).toBe("deep-task")
+  })
+})


### PR DESCRIPTION
## Summary

Add `kimi`, `claude`, and `qoder` as first-class install/sync targets so that `bun run src/index.ts install ./plugins/galeharness-cli --to all` and `sync --target all` correctly deploy skills to Claude, Kimi, and Qoder.

## Changes

### Install targets
- `src/converters/claude-to-kimi.ts` + `src/targets/kimi.ts`: Kimi install target (writes skills/agents/commands as `~/.kimi/skills/<name>/SKILL.md`)
- `src/converters/claude-to-claude.ts` + `src/targets/claude.ts`: Claude install target (writes to `~/.claude/{skills,agents,commands}/`)
- `src/targets/index.ts`: register `kimi` and `claude`
- `src/utils/resolve-output.ts`: fix default output paths for `kimi` and `claude`

### Sync targets
- `src/sync/qoder.ts`: Qoder sync target (skills + commands; MCP skipped with warning)
- `src/sync/registry.ts`: register `qoder`
- `src/sync/kimi.ts`: Kimi sync target (already in previous commit)

### Detection & CLI
- `src/utils/detect-tools.ts`: detect `~/.claude` so `install --to all\) includes Claude
- `src/commands/sync.ts`: guard `sync --target all\) against non-sync targets (e.g. `claude`)
- `src/commands/install.ts`: wire `kimiHome` through `resolveTargetOutputRoot`

### Tests
- `tests/sync-qoder.test.ts`: sync coverage for Qoder
- `tests/sync-kimi.test.ts`: sync coverage for Kimi
- `tests/cli.test.ts` & `tests/detect-tools.test.ts`: updated for new targets

## Verification

```bash
bun test tests/sync-kimi.test.ts tests/sync-qoder.test.ts tests/cli.test.ts tests/detect-tools.test.ts
```

All 25 tests pass.

Also verified live:
- `claude -p` answers **是** when asked whether `gh:brainstorm` is available.
- `kimi --print` answers **是** when asked whether `gh:brainstorm` is available.
- `~/.qoder/skills/gh-brainstorm/SKILL.md` exists after install.