### PR TITLE
fix(bootstrap,readme): correct repo name from GaleHarnessCLI to GaleHarnessCodingCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ flowchart LR
 
 ```bash
 # 1. 克隆仓库
-git clone https://github.com/wangrenzhu-ola/GaleHarnessCLI.git
+git clone https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI.git
 cd GaleHarnessCLI
 
 # 2. 运行一键安装脚本
@@ -500,8 +500,8 @@ bash scripts/setup.sh
 git config --global credential.helper ""
 
 # 2. 查询最新 tag 并浅克隆（只下载最新版本，快且小）
-$latestTag = (git ls-remote --tags --sort="-v:refname" https://github.com/wangrenzhu-ola/GaleHarnessCLI.git | Select-Object -First 1).Split("`t")[1].Replace("refs/tags/", "")
-git clone --branch $latestTag --depth 1 --single-branch https://github.com/wangrenzhu-ola/GaleHarnessCLI.git
+$latestTag = (git ls-remote --tags --sort="-v:refname" https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI.git | Select-Object -First 1).Split("`t")[1].Replace("refs/tags/", "")
+git clone --branch $latestTag --depth 1 --single-branch https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI.git
 cd GaleHarnessCLI
 
 # 3. 运行一键安装脚本（如遇到权限问题，以管理员身份运行 PowerShell）
@@ -514,10 +514,10 @@ cd GaleHarnessCLI
 
 ```powershell
 # 首选：jsDelivr CDN（国内快，全球稳）
-irm https://cdn.jsdelivr.net/gh/wangrenzhu-ola/GaleHarnessCLI@main/scripts/bootstrap.ps1 | iex
+irm https://cdn.jsdelivr.net/gh/wangrenzhu-ola/GaleHarnessCodingCLI@main/scripts/bootstrap.ps1 | iex
 
 # 备选：GitHub 官方源（如遇 404 请等待 2-3 分钟后重试）
-irm https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCLI/main/scripts/bootstrap.ps1 | iex
+irm https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/bootstrap.ps1 | iex
 ```
 
 `bootstrap.ps1` 会自动：

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,8 +1,8 @@
 # GaleHarnessCLI Windows 零依赖启动脚本
 # 用途：在全新 Windows 上（无 Git）一键完成环境准备
 # 运行方式：复制以下命令到 PowerShell 执行
-#   irm https://cdn.jsdelivr.net/gh/wangrenzhu-ola/GaleHarnessCLI@main/scripts/bootstrap.ps1 | iex
-#   irm https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCLI/main/scripts/bootstrap.ps1 | iex
+#   irm https://cdn.jsdelivr.net/gh/wangrenzhu-ola/GaleHarnessCodingCLI@main/scripts/bootstrap.ps1 | iex
+#   irm https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/bootstrap.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 
@@ -113,7 +113,7 @@ if (Test-Path "$cloneDir\.git") {
     }
 
     # Query GitHub API for the latest release tag (shallow clone for speed)
-    $repoUrl = "https://github.com/wangrenzhu-ola/GaleHarnessCLI.git"
+    $repoUrl = "https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI.git"
     $apiTagsUrl = "https://api.github.com/repos/wangrenzhu-ola/GaleHarnessCodingCLI/tags?per_page=1"
     $cloneRef = "main"
 


### PR DESCRIPTION
## Problem

All download/clone URLs in `bootstrap.ps1` and README used the wrong repository name `GaleHarnessCLI` instead of the actual name `GaleHarnessCodingCLI`. This caused immediate 404 failures on both jsDelivr CDN and `git clone`.

## Changes

- `scripts/bootstrap.ps1`: fixed 3 URLs (jsDelivr comment, raw comment, `$repoUrl`)
- `README.md`: fixed 5 URLs (macOS clone, Windows manual clone ×2, bootstrap one-liner ×2)

## Verification

```bash
curl -sI https://cdn.jsdelivr.net/gh/wangrenzhu-ola/GaleHarnessCodingCLI@main/scripts/bootstrap.ps1
# HTTP/2 200
```