### PR TITLE
fix(cli): show help instead of error when no subcommand is provided

### DIFF
--- a/src/commands/board.ts
+++ b/src/commands/board.ts
@@ -17,7 +17,7 @@ export default defineCommand({
   },
   async run({ args, cmd }) {
     if (!args._.length) {
-      return boardList.run?.({ args: { ...args, format: args.format ?? "table", limit: args.limit ?? "20" }, cmd })
+      return boardList.run?.({ args: { ...args, format: args.format ?? "table", limit: args.limit ?? "20", offset: args.offset ?? "0" }, cmd })
     }
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { defineCommand, runMain } from "citty"
+import { defineCommand, runMain, showUsage } from "citty"
 import packageJson from "../package.json"
 import convert from "./commands/convert"
 import install from "./commands/install"
@@ -21,6 +21,12 @@ const main = defineCommand({
     "plugin-path": () => pluginPath,
     sync: () => sync,
     board: () => board,
+  },
+  run: async (ctx) => {
+    const hasSubCommand = ctx.rawArgs.some((arg) => !arg.startsWith("-"));
+    if (!hasSubCommand) {
+      await showUsage(ctx.cmd);
+    }
   },
 })
 


### PR DESCRIPTION
Running gale-harness without a subcommand threw "ERROR No command specified." (exit 1) because citty's E_NO_COMMAND path fires when subCommands exist but no run handler is defined. Adding a run handler that calls showUsage() produces a friendlier experience consistent with standard CLI tools (git, npm, docker).

Also fix gale-harness board failing with "Error: --offset must be a non-negative integer" — the board command's delegation to boardList.run provided defaults for format and limit but not offset, causing Number(undefined) -> NaN -> validation failure.

🤖 Generated with [Qoder][https://qoder.com]