### PR TITLE
fix: remove command substitution from pre-resolved shell blocks

### DIFF
--- a/plugins/galeharness-cli/AGENTS.md
+++ b/plugins/galeharness-cli/AGENTS.md
@@ -137,7 +137,7 @@ Why: shell-heavy exploration causes avoidable permission prompts in sub-agent wo
 - [ ] Never instruct agents to use `find`, `ls`, `cat`, `head`, `tail`, `grep`, `rg`, `wc`, or `tree` through a shell for routine file discovery, content search, or file reading
 - [ ] Describe tools by capability class with platform hints — e.g., "Use the native file-search/glob tool (e.g., Glob in Claude Code)" — not by Claude Code-specific tool names alone
 - [ ] When shell is the only option (e.g., `ast-grep`, `bundle show`, git commands), instruct one simple command at a time — no action chaining (`cmd1 && cmd2`, `cmd1 ; cmd2`) and no error suppression (`2>/dev/null`, `|| true`). Boolean conditions within if/while guards (`[ -n "$X" ] || [ -n "$Y" ]`) are fine — that is normal conditional logic, not action chaining. Simple pipes (e.g., `| jq .field`) and output redirection (e.g., `> file`) are acceptable when they don't obscure failures
-- [ ] **Pre-resolution exception:** `!` backtick pre-resolution commands run at skill load time, not at agent runtime. They may use chaining (`&&`, `||`), error suppression (`2>/dev/null`), and fallback sentinels (e.g., `|| echo '__NO_CONFIG__'`) to produce a clean, parseable value for the model. This is the preferred pattern for environment probes (CLI availability, config file reads) that would otherwise require runtime shell calls with chaining. Example: `` !`command -v codex >/dev/null 2>&1 && echo "AVAILABLE" || echo "NOT_FOUND"` ``
+- [ ] **Pre-resolution exception:** `!` backtick pre-resolution commands run at skill load time, not at agent runtime. They may use chaining (`&&`, `||`) and error suppression (`2>/dev/null`), but **MUST NOT** use command substitutions (`$(...)`) or backticks inside them, as these fail strict permission checks on some platforms (e.g., Claude CLI). Use them only for simple environment probes (e.g., `` !`command -v codex >/dev/null 2>&1 && echo "AVAILABLE" || echo "NOT_FOUND"` ``). Do not use them for reading complex config files.
 - [ ] Do not encode shell recipes for routine exploration when native tools can do the job; encode intent and preferred tool classes instead
 - [ ] For shell-only workflows (e.g., `gh`, `git`, `bundle show`, project CLIs), explicit command examples are acceptable when they are simple, task-scoped, and not chained together
 
@@ -153,13 +153,14 @@ When dispatching sub-agents, **omit the `mode` parameter** on the Agent/Task too
 
 Plugin config lives at `.compound-engineering/config.local.yaml` in the repo root. This file is gitignored (machine-local settings), which creates two gotchas:
 
-1. **Path resolution:** Never read the config relative to CWD — the user may invoke a skill from a subdirectory. Always resolve from the repo root. In pre-resolution commands, use `git rev-parse --show-toplevel` to find the root.
+1. **Path resolution:** Never read the config relative to CWD — the user may invoke a skill from a subdirectory. Always resolve from the repo root.
+2. **Worktrees:** Gitignored files are per-worktree. A config file created in the main checkout does not exist in worktrees. When reading config, fall back to the main repo root if the file is missing in the current worktree.
 
-2. **Worktrees:** Gitignored files are per-worktree. A config file created in the main checkout does not exist in worktrees. When reading config, fall back to the main repo root if the file is missing in the current worktree:
-   ```
-   !`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
-   ```
-   The first `cat` tries the current worktree root. The second derives the main repo root from `git-common-dir` as a fallback. In a regular (non-worktree) checkout, both paths are identical.
+**Important:** Do NOT use inline pre-resolved shell commands (`!` + `$(...)`) to read this config, as command substitutions fail strict permission checks on some platforms (e.g., Claude CLI). Instead, use natural language instructions to tell the LLM to read the file using its native file-read tools at the start of execution. For example:
+
+```
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
+```
 
 If neither path has the file, fall through to defaults — never fail or block on missing config.
 

--- a/plugins/galeharness-cli/skills/document-review/SKILL.md
+++ b/plugins/galeharness-cli/skills/document-review/SKILL.md
@@ -8,11 +8,11 @@ argument-hint: "[mode:headless] [path/to/document.md]"
 
 Review requirements or plan documents through multi-persona analysis. Dispatches specialized reviewer agents in parallel, auto-fixes quality issues, and presents strategic questions for user decision.
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains `language: en`, write findings in English.
-If `__NO_CONFIG__` or `language: zh-CN` or no language key, write findings in Chinese (default).
+If the config file contains `language: en`, write findings in English.
+If the file is missing, contains `language: zh-CN`, or has no language key, write findings in Chinese (default).
 
 ## Phase 0: Detect Mode
 

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -45,11 +45,11 @@ This skill does not implement code. It explores, clarifies, and documents decisi
 
 Do not proceed until you have a feature description from the user.
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains `language: en`, write documents in English.
-If `__NO_CONFIG__` or `language: zh-CN` or no language key, write documents in Chinese (default).
+If the config file contains `language: en`, write documents in English.
+If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
 ## Execution Flow
 

--- a/plugins/galeharness-cli/skills/gh-compound-refresh/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound-refresh/SKILL.md
@@ -8,11 +8,11 @@ disable-model-invocation: true
 
 Maintain the quality of `docs/solutions/`（或全局知识库）over time. This workflow reviews existing learnings against the current codebase, then refreshes any derived pattern docs that depend on them.
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains `language: en`, write documents in English.
-If `__NO_CONFIG__` or `language: zh-CN` or no language key, write documents in Chinese (default).
+If the config file contains `language: en`, write documents in English.
+If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
 ## Mode Detection
 

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -40,11 +40,11 @@ Before presenting mode options to the user, log the skill start event so this ex
 
 <!-- /HKT-PATCH:gale-task-start -->
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains `language: en`, write documents in English.
-If `__NO_CONFIG__` or `language: zh-CN` or no language key, write documents in Chinese (default).
+If the config file contains `language: en`, write documents in English.
+If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
 Present the user with two options before proceeding, using the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini). If no question tool is available, present the options and wait for the user's reply.
 

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -41,11 +41,11 @@ If no argument is provided, proceed with open-ended ideation.
 2. **Generate many -> critique all -> explain survivors only** - The quality mechanism is explicit rejection with reasons, not optimistic ranking. Do not let extra process obscure this pattern.
 3. **Route action into brainstorming** - Ideation identifies promising directions; `gh:brainstorm` defines the selected one precisely enough for planning. Do not skip to planning from ideation output.
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains `language: en`, write documents in English.
-If `__NO_CONFIG__` or `language: zh-CN` or no language key, write documents in Chinese (default).
+If the config file contains `language: en`, write documents in English.
+If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
 ## Execution Flow
 

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -30,11 +30,11 @@ If the input is present but unclear or underspecified, do not abandon — ask on
 
 **IMPORTANT: All file references in the plan document must use repo-relative paths (e.g., `src/models/user.rb`), never absolute paths (e.g., `/Users/name/Code/project/src/models/user.rb`). This applies everywhere — implementation unit file lists, pattern references, origin document links, and prose mentions. Absolute paths break portability across machines, worktrees, and teammates.**
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains `language: en`, write documents in English.
-If `__NO_CONFIG__` or `language: zh-CN` or no language key, write documents in Chinese (default).
+If the config file contains `language: en`, write documents in English.
+If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
 ## Core Principles
 

--- a/plugins/galeharness-cli/skills/gh-sessions/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-sessions/SKILL.md
@@ -16,11 +16,12 @@ Search your session history.
 
 ## Pre-resolved context
 
-**Repo name (pre-resolved):** !`common=$(git rev-parse --git-common-dir 2>/dev/null); if [ "$common" = ".git" ]; then basename "$(git rev-parse --show-toplevel 2>/dev/null)"; else basename "$(dirname "$common")"; fi`
+**Repo and Branch Context:**
+Determine the current repository name and active git branch before dispatching. You can use native tools or simple safe commands (like `git rev-parse --abbrev-ref HEAD`) to find them. Do not use complex chained shell substitutions.
+- For repo name: resolve the basename of the repository root (handle worktrees appropriately).
+- For branch: resolve the current active branch.
 
-**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null`
-
-If the lines above resolved to plain values (a folder name like `my-repo` and a branch name like `feat/my-branch`), they are ready to pass to the agent. If they still contain backtick command strings or are empty, they did not resolve — omit them from the dispatch and let the agent derive them at runtime.
+If you cannot quickly determine these values, omit them from the dispatch and let the agent derive them at runtime.
 
 ## Execution
 

--- a/plugins/galeharness-cli/skills/gh-work-beta/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work-beta/SKILL.md
@@ -42,12 +42,11 @@ After extracting tokens from arguments, resolve the delegation state using this 
 2. **Config file** -- extract settings from the config block below. Value `codex` for `work_delegate` activates delegation; `false` deactivates.
 3. **Hard default** -- `false` (delegation off)
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || cat "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Config:**
+At the start of execution, use your native file-read tool to read `.compound-engineering/config.local.yaml` from the repository root. If the file is missing in the current worktree, check the main repository root (the parent of `.git/worktrees`). If the file is missing or unreadable, do not block the workflow — proceed silently with default settings.
 
-If the block above contains YAML key-value pairs, extract values for the keys listed below.
-If it shows `__NO_CONFIG__`, the file does not exist — all settings fall through to defaults.
-If it shows an unresolved command string, read `.compound-engineering/config.local.yaml` from the repo root using the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the file does not exist, all settings fall through to defaults.
+If the config file contains YAML key-value pairs, extract values for the keys listed below.
+If the file does not exist, all settings fall through to defaults.
 
 If any setting has an unrecognized value, fall through to the hard default for that setting.
 

--- a/plugins/galeharness-cli/skills/gh-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-work-beta/references/codex-delegation-workflow.md
@@ -59,8 +59,7 @@ If `inside_sandbox` is true, delegation would recurse or fail.
 !`command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_FOUND"`
 
 If the line above shows `CODEX_AVAILABLE`, proceed to the next check.
-If it shows `CODEX_NOT_FOUND`, the Codex CLI is not installed. Emit "Codex CLI not found (install via `npm install -g @openai/codex` or `brew install codex`) -- using standard mode." and set `delegation_active` to false.
-If it shows an unresolved command string, run `command -v codex` using a shell tool. If the command prints a path, proceed. If it fails or prints nothing, emit the same message and set `delegation_active` to false.
+If it shows `CODEX_NOT_FOUND` or anything else, the Codex CLI is not installed or unavailable. Emit "Codex CLI not found (install via `npm install -g @openai/codex` or `brew install codex`) -- using standard mode." and set `delegation_active` to false.
 
 **3. Consent Flow**
 

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -350,3 +350,28 @@ describe("gh:plan review contract", () => {
     expect(content).not.toContain("**Options for Standard or Lightweight plans:**")
   })
 })
+
+describe("skill compatibility contract", () => {
+  test("skills do not use inline pre-resolved shell with command substitution", async () => {
+    const files = [
+      "plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md",
+      "plugins/galeharness-cli/skills/gh-plan/SKILL.md",
+      "plugins/galeharness-cli/skills/gh-ideate/SKILL.md",
+      "plugins/galeharness-cli/skills/gh-compound/SKILL.md",
+      "plugins/galeharness-cli/skills/gh-compound-refresh/SKILL.md",
+      "plugins/galeharness-cli/skills/document-review/SKILL.md",
+      "plugins/galeharness-cli/skills/gh-work-beta/SKILL.md",
+      "plugins/galeharness-cli/skills/gh-sessions/SKILL.md",
+    ]
+
+    for (const file of files) {
+      const content = await readRepoFile(file)
+      // Check for !` followed by anything containing $(
+      const match = content.match(/!`[^`]*\$\(/)
+      expect(match).toBeNull()
+      
+      // Should not contain the old unresolved command string instruction
+      expect(content).not.toContain("unresolved command string")
+    }
+  })
+})


### PR DESCRIPTION
### 意图

修复了部分技能文件加载时由于 `!cat "$(git rev-parse ...)"` 形式的预解析命令替换 `$(...)`，导致在部分平台（如 Claude CLI）严格的 Shell 权限检查中失败的问题。

### 变更详情

- 将 `SKILL.md` 文件中预解析的内联配置读取逻辑替换为了自然语言指令，指导大模型在运行时使用其原生的文件读取工具来加载配置。
- 删除了过时的 `unresolved command string` 降级逻辑，因为不再使用 Shell 命令预解析配置文件。
- 在 `AGENTS.md` 规范中明确禁止在 `!` 预解析代码块中使用 `$(...)` 命令替换语法。
- 添加了名为 `skill compatibility contract` 的全新契约测试，以防后续该语法回退。

### 验证

- 成功通过测试：`bun test tests/pipeline-review-contract.test.ts`
- 受影响的所有技能均已正确更新且未影响业务逻辑。