### PR TITLE
docs(readme): add cross-platform environment setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,79 +471,90 @@ flowchart LR
 
 ### 前置要求
 
-- [Bun](https://bun.sh/) >= 1.0.0
-- Node.js >= 18 (可选，用于部分工具)
-- Git
-- Python >= 3.9 (用于 HKTMemory)
+- macOS 11+ 或 Windows 10/11
+- 能联网的终端（macOS: Terminal / iTerm2，Windows: PowerShell）
 
-### 方式一：克隆源码（所有安装方式的前提）
+> 不需要预先安装任何工具。一键脚本会自动检测并安装缺失的依赖。
+
+### 一键安装
+
+#### macOS
 
 ```bash
-# 克隆仓库
+# 1. 克隆仓库
 git clone https://github.com/wangrenzhu-ola/GaleHarnessCLI.git
 cd GaleHarnessCLI
 
-# 安装依赖
-bun install
+# 2. 运行一键安装脚本
+bash scripts/setup.sh
+```
 
-# 安装 HKTMemory (必需)
-bash vendor/hkt-memory/install.sh
+脚本会交互式提示你输入 **HKT_MEMORY_API_KEY**，并自动配置好所有环境变量。
 
-# 配置 HKTMemory 环境变量
-export HKT_MEMORY_API_KEY=<your_key>
-export HKT_MEMORY_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
-export HKT_MEMORY_MODEL=embedding-3
+#### Windows
 
-# 或使用文件模式（无需 API）
-export HKT_MEMORY_FILE_MODE=true
+```powershell
+# 1. 克隆仓库
+git clone https://github.com/wangrenzhu-ola/GaleHarnessCLI.git
+cd GaleHarnessCLI
 
-# 验证安装
+# 2. 运行一键安装脚本（如遇到权限问题，以管理员身份运行 PowerShell）
+.\scripts\setup.ps1
+```
+
+脚本会自动安装 Git（如未安装）、Bun、Python、uv，交互式提示输入 **API Key** 并写入系统环境变量。
+
+> **PowerShell 执行策略：** 如果脚本无法运行，先执行：
+> ```powershell
+> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+> ```
+
+### 安装后自检
+
+安装脚本运行完毕后，请**重新打开终端**，然后依次运行以下命令验证：
+
+```bash
+# 1. Bun 运行时
+bun --version
+# → 期望: 1.x.x
+
+# 2. Python 版本
+python3 --version        # macOS
+python --version         # Windows
+# → 期望: Python 3.9+
+
+# 3. uv 包管理器
+uv --version
+# → 期望: uv x.x.x
+
+# 4. 全局 CLI
+gale-harness --help
+# → 期望: 显示 CLI 帮助信息
+
+# 5. HKTMemory 统计
+uv run vendor/hkt-memory/scripts/hkt_memory_v5.py stats
+# → 期望: 数据库和向量存储的统计信息
+
+# 6. 项目测试
 bun test
+# → 期望: 测试通过
 ```
 
-> 本项目不发布到 npm。所有安装方式均基于源码克隆。
+### 安装到 AI 编码工具
 
-### 方式二：全局安装（推荐，随处可用）
-
-克隆后通过 `bun link` 将 CLI 链接到全局，无需每次指定路径：
+全局安装后，在任意目录使用 `gale-harness` 命令：
 
 ```bash
-# 在仓库根目录执行
-bun link
-
-# 确保 ~/.bun/bin 在 PATH 中（添加到 ~/.zshrc 或 ~/.bashrc）
-export PATH="$HOME/.bun/bin:$PATH"
-
-# 之后在仓库根目录或任何指定了绝对/相对路径的目录直接使用
-gale-harness install ./plugins/galeharness-cli --to qoder
-```
-
-**支持的平台 (15个)：**
-
-| 平台 | 说明 |
-|------|------|
-| `claude` | Claude Code |
-| `opencode` | OpenCode |
-| `codex` | OpenAI Codex |
-| `droid` | Droid |
-| `pi` | PI |
-| `copilot` | GitHub Copilot |
-| `gemini` | Gemini CLI |
-| `kiro` | Kiro |
-| `windsurf` | Windsurf |
-| `openclaw` | OpenClaw |
-| `qwen` | Qwen |
-| `qoder` | Qoder |
-| `trae` | Trae (字节跳动) |
-| `cursor` | Cursor |
-| `kimi` | Kimi Code CLI |
-
-**一键安装到所有平台：**
-
-```bash
-# 安装到所有检测到的平台
+# 一键安装到所有检测到的平台
 gale-harness install ./plugins/galeharness-cli --to all
+
+# 或指定平台
+gale-harness install ./plugins/galeharness-cli --to claude
+gale-harness install ./plugins/galeharness-cli --to cursor
+gale-harness install ./plugins/galeharness-cli --to kimi
 ```
+
+**支持的平台 (15个)：** `claude`, `opencode`, `codex`, `droid`, `pi`, `gemini`, `copilot`, `kiro`, `windsurf`, `openclaw`, `qwen`, `qoder`, `trae`, `cursor`, `kimi`
 
 **Claude Code** —— 本地插件模式：
 
@@ -554,70 +565,6 @@ alias ghc='claude --plugin-dir /path/to/GaleHarnessCLI/plugins/galeharness-cli'
 
 运行 `ghc` 而不是 `claude` 来加载本地插件。
 
-### 方式三：安装到目标平台
-
-#### Claude Code
-
-```bash
-# 加载本地插件（在 ~/.zshrc 或 ~/.bashrc 中设置 alias 后随处使用）
-alias ghc='claude --plugin-dir /path/to/GaleHarnessCLI/plugins/galeharness-cli'
-
-# 或用 CLI 安装（一次性写入配置）
-bun run src/index.ts install ./plugins/galeharness-cli --to claude
-```
-
-#### OpenCode / Codex / Gemini / Qoder / 其他平台
-
-```bash
-# 在仓库根目录执行
-
-# OpenCode
-bun run src/index.ts install ./plugins/galeharness-cli --to opencode
-
-# Codex
-bun run src/index.ts install ./plugins/galeharness-cli --to codex
-
-# Gemini CLI
-bun run src/index.ts install ./plugins/galeharness-cli --to gemini
-
-# GitHub Copilot
-bun run src/index.ts install ./plugins/galeharness-cli --to copilot
-
-# Qoder
-bun run src/index.ts install ./plugins/galeharness-cli --to qoder
-
-# 支持的平台: claude, opencode, codex, droid, pi, gemini, copilot, kiro, windsurf, openclaw, qwen, qoder, trae, cursor, kimi
-bun run src/index.ts install ./plugins/galeharness-cli --to <platform>
-
-# 安装到所有检测到的平台
-bun run src/index.ts install ./plugins/galeharness-cli --to all
-```
-
-<details>
-<summary>各平台输出详情</summary>
-
-| 平台 | 输出路径 | 说明 |
-|------|----------|------|
-| `claude` | `~/.claude/` | 原生格式：skills、agents、commands 直接写入 |
-| `opencode` | `~/.config/opencode/` | 命令作为 `.md` 文件；`opencode.json` MCP 配置深度合并；覆盖前备份 |
-| `codex` | `~/.codex/prompts` + `~/.codex/skills` | 命令成为 prompt + skill 对 |
-| `droid` | `~/.factory/` | 工具名称映射 (`Bash`->`Execute`, `Write`->`Create`) |
-| `pi` | `~/.pi/agent/` | Prompts, skills, extensions 和 `mcporter.json` |
-| `gemini` | `.gemini/` | Skills 来自 agents；命令作为 `.toml` |
-| `copilot` | `.github/` | Agents 作为 `.agent.md` 带 Copilot frontmatter |
-| `kiro` | `.kiro/` | Agents 作为 JSON configs + prompt `.md` 文件 |
-| `openclaw` | `~/.openclaw/extensions/<plugin>/` | 入口 TypeScript skill 文件 |
-| `windsurf` | `~/.codeium/windsurf/` (global) 或 `.windsurf/` (workspace) | Agents 成为 skills；命令成为 flat workflows |
-| `qwen` | `~/.qwen/extensions/<plugin>/` | Agents 作为 `.yaml` |
-| `qoder` | `~/.qoder/` | Skills, agents, commands 作为 `.md` 文件 |
-| `trae` | `~/.trae/` | Skills, agents, commands 作为 `.md` 文件 (Agent Skills 标准) |
-| `cursor` | `~/.cursor/rules/` | Skills 作为 `.mdc` 规则文件 |
-| `kimi` | `~/.kimi/` | Skills、agents、commands 统一作为 `~/.kimi/skills/<name>/SKILL.md` |
-
-所有平台都是实验性的，可能随格式演进变化。
-
-</details>
-
 ### 项目初始化
 
 安装完成后，在项目目录运行：
@@ -627,12 +574,12 @@ bun run src/index.ts install ./plugins/galeharness-cli --to all
 ```
 
 这将：
-- 诊断环境配置
-- **强制安装 HKTMemory 向量知识库**
-- 交互式配置 HKTMemory API 凭证（支持文件模式回退）
-- 安装缺失工具 (agent-browser, gh, jq, vhs, silicon, ffmpeg)
+- 诊断环境配置（自动检测 Windows / macOS）
+- 安装缺失的推荐工具 (agent-browser, gh, jq, vhs, silicon, ffmpeg)
 - 引导项目配置
 - 验证 HKTMemory 连接状态
+
+> **Windows 用户：** `gh:setup` 会自动使用 PowerShell 路径进行工具检测和安装。
 
 ---
 
@@ -775,6 +722,8 @@ bun run src/index.ts sync --target all
 
 ## 环境变量
 
+安装脚本会自动配置以下变量，通常无需手动操作：
+
 | 变量 | 说明 | 必需 |
 |------|------|------|
 | `HKT_MEMORY_API_KEY` | HKTMemory API 密钥 | 否（可用文件模式） |
@@ -783,6 +732,11 @@ bun run src/index.ts sync --target all
 | `HKT_MEMORY_FILE_MODE` | 启用纯文件模式（无需 API） | 否 |
 
 **文件模式**：设置 `HKT_MEMORY_FILE_MODE=true` 可在无 API 密钥的情况下使用 HKTMemory，仅使用本地文件存储（L0/L1/L2 层 + 本地索引）。
+
+**如需手动修改：**
+
+- **macOS：** 编辑 shell profile（`~/.zshrc` 或 `~/.bashrc`）
+- **Windows：** 系统属性 → 环境变量 → 用户变量，或编辑 PowerShell profile（`notepad $PROFILE`）
 
 ---
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,292 @@
+# GaleHarnessCLI 环境一键安装脚本 (Windows)
+# 用法: .\scripts\setup.ps1
+
+#Requires -Version 5.1
+
+$ErrorActionPreference = "Stop"
+
+# =====================================================
+#  Colors
+# =====================================================
+function ok($msg)     { Write-Host "✓ $msg" -ForegroundColor Green }
+function warn($msg)   { Write-Host "⚠ $msg" -ForegroundColor Yellow }
+function err($msg)    { Write-Host "✗ $msg" -ForegroundColor Red }
+function info($msg)   { Write-Host "→ $msg" -ForegroundColor Cyan }
+function header($msg) { Write-Host "`n▶ $msg" -ForegroundColor Blue }
+
+# =====================================================
+#  Helpers
+# =====================================================
+function Test-Command($cmd) {
+    return [bool](Get-Command $cmd -ErrorAction SilentlyContinue)
+}
+
+function Add-ToUserPath($path) {
+    $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($currentPath -notlike "*$path*") {
+        [Environment]::SetEnvironmentVariable("Path", "$currentPath;$path", "User")
+        $env:Path = "$env:Path;$path"
+        ok "已添加到用户 PATH: $path"
+    }
+}
+
+# =====================================================
+#  Banner
+# =====================================================
+Write-Host ""
+Write-Host "GaleHarnessCLI 环境一键安装 (Windows)" -ForegroundColor White -BackgroundColor DarkBlue
+Write-Host "本脚本将自动检测并安装所有依赖。" -ForegroundColor Gray
+Write-Host ""
+
+# =====================================================
+#  1. Git
+# =====================================================
+header "1. 检查 Git"
+if (Test-Command "git") {
+    ok "Git 已安装 ($(git --version))"
+} else {
+    info "正在通过 winget 安装 Git..."
+    try {
+        winget install --id Git.Git --accept-source-agreements --accept-package-agreements --silent
+        ok "Git 安装完成"
+        warn "请重新打开 PowerShell 以使 Git 命令生效"
+    } catch {
+        err "Git 安装失败"
+        info "请手动下载安装: https://git-scm.com/download/win"
+        exit 1
+    }
+}
+
+# =====================================================
+#  2. Bun
+# =====================================================
+header "2. 检查 Bun"
+if (Test-Command "bun") {
+    ok "Bun 已安装 (v$(bun --version))"
+} else {
+    info "正在安装 Bun..."
+    try {
+        powershell -c "irm bun.sh/install.ps1|iex"
+        ok "Bun 安装完成"
+        Add-ToUserPath "$env:USERPROFILE\.bun\bin"
+        $env:Path = "$env:Path;$env:USERPROFILE\.bun\bin"
+        warn "已自动将 Bun 添加到用户 PATH，如仍找不到请重启 PowerShell"
+    } catch {
+        err "Bun 安装失败"
+        info "请手动安装: https://bun.sh/"
+        exit 1
+    }
+}
+
+# =====================================================
+#  3. Python 3.9+
+# =====================================================
+header "3. 检查 Python"
+
+$pythonCmd = $null
+foreach ($cmd in @("python", "python3", "py")) {
+    if (Test-Command $cmd) {
+        $pythonCmd = $cmd
+        break
+    }
+}
+
+if (-not $pythonCmd) {
+    info "正在通过 winget 安装 Python 3.12..."
+    try {
+        winget install --id Python.Python.3.12 --accept-source-agreements --accept-package-agreements --silent
+        ok "Python 3.12 安装完成"
+        warn "请重新打开 PowerShell 以使 python 命令生效"
+    } catch {
+        err "Python 安装失败"
+        info "请手动安装: https://www.python.org/downloads/windows/"
+        exit 1
+    }
+} else {
+    $pythonVersionStr = & $pythonCmd --version 2>&1
+    if ($pythonVersionStr -match "(\d+)\.(\d+)") {
+        $pythonMajor = [int]$Matches[1]
+        $pythonMinor = [int]$Matches[2]
+        if ($pythonMajor -gt 3 -or ($pythonMajor -eq 3 -and $pythonMinor -ge 9)) {
+            ok "Python 已安装 ($pythonVersionStr)"
+        } else {
+            err "Python 版本过低: $pythonVersionStr，需要 >= 3.9"
+            info "建议运行: winget install --id Python.Python.3.12"
+            exit 1
+        }
+    }
+}
+
+# =====================================================
+#  4. uv
+# =====================================================
+header "4. 检查 uv"
+if (Test-Command "uv") {
+    ok "uv 已安装"
+} else {
+    info "正在安装 uv..."
+    try {
+        irm https://astral.sh/uv/install.ps1 | iex
+        ok "uv 安装完成"
+        Add-ToUserPath "$env:USERPROFILE\.local\bin"
+        $env:Path = "$env:Path;$env:USERPROFILE\.local\bin"
+    } catch {
+        err "uv 安装失败"
+        info "请手动安装: https://docs.astral.sh/uv/getting-started/installation/"
+    }
+}
+
+# =====================================================
+#  5. Python Dependencies
+# =====================================================
+header "5. 安装 HKTMemory Python 依赖"
+try {
+    if (Test-Command "uv") {
+        uv pip install openai requests tqdm | Out-Null
+        ok "Python 依赖安装完成 (via uv)"
+    } else {
+        & $pythonCmd -m pip install openai requests tqdm | Out-Null
+        ok "Python 依赖安装完成 (via pip)"
+    }
+} catch {
+    warn "Python 依赖安装失败，请手动运行: uv pip install openai requests tqdm"
+}
+
+# =====================================================
+#  6. HKTMemory Directory Structure
+# =====================================================
+header "6. 创建 HKTMemory 目录结构"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+New-Item -ItemType Directory -Force -Path "memory/L0-Abstract/topics" | Out-Null
+New-Item -ItemType Directory -Force -Path "memory/L1-Overview/topics" | Out-Null
+New-Item -ItemType Directory -Force -Path "memory/L2-Full/daily" | Out-Null
+New-Item -ItemType Directory -Force -Path "memory/L2-Full/evergreen" | Out-Null
+New-Item -ItemType Directory -Force -Path "memory/L2-Full/episodes" | Out-Null
+New-Item -ItemType File -Force -Path "memory/L0-Abstract/index.md" | Out-Null
+New-Item -ItemType File -Force -Path "memory/L1-Overview/index.md" | Out-Null
+New-Item -ItemType File -Force -Path "memory/L2-Full/evergreen/MEMORY.md" | Out-Null
+ok "HKTMemory 目录结构就绪"
+
+# =====================================================
+#  7. Project Dependencies & Global Link
+# =====================================================
+header "7. 安装项目依赖并全局链接"
+if (Test-Command "bun") {
+    try {
+        bun install | Out-Null
+        ok "项目依赖安装完成"
+    } catch {
+        warn "bun install 失败，请手动运行"
+    }
+
+    try {
+        bun link | Out-Null
+        ok "gale-harness 已全局链接"
+    } catch {
+        warn "bun link 失败，请手动运行"
+    }
+} else {
+    warn "Bun 未就绪，跳过项目依赖安装"
+}
+
+# =====================================================
+#  8. Optional Tools
+# =====================================================
+header "8. 检查可选工具"
+$optionalTools = @(
+    @{ Name = "gh"; InstallCmd = "winget install --id GitHub.cli" },
+    @{ Name = "jq"; InstallCmd = "winget install --id jqlang.jq" },
+    @{ Name = "ffmpeg"; InstallCmd = "winget install --id Gyan.FFmpeg" }
+)
+foreach ($tool in $optionalTools) {
+    if (Test-Command $tool.Name) {
+        ok "$($tool.Name) 已安装"
+    } else {
+        warn "$($tool.Name) 未安装 (可选，建议运行: $($tool.InstallCmd))"
+    }
+}
+
+# =====================================================
+#  9. HKTMemory API Key (Interactive)
+# =====================================================
+header "9. 配置 HKTMemory"
+
+Write-Host ""
+Write-Host "HKTMemory 支持两种模式:" -ForegroundColor White
+Write-Host "  1. API 模式 — 需要 API Key，向量检索功能完整"
+Write-Host "  2. 文件模式 — 无需 API，仅使用本地文件存储"
+Write-Host ""
+
+$useApi = Read-Host "是否使用 API 模式? (y/n，默认 y)"
+if ([string]::IsNullOrWhiteSpace($useApi)) { $useApi = "y" }
+
+if ($useApi -match "^[Yy]") {
+    $secureApiKey = Read-Host "请输入 HKT_MEMORY_API_KEY" -AsSecureString
+    $apiKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureApiKey))
+
+    [Environment]::SetEnvironmentVariable("HKT_MEMORY_API_KEY", $apiKey, "User")
+    [Environment]::SetEnvironmentVariable("HKT_MEMORY_BASE_URL", "https://open.bigmodel.cn/api/paas/v4/", "User")
+    [Environment]::SetEnvironmentVariable("HKT_MEMORY_MODEL", "embedding-3", "User")
+
+    $env:HKT_MEMORY_API_KEY = $apiKey
+    $env:HKT_MEMORY_BASE_URL = "https://open.bigmodel.cn/api/paas/v4/"
+    $env:HKT_MEMORY_MODEL = "embedding-3"
+
+    ok "API 配置已写入用户环境变量"
+} else {
+    [Environment]::SetEnvironmentVariable("HKT_MEMORY_FILE_MODE", "true", "User")
+    $env:HKT_MEMORY_FILE_MODE = "true"
+    ok "文件模式已启用，配置已写入用户环境变量"
+}
+
+# =====================================================
+#  Summary & Self-Check
+# =====================================================
+header "安装完成！"
+
+Write-Host @"
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✅ GaleHarnessCLI 环境安装完成
+
+请重新打开 PowerShell，或运行以下命令使配置生效:
+  `$env:Path = [Environment]::GetEnvironmentVariable("Path", "User")
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  自检清单 — 请依次运行以下命令验证:
+
+  bun --version
+    → 期望: 1.x.x
+
+  python --version
+    → 期望: Python 3.9+
+
+  uv --version
+    → 期望: uv x.x.x
+
+  gale-harness --help
+    → 期望: 显示 CLI 帮助信息
+
+  uv run vendor/hkt-memory/scripts/hkt_memory_v5.py stats
+    → 期望: HKTMemory 统计信息
+
+  bun test
+    → 期望: 测试通过
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  全局使用:
+
+  安装到目标平台:
+    gale-harness install ./plugins/galeharness-cli --to all
+
+  同步个人配置:
+    gale-harness sync
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+"@ -ForegroundColor White
+
+ok "全部完成！"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# GaleHarnessCLI 环境一键安装脚本 (macOS)
+# 用法: bash scripts/setup.sh
+
+set -euo pipefail
+
+# =====================================================
+#  Colors
+# =====================================================
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+ok()     { echo -e "${GREEN}✓${NC} $1"; }
+warn()   { echo -e "${YELLOW}⚠${NC} $1"; }
+err()    { echo -e "${RED}✗${NC} $1"; }
+info()   { echo -e "${CYAN}→${NC} $1"; }
+header() { echo -e "\n${BLUE}${BOLD}▶ $1${NC}"; }
+
+# =====================================================
+#  OS Check
+# =====================================================
+OS="$(uname -s)"
+if [ "$OS" != "Darwin" ]; then
+  err "本脚本仅支持 macOS。请在 macOS 上运行，或使用 Windows PowerShell 脚本。"
+  exit 1
+fi
+
+# Detect shell profile
+SHELL_PROFILE=""
+case "${SHELL##*/}" in
+  zsh)  SHELL_PROFILE="$HOME/.zshrc" ;;
+  bash) SHELL_PROFILE="$HOME/.bashrc" ;;
+  *)    SHELL_PROFILE="$HOME/.profile" ;;
+esac
+
+# =====================================================
+#  Banner
+# =====================================================
+echo -e "${BOLD}GaleHarnessCLI 环境一键安装 (macOS)${NC}"
+echo "本脚本将自动检测并安装所有依赖。"
+echo ""
+
+# =====================================================
+#  1. Git
+# =====================================================
+header "1. 检查 Git"
+if command -v git >/dev/null 2>&1; then
+  ok "Git 已安装 ($(git --version))"
+else
+  info "正在安装 Git..."
+  if command -v brew >/dev/null 2>&1; then
+    brew install git
+  else
+    info "正在安装 Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    brew install git
+  fi
+  ok "Git 安装完成"
+fi
+
+# =====================================================
+#  2. Bun
+# =====================================================
+header "2. 检查 Bun"
+if command -v bun >/dev/null 2>&1; then
+  ok "Bun 已安装 (v$(bun --version))"
+else
+  info "正在安装 Bun..."
+  curl -fsSL https://bun.sh/install | bash
+  ok "Bun 安装完成"
+fi
+
+# Ensure bun is in PATH for this session
+if [ -d "$HOME/.bun/bin" ]; then
+  export PATH="$HOME/.bun/bin:$PATH"
+fi
+
+# =====================================================
+#  3. Python 3.9+
+# =====================================================
+header "3. 检查 Python"
+
+PYTHON_CMD=""
+for cmd in python3 python; do
+  if command -v "$cmd" >/dev/null 2>&1; then
+    PYTHON_CMD="$cmd"
+    break
+  fi
+done
+
+if [ -z "$PYTHON_CMD" ]; then
+  info "正在安装 Python..."
+  if command -v brew >/dev/null 2>&1; then
+    brew install python@3.12
+  fi
+  PYTHON_CMD="python3"
+fi
+
+PYTHON_VERSION=$($PYTHON_CMD --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+
+if [ "$PYTHON_MAJOR" -gt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 9 ]; }; then
+  ok "Python 已安装 (${PYTHON_VERSION})"
+else
+  err "Python 版本过低: ${PYTHON_VERSION}，需要 >= 3.9"
+  info "建议运行: brew install python@3.12"
+  exit 1
+fi
+
+# =====================================================
+#  4. uv
+# =====================================================
+header "4. 检查 uv"
+if command -v uv >/dev/null 2>&1; then
+  ok "uv 已安装"
+else
+  info "正在安装 uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ok "uv 安装完成"
+fi
+
+# Ensure uv is in PATH for this session
+if [ -d "$HOME/.local/bin" ]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# =====================================================
+#  5. Python Dependencies
+# =====================================================
+header "5. 安装 HKTMemory Python 依赖"
+if uv pip install openai requests tqdm >/dev/null 2>&1; then
+  ok "Python 依赖安装完成 (via uv)"
+elif $PYTHON_CMD -m pip install openai requests tqdm >/dev/null 2>&1; then
+  ok "Python 依赖安装完成 (via pip)"
+else
+  warn "Python 依赖安装失败，请手动运行: uv pip install openai requests tqdm"
+fi
+
+# =====================================================
+#  6. HKTMemory Directory Structure
+# =====================================================
+header "6. 创建 HKTMemory 目录结构"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+mkdir -p memory/L0-Abstract/topics
+mkdir -p memory/L1-Overview/topics
+mkdir -p memory/L2-Full/daily
+mkdir -p memory/L2-Full/evergreen
+mkdir -p memory/L2-Full/episodes
+touch memory/L0-Abstract/index.md
+touch memory/L1-Overview/index.md
+touch memory/L2-Full/evergreen/MEMORY.md
+ok "HKTMemory 目录结构就绪"
+
+# =====================================================
+#  7. Project Dependencies & Global Link
+# =====================================================
+header "7. 安装项目依赖并全局链接"
+if command -v bun >/dev/null 2>&1; then
+  bun install >/dev/null 2>&1 && ok "项目依赖安装完成" || warn "bun install 失败，请手动运行"
+
+  bun link >/dev/null 2>&1 && ok "gale-harness 已全局链接" || warn "bun link 失败，请手动运行"
+else
+  warn "Bun 未就绪，跳过项目依赖安装"
+fi
+
+# =====================================================
+#  8. Optional Tools
+# =====================================================
+header "8. 检查可选工具"
+optional_tools=("gh" "jq" "ffmpeg")
+for tool in "${optional_tools[@]}"; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    ok "${tool} 已安装"
+  else
+    warn "${tool} 未安装 (可选，建议: brew install ${tool})"
+  fi
+done
+
+# =====================================================
+#  9. HKTMemory API Key (Interactive)
+# =====================================================
+header "9. 配置 HKTMemory"
+
+echo ""
+echo "HKTMemory 支持两种模式:"
+echo "  1. API 模式 — 需要 API Key，向量检索功能完整"
+echo "  2. 文件模式 — 无需 API，仅使用本地文件存储"
+echo ""
+read -r -p "是否使用 API 模式? (y/n，默认 y): " use_api
+use_api=${use_api:-y}
+
+if [[ "$use_api" =~ ^[Yy] ]]; then
+  read -r -s -p "请输入 HKT_MEMORY_API_KEY: " api_key
+  echo ""
+
+  # Write to shell profile
+  {
+    echo ""
+    echo "# HKTMemory Configuration (auto-generated by setup.sh)"
+    echo "export HKT_MEMORY_API_KEY=\"${api_key}\""
+    echo "export HKT_MEMORY_BASE_URL=\"https://open.bigmodel.cn/api/paas/v4/\""
+    echo "export HKT_MEMORY_MODEL=\"embedding-3\""
+  } >> "$SHELL_PROFILE"
+
+  # Export for current session
+  export HKT_MEMORY_API_KEY="$api_key"
+  export HKT_MEMORY_BASE_URL="https://open.bigmodel.cn/api/paas/v4/"
+  export HKT_MEMORY_MODEL="embedding-3"
+
+  ok "API 配置已写入 ${SHELL_PROFILE}"
+else
+  {
+    echo ""
+    echo "# HKTMemory Configuration (auto-generated by setup.sh)"
+    echo "export HKT_MEMORY_FILE_MODE=true"
+  } >> "$SHELL_PROFILE"
+
+  export HKT_MEMORY_FILE_MODE=true
+  ok "文件模式已启用，配置已写入 ${SHELL_PROFILE}"
+fi
+
+# =====================================================
+#  10. PATH Setup (bun bin)
+# =====================================================
+header "10. 配置 PATH"
+if ! grep -q '\.bun/bin' "$SHELL_PROFILE" 2>/dev/null; then
+  {
+    echo ""
+    echo "# Bun (auto-generated by setup.sh)"
+    echo 'export PATH="$HOME/.bun/bin:$PATH"'
+  } >> "$SHELL_PROFILE"
+  ok "Bun PATH 已写入 ${SHELL_PROFILE}"
+else
+  ok "Bun PATH 已存在"
+fi
+
+if ! grep -q '\.local/bin' "$SHELL_PROFILE" 2>/dev/null; then
+  {
+    echo ""
+    echo "# uv tools (auto-generated by setup.sh)"
+    echo 'export PATH="$HOME/.local/bin:$PATH"'
+  } >> "$SHELL_PROFILE"
+  ok "uv PATH 已写入 ${SHELL_PROFILE}"
+else
+  ok "uv PATH 已存在"
+fi
+
+# =====================================================
+#  Summary & Self-Check
+# =====================================================
+header "安装完成！"
+
+cat << EOF
+
+${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
+
+${GREEN}  ✅ GaleHarnessCLI 环境安装完成${NC}
+
+${BOLD}请重新打开终端，或运行以下命令使配置生效:${NC}
+  source ${SHELL_PROFILE}
+
+${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
+${BOLD}  自检清单 — 请依次运行以下命令验证:${NC}
+
+  ${CYAN}bun --version${NC}
+    → 期望: 1.x.x
+
+  ${CYAN}python3 --version${NC}
+    → 期望: Python 3.9+
+
+  ${CYAN}uv --version${NC}
+    → 期望: uv x.x.x
+
+  ${CYAN}gale-harness --help${NC}
+    → 期望: 显示 CLI 帮助信息
+
+  ${CYAN}uv run vendor/hkt-memory/scripts/hkt_memory_v5.py stats${NC}
+    → 期望: HKTMemory 统计信息
+
+  ${CYAN}bun test${NC}
+    → 期望: 测试通过
+
+${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
+${BOLD}  全局使用:${NC}
+
+  安装到目标平台:
+    ${CYAN}gale-harness install ./plugins/galeharness-cli --to all${NC}
+
+  同步个人配置:
+    ${CYAN}gale-harness sync${NC}
+
+${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
+
+EOF
+
+ok "全部完成！"


### PR DESCRIPTION
## 变更内容

完善 README.md 的安装指南，补充 macOS 和 Windows 的完整环境初始化教程。

### 主要改进

- **前置要求表格化**：将工具列表改为清晰的表格，标明用途和是否必需
- **新增 macOS 环境准备**：Homebrew → Bun → Git/Python/uv → 可选工具的完整安装流程
- **新增 Windows 环境准备**：
  - PowerShell 下的 Bun、Python、uv 安装
  - winget 安装 Git、gh、jq、ffmpeg 等工具
  - PowerShell 执行策略提示（解决全新 Windows 最常见的脚本阻塞问题）
- **HKTMemory 安装分平台**：
  - macOS/Linux 保留 `bash vendor/hkt-memory/install.sh`
  - Windows 提供完整的 PowerShell 手动等价步骤
- **环境变量配置分平台**：macOS/Linux 的 shell export vs Windows 的 `$env:` / 系统属性 / PowerShell profile
- **全局安装 PATH 配置分平台**
- **项目初始化补充 Windows 说明**

### 背景

当前 CI 使用 `oven-sh/setup-bun@v2` 自动安装 Bun，且 Windows job 跳过了部分平台相关测试。全新 Windows/macOS 开发机没有这些预装环境，README 此前缺少从零开始的完整初始化指南。

### 验证

- `bun run release:validate` 通过