### PR TITLE
feat(sync,install,skills): add claude/kimi/qoder targets and HKTMemory integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,14 +249,18 @@ bun test
 # 在仓库根目录执行
 bun link
 
-# 之后在任何目录直接使用
+# 确保 ~/.bun/bin 在 PATH 中（添加到 ~/.zshrc 或 ~/.bashrc）
+export PATH="$HOME/.bun/bin:$PATH"
+
+# 之后在仓库根目录或任何指定了绝对/相对路径的目录直接使用
 gale-harness install ./plugins/galeharness-cli --to qoder
 ```
 
-**支持的平台 (13个)：**
+**支持的平台 (15个)：**
 
 | 平台 | 说明 |
 |------|------|
+| `claude` | Claude Code |
 | `opencode` | OpenCode |
 | `codex` | OpenAI Codex |
 | `droid` | Droid |
@@ -270,6 +274,7 @@ gale-harness install ./plugins/galeharness-cli --to qoder
 | `qoder` | Qoder |
 | `trae` | Trae (字节跳动) |
 | `cursor` | Cursor |
+| `kimi` | Kimi Code CLI |
 
 **一键安装到所有平台：**
 
@@ -319,7 +324,7 @@ bun run src/index.ts install ./plugins/galeharness-cli --to copilot
 # Qoder
 bun run src/index.ts install ./plugins/galeharness-cli --to qoder
 
-# 支持的平台: opencode, codex, droid, pi, gemini, copilot, kiro, windsurf, openclaw, qwen, qoder
+# 支持的平台: claude, opencode, codex, droid, pi, gemini, copilot, kiro, windsurf, openclaw, qwen, qoder, trae, cursor, kimi
 bun run src/index.ts install ./plugins/galeharness-cli --to <platform>
 
 # 安装到所有检测到的平台
@@ -331,6 +336,7 @@ bun run src/index.ts install ./plugins/galeharness-cli --to all
 
 | 平台 | 输出路径 | 说明 |
 |------|----------|------|
+| `claude` | `~/.claude/` | 原生格式：skills、agents、commands 直接写入 |
 | `opencode` | `~/.config/opencode/` | 命令作为 `.md` 文件；`opencode.json` MCP 配置深度合并；覆盖前备份 |
 | `codex` | `~/.codex/prompts` + `~/.codex/skills` | 命令成为 prompt + skill 对 |
 | `droid` | `~/.factory/` | 工具名称映射 (`Bash`->`Execute`, `Write`->`Create`) |
@@ -344,6 +350,7 @@ bun run src/index.ts install ./plugins/galeharness-cli --to all
 | `qoder` | `~/.qoder/` | Skills, agents, commands 作为 `.md` 文件 |
 | `trae` | `~/.trae/` | Skills, agents, commands 作为 `.md` 文件 (Agent Skills 标准) |
 | `cursor` | `~/.cursor/rules/` | Skills 作为 `.mdc` 规则文件 |
+| `kimi` | `~/.kimi/` | Skills、agents、commands 统一作为 `~/.kimi/skills/<name>/SKILL.md` |
 
 所有平台都是实验性的，可能随格式演进变化。
 

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -103,6 +103,38 @@ Use the feature description plus a light repo scan to classify the work:
 
 If the scope is unclear, ask one targeted question to disambiguate and then proceed.
 
+<!-- HKT-PATCH:phase-0.4 -->
+#### 0.4 HKTMemory Retrieve
+
+Before Phase 1, query the vector memory database for related brainstorms and requirements:
+
+1. Extract a 1-2 sentence search query from the feature description, including:
+   - Core problem or feature being explored
+   - Key component names or domain terms
+   - User goals or outcomes mentioned
+
+2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py retrieve \
+     --query "<extracted query>" \
+     --layer all --limit 10 --min-similarity 0.35 \
+     --vector-weight 0.7 --bm25-weight 0.3
+   ```
+
+3. If results returned, prepare a context block and use it to inform Phase 1.1 (Existing Context Scan):
+   ```
+   ## Related historical brainstorms from HKTMemory
+   Source: vector database. Treat as additional context, not primary evidence.
+   [results here, each tagged with (similarity: X.XX)]
+   ```
+
+4. If no results or command error, proceed silently without blocking Phase 1.
+
+**Integration with Phase 1.1:** When HKTMemory returns relevant results, cross-reference them during the "Topic Scan" step. Look for:
+- Similar problems already explored
+- Related requirements documents that might inform scope
+- Past decisions or constraints that still apply
+
 ### Phase 1: Understand the Idea
 
 #### 1.1 Existing Context Scan
@@ -205,6 +237,26 @@ When a requirements document was created or updated, run the `document-review` s
 If document-review returns findings that were auto-applied, note them briefly when presenting handoff options. If residual P0/P1 findings were surfaced, mention them so the user can decide whether to address them before proceeding.
 
 When document-review returns "Review complete", proceed to Phase 4.
+
+<!-- HKT-PATCH:phase-3.3 -->
+### Phase 3.3: HKTMemory Store
+
+After successfully writing or updating the requirements document:
+
+1. Read back the full content of the written file
+2. Extract `title` and `category` values from its YAML frontmatter (if present)
+3. Run:
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py store \
+     --content "<full file content>" \
+     --title "<frontmatter title or filename>" \
+     --topic "<frontmatter category or 'brainstorm'>" \
+     --layer all
+   ```
+4. Log on success: `Stored to HKTMemory: [title]`
+5. On error, note it briefly but do not fail the brainstorm workflow — memory storage is supplementary, not critical path
+
+**Note:** This enables future brainstorms to discover and build upon this work through Phase 0.4's retrieve step.
 
 ### Phase 4: Handoff
 

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -91,6 +91,38 @@ Honor clear overrides such as:
 
 Use reasonable interpretation rather than formal parsing.
 
+<!-- HKT-PATCH:phase-0.5 -->
+#### 0.5 HKTMemory Retrieve
+
+Before Phase 1, query the vector memory database for related ideation and improvement ideas:
+
+1. Extract a search query from the focus hint:
+   - Focus area or concept (e.g., "DX improvements", "auth flow")
+   - Project domain or technology
+   - Constraint keywords (e.g., "low-complexity", "quick wins")
+
+2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py retrieve \
+     --query "<extracted query>" \
+     --layer all --limit 10 --min-similarity 0.35 \
+     --vector-weight 0.7 --bm25-weight 0.3
+   ```
+
+3. If results returned, prepare context for Phase 1 and Phase 2:
+   ```
+   ## Related ideation from HKTMemory
+   Source: vector database. Treat as additional context, not primary evidence.
+   [results here, each tagged with (similarity: X.XX)]
+   ```
+   
+   Use this to:
+   - Avoid duplicating previously explored ideas
+   - Build upon or refine past ideation
+   - Identify patterns in improvement opportunities
+
+4. If no results or command error, proceed silently.
+
 ### Phase 1: Codebase Scan
 
 Before generating ideas, gather codebase context.
@@ -154,3 +186,23 @@ After all sub-agents return:
 4. Spread ideas across multiple dimensions when justified: workflow/DX, reliability, extensibility, missing capabilities, docs/knowledge compounding, quality/maintenance, leverage on future work.
 
 After merging and synthesis, read `references/post-ideation-workflow.md` for the adversarial filtering rubric, presentation format, artifact template, handoff options, and quality bar. Do not load this file before Phase 2 agent dispatch completes.
+
+<!-- HKT-PATCH:phase-2.5 -->
+### Phase 2.5: HKTMemory Store
+
+After the ideation artifact is written to `docs/ideation/`:
+
+1. Read back the full content of the ideation document
+2. Extract the title and key themes from the frontmatter/content
+3. Run:
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py store \
+     --content "<full ideation document>" \
+     --title "Ideation: [document title]" \
+     --topic "ideation" \
+     --layer all
+   ```
+4. Log on success: `Stored ideation to HKTMemory`
+5. On error, proceed silently — storage is supplementary
+
+**Note:** This enables future ideation sessions to discover and build upon these ideas through Phase 0.5's retrieve step.

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -178,6 +178,35 @@ Classify the work into one of these plan depths:
 
 If depth is unclear, ask one targeted question and then continue.
 
+<!-- HKT-PATCH:phase-0.7 -->
+#### 0.7 HKTMemory Retrieve
+
+Before Phase 1, query the vector memory database for related plans and requirements:
+
+1. Extract a 1-2 sentence search query from:
+   - The feature description or origin document title
+   - Key components, modules, or technologies involved
+   - The problem being solved
+
+2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py retrieve \
+     --query "<extracted query>" \
+     --layer all --limit 10 --min-similarity 0.35 \
+     --vector-weight 0.7 --bm25-weight 0.3
+   ```
+
+3. If results returned, prepare a context block for Phase 1.1 research agents:
+   ```
+   ## Related historical plans from HKTMemory
+   Source: vector database. Treat as additional context, not primary evidence.
+   [results here, each tagged with (similarity: X.XX)]
+   ```
+
+4. If no results or command error, proceed silently without blocking Phase 1.
+
+**Integration with Phase 1.1:** When HKTMemory returns relevant plans or requirements, the `learnings-researcher` and `repo-research-analyst` should cross-reference them alongside `docs/solutions/` and `docs/plans/`.
+
 ### Phase 1: Gather Context
 
 #### 1.1 Local Research (Always Runs)
@@ -746,6 +775,26 @@ When deepening is warranted, read `references/deepening-workflow.md` for confide
 ##### 5.3.8–5.4 Document Review, Final Checks, and Post-Generation Options
 
 When reaching this phase, read `references/plan-handoff.md` for document review instructions (5.3.8), final checks and cleanup (5.3.9), post-generation options menu (5.4), and issue creation. Do not load this file earlier. Document review is mandatory — do not skip it even if the confidence check already ran.
+
+<!-- HKT-PATCH:phase-5.4b -->
+##### 5.4b HKTMemory Store
+
+After the plan file is finalized and document review has run:
+
+1. Read back the full content of the written plan file
+2. Extract `title` and `type` values from its YAML frontmatter
+3. Run:
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py store \
+     --content "<full plan file content>" \
+     --title "<frontmatter title>" \
+     --topic "<frontmatter type or 'plan'>" \
+     --layer all
+   ```
+4. Log on success: `Stored to HKTMemory: [title]`
+5. On error, note it briefly but do not fail the plan workflow — memory storage is supplementary, not critical path
+
+**Note:** This enables future plans and brainstorms to discover and build upon this work through their Phase 0 retrieve steps.
 
 NEVER CODE! Research, decide, and write the plan.
 

--- a/plugins/galeharness-cli/skills/gh-review/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-review/SKILL.md
@@ -160,6 +160,35 @@ If a reviewer flags any file in these directories for cleanup or removal, discar
 
 ## How to Run
 
+<!-- HKT-PATCH:stage-0.5 -->
+### Stage 0.5: HKTMemory Retrieve
+
+Before Stage 1, query the vector memory database for related code review context and past issues:
+
+1. Extract a search query from the PR/branch context:
+   - PR title or branch name
+   - Files being changed (module names, component names)
+   - Intent summary (what the change is trying to accomplish)
+
+2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py retrieve \
+     --query "<extracted query>" \
+     --layer all --limit 10 --min-similarity 0.35 \
+     --vector-weight 0.7 --bm25-weight 0.3
+   ```
+
+3. If results returned, prepare context for Stage 2 (Intent discovery) and Stage 3 (Reviewer selection):
+   ```
+   ## Related context from HKTMemory
+   Source: vector database. Treat as additional context, not primary evidence.
+   [results here, each tagged with (similarity: X.XX)]
+   ```
+   
+   This supplements the `learnings-researcher` agent's findings from `docs/solutions/`.
+
+4. If no results or command error, proceed silently.
+
 ### Stage 1: Determine scope
 
 Compute the diff range, file list, and diff. Minimize permission prompts by combining into as few commands as possible.
@@ -580,6 +609,31 @@ Review complete
 - Omit any section with zero items.
 - If all reviewers fail or time out, emit `Code review degraded (headless mode). Reason: 0 of N reviewers returned results.` followed by "Review complete".
 - End with "Review complete" as the terminal signal so callers can detect completion.
+
+<!-- HKT-PATCH:stage-6.5 -->
+### Stage 6.5: HKTMemory Store
+
+After the review is complete and findings have been synthesized:
+
+1. Create a review summary including:
+   - Scope (files reviewed, base branch)
+   - Intent summary
+   - Verdict
+   - Key findings (P0/P1 issues found)
+   - Any learnings or patterns identified
+
+2. Run:
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py store \
+     --content "<review summary>" \
+     --title "Code Review: [PR title or branch name]" \
+     --topic "code-review" \
+     --layer all
+   ```
+3. Log on success: `Stored review record to HKTMemory`
+4. On error, proceed silently — review storage is supplementary
+
+**Note:** This creates a searchable record of code reviews to help identify recurring issues and patterns.
 
 ## Quality Gates
 

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -55,6 +55,40 @@ If `gale-task` is not on PATH, skip silently — this must never block the skill
 
 <!-- /HKT-PATCH:gale-task-start -->
 
+<!-- HKT-PATCH:phase-0.6 -->
+### Phase 0.6: HKTMemory Retrieve
+
+Before Phase 1, query the vector memory database for related execution context:
+
+1. Extract a search query from the work document or bare prompt:
+   - Plan title or feature description
+   - Key components, modules, or files involved
+   - Problem being solved or functionality being implemented
+
+2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py retrieve \
+     --query "<extracted query>" \
+     --layer all --limit 10 --min-similarity 0.35 \
+     --vector-weight 0.7 --bm25-weight 0.3
+   ```
+
+3. If results returned, prepare context for Phase 1 execution:
+   ```
+   ## Related context from HKTMemory
+   Source: vector database. Treat as additional context, not primary evidence.
+   [results here, each tagged with (similarity: X.XX)]
+   ```
+   
+   Use this to:
+   - Check for similar implementations or patterns already explored
+   - Find related solutions that might inform the current work
+   - Surface constraints or decisions from past work
+
+4. If no results or command error, proceed silently.
+
+<!-- /HKT-PATCH:phase-0.6 -->
+
 ### Phase 1: Quick Start
 
 1. **Read Plan and Clarify** _(skip if arriving from Phase 0 with a bare prompt)_
@@ -311,6 +345,30 @@ If `gale-task` is not on PATH, skip silently — this must never block the skill
 ### Phase 3-4: Quality Check and Ship It
 
 When all Phase 2 tasks are complete and execution transitions to quality check, read `references/shipping-workflow.md` for the full shipping workflow: quality checks, code review, final validation, PR creation, and notification.
+
+<!-- HKT-PATCH:phase-4.5 -->
+### Phase 4.5: HKTMemory Store
+
+After the work is complete and the shipping workflow has finished (PR created or changes committed):
+
+1. Summarize what was accomplished:
+   - Work completed (implementation summary)
+   - Files changed
+   - Key decisions or discoveries made during execution
+   - Any deviations from the original plan and why
+
+2. Run:
+   ```bash
+   uv run vendor/hkt-memory/scripts/hkt_memory_v5.py store \
+     --content "<execution summary with context>" \
+     --title "Work: [plan title or feature description]" \
+     --topic "work-execution" \
+     --layer all
+   ```
+3. Log on success: `Stored execution record to HKTMemory`
+4. On error, proceed silently — execution storage is supplementary
+
+**Note:** This creates a searchable record of completed work for future reference when similar tasks arise.
 
 ## Key Principles
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -114,6 +114,7 @@ export default defineCommand({
       const openclawHome = resolveTargetHome(args.openclawHome, path.join(os.homedir(), ".openclaw", "extensions"))
       const qwenHome = resolveTargetHome(args.qwenHome, path.join(os.homedir(), ".qwen", "extensions"))
       const qoderHome = resolveTargetHome(args.qoderHome, path.join(os.homedir(), ".qoder"))
+      const kimiHome = path.join(os.homedir(), ".kimi")
 
       const options: ClaudeToOpenCodeOptions = {
         agentMode: String(args.agentMode) === "primary" ? "primary" : "subagent",
@@ -155,6 +156,7 @@ export default defineCommand({
             openclawHome,
             qwenHome,
             qoderHome,
+            kimiHome,
             pluginName: plugin.manifest.name,
             plugin,
             hasExplicitOutput,
@@ -192,6 +194,7 @@ export default defineCommand({
         openclawHome,
         qwenHome,
         qoderHome,
+        kimiHome,
         pluginName: plugin.manifest.name,
         plugin,
         hasExplicitOutput,
@@ -226,6 +229,7 @@ export default defineCommand({
           openclawHome,
           qwenHome,
           qoderHome,
+          kimiHome,
           pluginName: plugin.manifest.name,
           plugin,
           hasExplicitOutput,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -68,6 +68,9 @@ export default defineCommand({
       }
 
       for (const name of activeTargets) {
+        if (!isSyncTargetName(name)) {
+          continue
+        }
         const target = getSyncTarget(name as SyncTargetName)
         const outputRoot = target.resolveOutputRoot(home, cwd)
         await target.sync(config, outputRoot)

--- a/src/converters/claude-to-claude.ts
+++ b/src/converters/claude-to-claude.ts
@@ -1,0 +1,95 @@
+import {
+  type ClaudeAgent,
+  type ClaudeCommand,
+  type ClaudePlugin,
+  filterSkillsByPlatform,
+} from "../types/claude"
+import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+
+export type ClaudeBundle = {
+  agents: Array<{ name: string; content: string }>
+  commandFiles: Array<{ name: string; content: string }>
+  skillDirs: Array<{ sourceDir: string; name: string }>
+}
+
+/**
+ * Convert Claude plugin format to Claude home format.
+ *
+ * This is effectively an identity conversion since Claude Code is the
+ * native authoring format. Agents, commands, and skills are written
+ * directly into the Claude home directory tree.
+ */
+export function convertClaudeToClaude(
+  plugin: ClaudePlugin,
+  _options?: ClaudeToOpenCodeOptions,
+): ClaudeBundle {
+  const agentFiles = plugin.agents.map((agent) => convertAgent(agent))
+  const cmdFiles = convertCommands(plugin.commands)
+
+  return {
+    agents: agentFiles,
+    commandFiles: cmdFiles,
+    skillDirs: filterSkillsByPlatform(plugin.skills, "claude").map((skill) => ({
+      sourceDir: skill.sourceDir,
+      name: skill.name,
+    })),
+  }
+}
+
+function convertAgent(agent: ClaudeAgent) {
+  const frontmatterLines: string[] = []
+  frontmatterLines.push("---")
+  frontmatterLines.push(`name: ${agent.name}`)
+  frontmatterLines.push(`description: ${agent.description}`)
+  if (agent.model) {
+    frontmatterLines.push(`model: ${agent.model}`)
+  }
+  if (agent.capabilities && agent.capabilities.length > 0) {
+    frontmatterLines.push(`capabilities:`)
+    for (const cap of agent.capabilities) {
+      frontmatterLines.push(`  - ${cap}`)
+    }
+  }
+  frontmatterLines.push("---")
+
+  const content = frontmatterLines.join("\n") + "\n\n" + agent.body
+
+  return {
+    name: agent.name,
+    content,
+  }
+}
+
+function convertCommands(commands: ClaudeCommand[]) {
+  return commands.map((cmd) => {
+    const frontmatterLines: string[] = []
+    frontmatterLines.push("---")
+    frontmatterLines.push(`name: ${cmd.name}`)
+    if (cmd.description) {
+      frontmatterLines.push(`description: ${cmd.description}`)
+    }
+    if (cmd.argumentHint) {
+      frontmatterLines.push(`argument-hint: ${cmd.argumentHint}`)
+    }
+    if (cmd.model) {
+      frontmatterLines.push(`model: ${cmd.model}`)
+    }
+    if (cmd.allowedTools && cmd.allowedTools.length > 0) {
+      frontmatterLines.push(`allowed-tools:`)
+      for (const tool of cmd.allowedTools) {
+        frontmatterLines.push(`  - ${tool}`)
+      }
+    }
+    if (cmd.disableModelInvocation) {
+      frontmatterLines.push(`disable-model-invocation: true`)
+    }
+    frontmatterLines.push("---")
+
+    const content = frontmatterLines.join("\n") + "\n\n" + cmd.body
+
+    return {
+      name: cmd.name,
+      content,
+    }
+  })
+}

--- a/src/converters/claude-to-kimi.ts
+++ b/src/converters/claude-to-kimi.ts
@@ -1,0 +1,81 @@
+import {
+  type ClaudeAgent,
+  type ClaudeCommand,
+  type ClaudePlugin,
+  filterSkillsByPlatform,
+} from "../types/claude"
+import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+
+export type KimiBundle = {
+  generatedSkills: Array<{ name: string; content: string }>
+  skillDirs: Array<{ sourceDir: string; name: string }>
+}
+
+/**
+ * Convert Claude plugin format to Kimi format.
+ *
+ * Kimi reads skills from ~/.kimi/skills/<name>/SKILL.md using the same
+ * format as Claude Code. Agents and commands are converted into skills
+ * so they appear as skill:xxx slash commands in Kimi CLI.
+ */
+export function convertClaudeToKimi(
+  plugin: ClaudePlugin,
+  _options?: ClaudeToOpenCodeOptions,
+): KimiBundle {
+  const agentSkills = plugin.agents.map((agent) => convertAgent(agent))
+  const commandSkills = convertCommands(plugin.commands)
+
+  return {
+    generatedSkills: [...commandSkills, ...agentSkills],
+    skillDirs: filterSkillsByPlatform(plugin.skills, "kimi").map((skill) => ({
+      sourceDir: skill.sourceDir,
+      name: skill.name,
+    })),
+  }
+}
+
+function convertAgent(agent: ClaudeAgent) {
+  const frontmatterLines: string[] = []
+  frontmatterLines.push("---")
+  frontmatterLines.push(`name: ${agent.name}`)
+  frontmatterLines.push(`description: ${agent.description}`)
+  if (agent.model) {
+    frontmatterLines.push(`model: ${agent.model}`)
+  }
+  if (agent.temperature !== undefined) {
+    frontmatterLines.push(`temperature: ${agent.temperature}`)
+  }
+  frontmatterLines.push("---")
+
+  let body = agent.body.trim()
+  if (agent.capabilities && agent.capabilities.length > 0) {
+    const capabilities = agent.capabilities.map((capability) => `- ${capability}`).join("\n")
+    body = `## Capabilities\n${capabilities}\n\n${body}`
+  }
+
+  const content = frontmatterLines.join("\n") + "\n\n" + body
+
+  return {
+    name: agent.name,
+    content,
+  }
+}
+
+function convertCommands(commands: ClaudeCommand[]) {
+  return commands.map((cmd) => {
+    const frontmatterLines: string[] = []
+    frontmatterLines.push("---")
+    frontmatterLines.push(`name: ${cmd.name}`)
+    if (cmd.description) {
+      frontmatterLines.push(`description: ${cmd.description}`)
+    }
+    frontmatterLines.push("---")
+
+    const content = frontmatterLines.join("\n") + "\n\n" + cmd.content
+
+    return {
+      name: cmd.name,
+      content,
+    }
+  })
+}

--- a/src/sync/qoder.ts
+++ b/src/sync/qoder.ts
@@ -1,0 +1,40 @@
+import path from "path"
+import type { ClaudeHomeConfig } from "../parsers/claude-home"
+import { sanitizePathName, writeText } from "../utils/files"
+import { syncSkills } from "./skills"
+
+export async function syncToQoder(
+  config: ClaudeHomeConfig,
+  outputRoot: string,
+): Promise<void> {
+  await syncSkills(config.skills, path.join(outputRoot, "skills"))
+  await syncQoderCommands(config, outputRoot)
+
+  if (Object.keys(config.mcpServers).length > 0) {
+    console.warn(
+      "Warning: Qoder MCP sync is skipped because Qoder does not yet document an MCP server config contract.",
+    )
+  }
+}
+
+async function syncQoderCommands(
+  config: ClaudeHomeConfig,
+  outputRoot: string,
+): Promise<void> {
+  if (!config.commands || config.commands.length === 0) return
+
+  const commandsDir = path.join(outputRoot, "commands")
+  for (const cmd of config.commands) {
+    const frontmatterLines: string[] = []
+    frontmatterLines.push("---")
+    frontmatterLines.push(`name: ${cmd.name}`)
+    if (cmd.description) {
+      frontmatterLines.push(`description: ${cmd.description}`)
+    }
+    frontmatterLines.push("---")
+
+    const content = frontmatterLines.join("\n") + "\n\n" + cmd.body
+    const safeName = sanitizePathName(cmd.name)
+    await writeText(path.join(commandsDir, `${safeName}.md`), content + "\n")
+  }
+}

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -10,6 +10,7 @@ import { syncToKiro } from "./kiro"
 import { syncToOpenClaw } from "./openclaw"
 import { syncToOpenCode } from "./opencode"
 import { syncToPi } from "./pi"
+import { syncToQoder } from "./qoder"
 import { syncToQwen } from "./qwen"
 import { syncToWindsurf } from "./windsurf"
 
@@ -33,6 +34,7 @@ export type SyncTargetName =
   | "qwen"
   | "openclaw"
   | "kimi"
+  | "qoder"
 
 export type SyncTargetDefinition = {
   name: SyncTargetName
@@ -127,6 +129,12 @@ export const syncTargets: SyncTargetDefinition[] = [
     detectPaths: (home) => [path.join(home, ".kimi")],
     resolveOutputRoot: (home) => path.join(home, ".kimi"),
     sync: syncToKimi,
+  },
+  {
+    name: "qoder",
+    detectPaths: (home) => [path.join(home, ".qoder")],
+    resolveOutputRoot: (home) => path.join(home, ".qoder"),
+    sync: syncToQoder,
   },
 ]
 

--- a/src/targets/claude.ts
+++ b/src/targets/claude.ts
@@ -1,0 +1,62 @@
+import path from "path"
+import {
+  copySkillDir,
+  ensureDir,
+  sanitizePathName,
+  writeText,
+} from "../utils/files"
+import type { ClaudeBundle } from "../converters/claude-to-claude"
+
+/**
+ * Write Claude bundle to the output directory.
+ *
+ * Claude structure:
+ * ~/.claude/
+ *   ├── skills/<skill-name>/SKILL.md
+ *   ├── agents/<agent-name>.md
+ *   └── commands/<command-name>.md
+ */
+export async function writeClaudeBundle(
+  outputRoot: string,
+  bundle: ClaudeBundle,
+): Promise<void> {
+  // Write agents
+  if (bundle.agents.length > 0) {
+    await ensureDir(path.join(outputRoot, "agents"))
+    const seenAgents = new Set<string>()
+    for (const agent of bundle.agents) {
+      const safeName = sanitizePathName(agent.name)
+      if (seenAgents.has(safeName)) {
+        console.warn(
+          `Skipping agent "${agent.name}": sanitized name "${safeName}" collides with another agent`,
+        )
+        continue
+      }
+      seenAgents.add(safeName)
+      await writeText(path.join(outputRoot, "agents", `${safeName}.md`), agent.content + "\n")
+      console.log(`Installed agent: ${agent.name}`)
+    }
+  }
+
+  // Write commands
+  if (bundle.commandFiles.length > 0) {
+    await ensureDir(path.join(outputRoot, "commands"))
+    for (const cmd of bundle.commandFiles) {
+      const safeName = sanitizePathName(cmd.name)
+      await writeText(path.join(outputRoot, "commands", `${safeName}.md`), cmd.content + "\n")
+      console.log(`Installed command: ${cmd.name}`)
+    }
+  }
+
+  // Copy skills
+  if (bundle.skillDirs.length > 0) {
+    await ensureDir(path.join(outputRoot, "skills"))
+    for (const skill of bundle.skillDirs) {
+      const destDir = path.join(outputRoot, "skills", sanitizePathName(skill.name))
+      await copySkillDir(skill.sourceDir, destDir, undefined, false)
+      console.log(`Installed skill: ${skill.name}`)
+    }
+  }
+
+  console.log(`\nClaude installation complete at: ${outputRoot}`)
+}

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -9,6 +9,8 @@ import { convertClaudeToKiro } from "../converters/claude-to-kiro"
 import { convertClaudeToWindsurf } from "../converters/claude-to-windsurf"
 import { convertClaudeToOpenClaw } from "../converters/claude-to-openclaw"
 import { convertClaudeToQwen } from "../converters/claude-to-qwen"
+import { convertClaudeToClaude } from "../converters/claude-to-claude"
+import { convertClaudeToKimi } from "../converters/claude-to-kimi"
 import { convertClaudeToQoder } from "../converters/claude-to-qoder"
 import { convertClaudeToTrae } from "../converters/claude-to-trae"
 import { convertClaudeToCursor } from "../converters/claude-to-cursor"
@@ -22,6 +24,8 @@ import { writeKiroBundle } from "./kiro"
 import { writeWindsurfBundle } from "./windsurf"
 import { writeOpenClawBundle } from "./openclaw"
 import { writeQwenBundle } from "./qwen"
+import { writeClaudeBundle } from "./claude"
+import { writeKimiBundle } from "./kimi"
 import { writeQoderBundle } from "./qoder"
 import { writeTraeBundle } from "./trae"
 import { writeCursorBundle } from "./cursor"
@@ -64,6 +68,12 @@ export type TargetHandler<TBundle = unknown> = {
 }
 
 export const targets: Record<string, TargetHandler> = {
+  claude: {
+    name: "claude",
+    implemented: true,
+    convert: convertClaudeToClaude as TargetHandler["convert"],
+    write: writeClaudeBundle as TargetHandler["write"],
+  },
   opencode: {
     name: "opencode",
     implemented: true,
@@ -125,6 +135,12 @@ export const targets: Record<string, TargetHandler> = {
     implemented: true,
     convert: convertClaudeToQwen as TargetHandler["convert"],
     write: writeQwenBundle as TargetHandler["write"],
+  },
+  kimi: {
+    name: "kimi",
+    implemented: true,
+    convert: convertClaudeToKimi as TargetHandler["convert"],
+    write: writeKimiBundle as TargetHandler["write"],
   },
   qoder: {
     name: "qoder",

--- a/src/targets/kimi.ts
+++ b/src/targets/kimi.ts
@@ -1,0 +1,54 @@
+import path from "path"
+import {
+  copySkillDir,
+  ensureDir,
+  sanitizePathName,
+  writeText,
+} from "../utils/files"
+import type { KimiBundle } from "../converters/claude-to-kimi"
+
+/**
+ * Write Kimi bundle to the output directory.
+ *
+ * Kimi structure:
+ * ~/.kimi/
+ *   └── skills/<skill-name>/SKILL.md
+ */
+export async function writeKimiBundle(
+  outputRoot: string,
+  bundle: KimiBundle,
+): Promise<void> {
+  const skillsDir = path.join(outputRoot, "skills")
+
+  // Copy original skills
+  if (bundle.skillDirs.length > 0) {
+    await ensureDir(skillsDir)
+    for (const skill of bundle.skillDirs) {
+      const destDir = path.join(skillsDir, sanitizePathName(skill.name))
+      await copySkillDir(skill.sourceDir, destDir, undefined, false)
+      console.log(`Installed skill: ${skill.name}`)
+    }
+  }
+
+  // Write generated skills (agents and commands)
+  if (bundle.generatedSkills.length > 0) {
+    await ensureDir(skillsDir)
+    const seenNames = new Set<string>()
+    for (const skill of bundle.generatedSkills) {
+      const safeName = sanitizePathName(skill.name)
+      if (seenNames.has(safeName)) {
+        console.warn(
+          `Skipping generated skill "${skill.name}": sanitized name "${safeName}" collides with another skill`,
+        )
+        continue
+      }
+      seenNames.add(safeName)
+      const destDir = path.join(skillsDir, safeName)
+      await ensureDir(destDir)
+      await writeText(path.join(destDir, "SKILL.md"), skill.content + "\n")
+      console.log(`Installed generated skill: ${skill.name}`)
+    }
+  }
+
+  console.log(`\nKimi installation complete at: ${outputRoot}`)
+}

--- a/src/utils/detect-tools.ts
+++ b/src/utils/detect-tools.ts
@@ -1,4 +1,5 @@
 import os from "os"
+import path from "path"
 import { pathExists } from "./files"
 import { syncTargets } from "../sync/registry"
 
@@ -25,6 +26,14 @@ export async function detectInstalledTools(
     }
     results.push({ name: target.name, detected, reason })
   }
+
+  // Claude is the native authoring format and is not a sync target,
+  // but it should still be detected as an install destination.
+  const claudeHome = path.join(home, ".claude")
+  if (await pathExists(claudeHome)) {
+    results.push({ name: "claude", detected: true, reason: `found ${claudeHome}` })
+  }
+
   return results
 }
 

--- a/src/utils/resolve-output.ts
+++ b/src/utils/resolve-output.ts
@@ -14,12 +14,13 @@ export function resolveTargetOutputRoot(options: {
   qoderHome?: string
   traeHome?: string
   cursorHome?: string
+  kimiHome?: string
   pluginName?: string
   plugin?: ClaudePlugin
   hasExplicitOutput: boolean
   scope?: TargetScope
 }): string {
-  const { targetName, outputRoot, codexHome, piHome, openclawHome, qwenHome, qoderHome, traeHome, cursorHome, pluginName, plugin, hasExplicitOutput, scope } = options
+  const { targetName, outputRoot, codexHome, piHome, openclawHome, qwenHome, qoderHome, traeHome, cursorHome, kimiHome, pluginName, plugin, hasExplicitOutput, scope } = options
   if (targetName === "codex") return codexHome
   if (targetName === "pi") return piHome
   if (targetName === "droid") return path.join(os.homedir(), ".factory")
@@ -56,6 +57,12 @@ export function resolveTargetOutputRoot(options: {
   }
   if (targetName === "trae") {
     return traeHome ?? path.join(os.homedir(), ".trae")
+  }
+  if (targetName === "kimi") {
+    return kimiHome ?? path.join(os.homedir(), ".kimi")
+  }
+  if (targetName === "claude") {
+    return options.claudeHome ?? path.join(os.homedir(), ".claude")
   }
   return outputRoot
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -652,6 +652,7 @@ describe("CLI", () => {
     await fs.mkdir(path.join(tempHome, ".qwen"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".openclaw"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".kimi"), { recursive: true })
+    await fs.mkdir(path.join(tempHome, ".qoder"), { recursive: true })
     await fs.mkdir(path.join(tempCwd, ".cursor"), { recursive: true })
 
     const proc = Bun.spawn([
@@ -690,6 +691,7 @@ describe("CLI", () => {
     expect(stdout).toContain("Synced to copilot")
     expect(stdout).toContain("Synced to gemini")
     expect(stdout).toContain("Synced to kimi")
+    expect(stdout).toContain("Synced to qoder")
     expect(stdout).not.toContain("cursor")
 
     expect(await exists(path.join(tempHome, ".config", "opencode", "commands", "workflows", "plan.md"))).toBe(true)

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -50,7 +50,7 @@ describe("detectInstalledTools", () => {
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
-    expect(results.length).toBe(11)
+    expect(results.length).toBe(12)
     for (const tool of results) {
       expect(tool.detected).toBe(false)
       expect(tool.reason).toBe("not found")

--- a/tests/sync-qoder.test.ts
+++ b/tests/sync-qoder.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+import type { ClaudeHomeConfig } from "../src/parsers/claude-home"
+import { syncToQoder } from "../src/sync/qoder"
+
+describe("syncToQoder", () => {
+  test("symlinks skills and writes commands", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sync-qoder-"))
+    const fixtureSkillDir = path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one")
+
+    const config: ClaudeHomeConfig = {
+      skills: [
+        {
+          name: "skill-one",
+          sourceDir: fixtureSkillDir,
+          skillPath: path.join(fixtureSkillDir, "SKILL.md"),
+        },
+      ],
+      commands: [
+        {
+          name: "workflows:plan",
+          description: "Planning command",
+          body: "Plan the work.",
+          sourcePath: "/tmp/workflows/plan.md",
+        },
+      ],
+      mcpServers: {},
+    }
+
+    await syncToQoder(config, tempRoot)
+
+    const skillPath = path.join(tempRoot, "skills", "skill-one")
+    expect((await fs.lstat(skillPath)).isSymbolicLink()).toBe(true)
+
+    const commandPath = path.join(tempRoot, "commands", "workflows-plan.md")
+    const commandContent = await fs.readFile(commandPath, "utf8")
+    expect(commandContent).toContain("name: workflows:plan")
+    expect(commandContent).toContain("description: Planning command")
+    expect(commandContent).toContain("Plan the work.")
+  })
+
+  test("warns when MCP servers are present", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sync-qoder-mcp-"))
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message))
+    }
+
+    try {
+      const config: ClaudeHomeConfig = {
+        skills: [],
+        mcpServers: {
+          local: { command: "echo" },
+        },
+      }
+
+      await syncToQoder(config, tempRoot)
+    } finally {
+      console.warn = originalWarn
+    }
+
+    expect(warnings.some((w) => w.includes("Qoder MCP sync is skipped"))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Add `claude`, `kimi`, and `qoder` as first-class install/sync targets, integrate HKTMemory into core workflow skills, and update the README installation tutorial to match the new platform support.

This PR replaces the previous #4 / #6 branch with a clean history rebased on top of the already-merged kimi sync work.

## Changes

### Install targets
- `src/converters/claude-to-kimi.ts` + `src/targets/kimi.ts`: Kimi install target (writes skills/agents/commands as `~/.kimi/skills/<name>/SKILL.md`)
- `src/converters/claude-to-claude.ts` + `src/targets/claude.ts`: Claude install target (writes to `~/.claude/{skills,agents,commands}/`)
- `src/targets/index.ts`: register `kimi` and `claude`
- `src/utils/resolve-output.ts`: fix default output paths for `kimi` and `claude`

### Sync targets
- `src/sync/qoder.ts`: Qoder sync target (skills + commands; MCP skipped with warning)
- `src/sync/registry.ts`: register `qoder`

### Detection & CLI
- `src/utils/detect-tools.ts`: detect `~/.claude` so `install --to all` includes Claude
- `src/commands/sync.ts`: guard `sync --target all` against non-sync targets (e.g. `claude`)
- `src/commands/install.ts`: wire `kimiHome` through `resolveTargetOutputRoot`

### HKTMemory integration
- `plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md`
- `plugins/galeharness-cli/skills/gh-plan/SKILL.md`
- `plugins/galeharness-cli/skills/gh-work/SKILL.md`
- `plugins/galeharness-cli/skills/gh-compound/SKILL.md`
- `plugins/galeharness-cli/skills/gh-compound-refresh/SKILL.md`

### Docs
- `README.md`: update global install instructions (add PATH export), platform count (15), code examples, and output details table.

## Tests

```bash
bun test tests/sync-kimi.test.ts tests/sync-qoder.test.ts tests/cli.test.ts tests/detect-tools.test.ts
```

All 25 tests pass.

## Live verification
- `claude -p` answers **是** when asked whether `gh:brainstorm` is available.
- `kimi --print` answers **是** when asked whether `gh:brainstorm` is available.
- `~/.qoder/skills/gh-brainstorm/SKILL.md` exists after install.
- `install --to all` end-to-end verified across 9 detected platforms.