### PR TITLE
feat(gh-setup): Windows Trae IDE compatibility

### DIFF
--- a/docs/ideation/2026-04-17-windows-trae-compatibility-ideation.md
+++ b/docs/ideation/2026-04-17-windows-trae-compatibility-ideation.md
@@ -1,0 +1,81 @@
+---
+date: 2026-04-17
+topic: windows-trae-compatibility
+focus: Windows Trae IDE users cannot use gh: skills — uv not in PATH, bash scripts fail on PowerShell
+---
+
+# Ideation: Windows Trae Compatibility
+
+## Codebase Context
+
+**Project shape:** TypeScript/Bun CLI that converts Claude Code plugins to other agent platforms. Includes vendored HKTMemory v5.0 (Python/uv) and `gh:` prefix skills.
+
+**Key research findings:**
+- `uv run` and PEP 723 inline metadata work identically on Windows — the blocker is uv not in PATH, not missing platform support
+- Trae on Windows defaults to **PowerShell v5.x** — bash is not available by default. The AI sandbox does not inherit user terminal profiles
+- `check-health` bash script uses `#!/bin/bash`, bash arrays, `command -v`, `brew install` — completely broken on PowerShell
+- Original compound-engineering-plugin has **zero Windows support** — we would be first movers
+- Existing Windows fix already in repo: `sanitizePathName()` handles colon-in-filename for gh: skills
+- All 6 core skills use `uv run vendor/hkt-memory/scripts/hkt_memory_v5.py` — works once uv is installed
+- Trae forum confirms default shell is PowerShell 5.x with encoding issues; sandbox does not inherit terminal profile
+
+**Affected skills:** gh:brainstorm, gh:plan, gh:work, gh:review, gh:compound, gh:ideate (all HKTMemory calls), gh:setup (check-health script)
+
+## Ranked Ideas
+
+### 1. `gh:setup` Windows inline detection path + uv install guidance
+**Description:** Add platform detection early in `gh:setup` SKILL.md. When `$env:OS` is `Windows_NT`, skip `bash scripts/check-health`, emit inline PowerShell probe commands (`Get-Command uv`, `Get-Command gh`, `Test-Path .gitignore`), and output `irm https://astral.sh/uv/install.ps1 | iex` when uv is missing.
+**Rationale:** `gh:setup` is the onboarding entry point. A SKILL.md branch costs nothing to ship — no new files, no bash changes, zero macOS/Linux regression. Windows users get actionable instructions on first run instead of a bash error.
+**Downsides:** Guidance only — does not auto-execute installation. Depends on user running the PowerShell command manually.
+**Confidence:** 88%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 2. `docs/solutions/integrations/windows-trae-setup.md` knowledge doc
+**Description:** Persist the research findings as a solution doc: uv installation on Windows, PATH configuration (`%USERPROFILE%\.local\bin`), env var setup, which skills are immediately usable after uv install, known limitations (check-health bash). Serves both users and future contributors.
+**Rationale:** Zero-cost, immediate value. Answers "what do I do first on Windows?" and documents the current state as institutional knowledge.
+**Downsides:** Documentation alone doesn't fix the root issue — needs to accompany technical changes.
+**Confidence:** 95%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 3. `check-health.ps1` companion script
+**Description:** Add `plugins/galeharness-cli/skills/gh-setup/scripts/check-health.ps1` as a PowerShell equivalent of the bash script. Uses `Get-Command`, `git rev-parse`, `winget install` commands. `gh:setup` SKILL.md selects script by platform.
+**Rationale:** Zero regression on macOS/Linux. Windows users get actual diagnostic output and native install commands.
+**Downsides:** Two parallel implementations to maintain; new dependencies must be added in both places.
+**Confidence:** 82%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 4. HKTMemory TypeScript/HTTP client (remove Python dependency)
+**Description:** The env vars `HKT_MEMORY_BASE_URL` + `HKT_MEMORY_API_KEY` point to an HTTP endpoint. A `vendor/hkt-memory/client.ts` using `fetch` would implement store/retrieve/stats without Python or uv. All 6 skills replace `uv run hkt_memory_v5.py` with `bun run vendor/hkt-memory/client.ts`.
+**Rationale:** Eliminates Python + uv entirely. Bun is already required — zero new install cost. Faster cold start than uv.
+**Downsides:** Needs spike to understand full API contract. Local vector store logic may not map cleanly to HTTP calls — HKTMemory may use local file storage, not just a remote API.
+**Confidence:** 70%
+**Complexity:** Medium-High
+**Status:** Unexplored
+
+### 5. HKTMemory MCP Server (Trae-native integration)
+**Description:** Implement `mcp/hkt-memory-server.ts` exposing store/retrieve/stats as MCP tools. Trae agent calls MCP tools instead of shelling out, bypassing uv/bash entirely.
+**Rationale:** MCP is Trae's native tool interface — no shell execution required. Future-proof for other MCP-first platforms.
+**Downsides:** Highest implementation cost. Requires TypeScript reimplementation of HKTMemory logic or API wrapping. MCP server needs process management.
+**Confidence:** 65%
+**Complexity:** High
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | devcontainer.json | Bypasses the problem; Windows users want local execution |
+| 2 | `runCommand` CLI abstraction | Skills invoke uv via shell prose, not the CLI — abstraction doesn't reach the call site |
+| 3 | `gh:review` bash `$()` replacement | Independent issue, not in scope of Windows/HKTMemory feedback |
+| 4 | Add `trae` to `syncTargets` | Correct fix but unrelated to Windows runtime failure |
+| 5 | `--trae-home` CLI flag | Correct but lower priority than runtime failure |
+| 6 | Replace `deploy.sh` with Bun | Not on user install path; contributor-only concern |
+| 7 | Platform filter tags to block skills | Blocking is worse than fixing; bad user experience |
+| 8 | Post-install Windows PATH note | Not valuable enough as standalone change |
+| 9 | Git Bash detection and reuse | Unstable — Git install paths vary; simpler to guide uv install directly |
+
+## Session Log
+- 2026-04-17: Initial ideation — ~28 candidates generated across 3 parallel agents, 5 survivors after adversarial filtering. Immediate action: implement idea #1 + #2 (fast path to unblock users). Ideas #3–5 queued for follow-up planning.

--- a/docs/solutions/integrations/windows-trae-setup-2026-04-17.md
+++ b/docs/solutions/integrations/windows-trae-setup-2026-04-17.md
@@ -1,0 +1,122 @@
+---
+title: "Windows Trae IDE setup: uv PATH and bash compatibility"
+date: 2026-04-17
+category: integration-issues
+module: galeharness-cli-skills
+problem_type: integration_issue
+component: hkt-memory, gh-setup
+symptoms:
+  - "HKTMemory calls silently fail -- all gh: skills skip memory operations"
+  - "gh:setup crashes with 'bash: command not found' or similar"
+  - "uv not found when running uv run vendor/hkt-memory/scripts/hkt_memory_v5.py"
+  - "check-health script produces no output or PowerShell syntax errors"
+root_cause: config_error
+resolution_type: documentation
+severity: high
+related_components:
+  - skills/gh-setup
+  - vendor/hkt-memory
+  - all six core skills (gh:brainstorm, gh:plan, gh:work, gh:review, gh:compound, gh:ideate)
+---
+
+# Windows Trae IDE Setup: uv PATH and Bash Compatibility
+
+## Problem
+
+Windows users running GaleHarnessCLI skills in Trae IDE encounter two distinct failures:
+
+1. **All HKTMemory operations silently fail.** All 6 core skills (`gh:brainstorm`, `gh:plan`, `gh:work`, `gh:review`, `gh:compound`, `gh:ideate`) invoke `uv run vendor/hkt-memory/scripts/hkt_memory_v5.py`. When `uv` is not in PATH, the call fails and the skill silently skips memory operations. No error is surfaced to the user because the skills are designed to continue on HKTMemory failure.
+
+2. **`gh:setup` crashes immediately.** The setup skill runs `bash scripts/check-health`. Trae on Windows defaults to PowerShell v5.x. `bash` is not available in the sandbox shell. The script never runs, and the diagnostic output is empty.
+
+## Root Cause
+
+**Two separate issues:**
+
+### Issue 1: uv not in PATH on Windows
+
+`uv` does fully support Windows -- `uv run` and PEP 723 inline script metadata work identically across platforms. The failure is that:
+
+- Windows users typically do not have `uv` installed
+- Even when installed via `irm https://astral.sh/uv/install.ps1 | iex`, uv lands in `%USERPROFILE%\.local\bin` which is **not in PATH by default**
+- Trae's AI sandbox does not inherit user-defined terminal profiles or `$PROFILE` customizations
+
+### Issue 2: bash scripts incompatible with PowerShell
+
+`vendor/hkt-memory/install.sh`, `vendor/hkt-memory/deploy.sh`, and `plugins/galeharness-cli/skills/gh-setup/scripts/check-health` are all bash scripts using:
+- `#!/usr/bin/env bash`
+- bash arrays (`deps=(...)`)
+- `command -v` (no PowerShell equivalent)
+- `brew install` (macOS/Linux package manager)
+- Process substitution and `IFS` splitting
+
+PowerShell v5.x cannot run any of these.
+
+## Resolution
+
+### Step 1: Install uv on Windows
+
+Open PowerShell (not the Trae sandbox -- use a standalone PowerShell window) and run:
+
+```powershell
+irm https://astral.sh/uv/install.ps1 | iex
+```
+
+### Step 2: Add uv to PATH
+
+After installation, add `%USERPROFILE%\.local\bin` to your system PATH:
+
+1. Open **System Properties** -> **Advanced** -> **Environment Variables**
+2. Under "User variables", find `Path` and click **Edit**
+3. Add `%USERPROFILE%\.local\bin` as a new entry
+4. Click OK and restart Trae
+
+To verify: open a new PowerShell window and run `uv --version`.
+
+### Step 3: Configure HKTMemory environment variables
+
+Set these as **system-level** environment variables (not session-only -- Trae's sandbox must see them):
+
+| Variable | Value |
+|----------|-------|
+| `HKT_MEMORY_API_KEY` | Your API key |
+| `HKT_MEMORY_BASE_URL` | `https://open.bigmodel.cn/api/paas/v4/` |
+| `HKT_MEMORY_MODEL` | `embedding-3` |
+
+Set via System Properties -> Environment Variables -> New (under User variables).
+
+### Step 4: Restart Trae
+
+Trae's sandbox shell is spawned once at startup. Changes to PATH and environment variables are only picked up after a full Trae restart.
+
+### Step 5: Verify HKTMemory
+
+In the Trae sandbox terminal, run:
+
+```powershell
+uv run vendor/hkt-memory/scripts/hkt_memory_v5.py stats
+```
+
+If this returns stats output, HKTMemory is functional and all 6 core skills will use it.
+
+## Known Limitations (as of 2026-04-17)
+
+| Component | Status |
+|-----------|--------|
+| `gh:brainstorm`, `gh:plan`, `gh:work`, `gh:review`, `gh:compound`, `gh:ideate` | Work after uv + PATH fix |
+| `gh:setup` -- HKTMemory env var guidance | Handled via inline PowerShell path added in SKILL.md |
+| `gh:setup` -- `check-health` bash script | Not functional on PowerShell -- diagnostic output unavailable. Use inline PowerShell probes from gh:setup Windows path instead |
+| `vendor/hkt-memory/install.sh` | Bash-only -- run under Git Bash or WSL2 if needed, or skip (uv install handles dependencies automatically) |
+| `git-worktree`, `gh:optimize`, `gh:polish-beta` | May have additional bash dependencies not yet audited |
+
+## Future Work
+
+See `docs/ideation/2026-04-17-windows-trae-compatibility-ideation.md` for the full option space:
+
+- **check-health.ps1** -- PowerShell companion to the bash health-check script (Medium complexity)
+- **TypeScript HKTMemory client** -- Replace Python/uv entirely with a Bun-native HTTP client (Medium-High)
+- **MCP server** -- Wrap HKTMemory as a Trae-native MCP tool (High complexity)
+
+## Background
+
+The original compound-engineering-plugin (upstream) has no Windows support. This is GaleHarnessCLI's divergence: the uv + Python toolchain is well-supported on Windows once installed, making a working Windows path achievable with setup guidance alone. The bash script dependency in `gh:setup` is the harder problem requiring a `check-health.ps1` or equivalent.

--- a/plugins/galeharness-cli/skills/gh-setup/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-setup/SKILL.md
@@ -12,7 +12,70 @@ Ask the user each question below using the platform's blocking question tool (e.
 
 Interactive setup for compound-engineering — diagnoses environment health, cleans obsolete repo-local CE config, and helps configure required tools. Review agent selection is handled automatically by `gh:review`; project-specific review guidance belongs in `CLAUDE.md` or `AGENTS.md`.
 
-## Phase 1: Diagnose
+## Phase 0: Detect Platform
+
+Before any other step, determine whether this is a Windows environment.
+
+Run the following detection. On Windows PowerShell, `$env:OS` is set to `Windows_NT`. On POSIX (macOS/Linux), it is unset.
+
+**Windows detection:** Try running `$env:OS` in the current shell. If the output is `Windows_NT`, set `IS_WINDOWS=true` and follow the **Windows path** below. Otherwise, follow the **standard path**.
+
+If shell detection is unavailable, ask the user: "Are you on Windows?" and route accordingly.
+
+### Windows Path (PowerShell)
+
+On Windows, `bash` is not available in the default Trae shell (PowerShell v5.x). Skip Steps 1-2 and run the following inline diagnostics instead.
+
+Display: "Compound Engineering -- checking your environment (Windows)..."
+
+Run each check and report results:
+
+```powershell
+# Check uv
+Get-Command uv -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+```
+
+```powershell
+# Check gh
+Get-Command gh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+```
+
+```powershell
+# Check jq
+Get-Command jq -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+```
+
+```powershell
+# Check HKTMemory env vars
+[System.Environment]::GetEnvironmentVariable("HKT_MEMORY_API_KEY"), `
+[System.Environment]::GetEnvironmentVariable("HKT_MEMORY_BASE_URL"), `
+[System.Environment]::GetEnvironmentVariable("HKT_MEMORY_MODEL")
+```
+
+For each missing tool, report it as yellow and provide the Windows install command:
+
+| Tool | Windows install command |
+|------|------------------------|
+| uv | `irm https://astral.sh/uv/install.ps1 \| iex` |
+| gh | `winget install GitHub.cli` |
+| jq | `winget install jqlang.jq` |
+| ffmpeg | `winget install Gyan.FFmpeg` |
+| agent-browser | `npm install -g agent-browser` |
+
+**Important -- uv PATH on Windows:** After installing uv on Windows, add `$env:USERPROFILE\.local\bin` to your system PATH if it is not already there. Without this, `uv` is installed but not discoverable by the Trae sandbox shell. To verify: open a new PowerShell window and run `uv --version`.
+
+**HKTMemory env vars on Windows:** Set these in Windows System Properties -> Environment Variables (not just in the terminal session):
+- `HKT_MEMORY_API_KEY` -- your API key
+- `HKT_MEMORY_BASE_URL` -- `https://open.bigmodel.cn/api/paas/v4/`
+- `HKT_MEMORY_MODEL` -- `embedding-3`
+
+After installing uv and configuring env vars, restart Trae to ensure the sandbox picks up the updated PATH.
+
+Display a summary of the inline diagnostic results (which tools were found, which are missing, env var status). Then proceed to **Phase 1 / Step 3: Evaluate Results** below for the completion check and next steps.
+
+---
+
+## Phase 1: Diagnose (standard path -- macOS/Linux)
 
 ### Step 1: Determine Plugin Version
 
@@ -42,13 +105,19 @@ Display the script's output to the user.
 
 ### Step 3: Evaluate Results
 
-**Platform detection (pre-resolved):** !`[ -n "${CLAUDE_PLUGIN_ROOT}" ] && echo "CLAUDE_CODE" || echo "OTHER"`
+**Platform detection (pre-resolved):**
+- **macOS/Linux:** !`[ -n "${CLAUDE_PLUGIN_ROOT}" ] && echo "CLAUDE_CODE" || echo "OTHER"`
+- **Windows:** !`if ($env:CLAUDE_PLUGIN_ROOT) { "CLAUDE_CODE" } else { "OTHER" }`
 
-If the line above resolved to `CLAUDE_CODE`, this is a Claude Code session and `/gh:update` is available. Otherwise, omit any `/gh:update` references from output.
+If the platform detection resolved to `CLAUDE_CODE`, this is a Claude Code session and `/gh:update` is available. Otherwise, omit any `/gh:update` references from output.
+
+**For Windows users:** The inline diagnostic output from Phase 0 shows tool availability directly. A tool is missing if `Get-Command` returned nothing (blank line). For macOS/Linux users, check the health-check script output as described below.
 
 After the diagnostic report, check whether:
 
-- any dependencies are missing (reported as yellow in the script output)
+- any dependencies are missing:
+  - **macOS/Linux:** reported as yellow in the script output
+  - **Windows:** `Get-Command` returned no result for uv, gh, or jq
 - `compound-engineering.local.md` is present and needs cleanup
 - `.compound-engineering/config.local.yaml` does not exist or is not safely gitignored
 - `.compound-engineering/config.local.example.yaml` is missing or outdated


### PR DESCRIPTION
## Summary

Adds Windows platform support to `gh:setup` skill for Trae IDE users. Trae on Windows defaults to PowerShell v5.x where bash is unavailable, causing setup to fail silently.

## Changes

### SKILL.md (gh:setup)
- **Phase 0: Platform Detection** — Detect Windows via `$env:OS` and route to PowerShell path
- **Windows inline diagnostics** — PowerShell equivalents for `Get-Command uv/gh/jq` and env var checks
- **Windows install guidance** — One-liner commands for winget-based installs
- **Critical PATH note** — Documents `%USERPROFILE%\.local\bin` requirement (uv installs here by default but it's not in PATH)
- **Step 3 platform branching** — Separates evaluation logic for Windows vs macOS/Linux

### Documentation
- `docs/solutions/integrations/windows-trae-setup-2026-04-17.md` — Solution doc explaining root causes (uv PATH + bash incompatibility) with step-by-step resolution
- `docs/ideation/2026-04-17-windows-trae-compatibility-ideation.md` — Full ideation record with 5 ranked ideas and future work options

## Test Plan

- [ ] Run `gh:setup` on Windows Trae — should detect platform and show PowerShell diagnostics
- [ ] Verify uv install guidance appears when `Get-Command uv` returns nothing
- [ ] Verify HKTMemory env var check works on Windows
- [ ] Run `gh:setup` on macOS/Linux — should continue through standard bash path unchanged

## Known Limitations

| Component | Status |
|-----------|--------|
| Core 6 skills (brainstorm/plan/work/review/compound/ideate) | Work after uv+PATH fix |
| `check-health` bash script | Still non-functional on PowerShell — use inline diagnostics instead |
| `install.sh` / `deploy.sh` | Bash-only; uv handles deps automatically |

Future work (check-health.ps1, TypeScript client, MCP server) documented in ideation file.

🤖 Generated with [Qoder][https://qoder.com]