### PR TITLE
feat(kilo): 添加 Kilo Code 目标平台支持

### DIFF
--- a/docs/solutions/best-practices/new-target-platform-cr-checklist.md
+++ b/docs/solutions/best-practices/new-target-platform-cr-checklist.md
@@ -1,0 +1,154 @@
+---
+title: 新增目标平台时的代码审查常见问题清单
+date: 2026-04-22
+category: best-practices
+module: cli/targets
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - 在 GaleHarnessCLI 中新增 CLI 转换/安装/sync 目标平台
+  - 为目标平台编写 converter、writer、sync 集成代码
+  - 为目标平台添加完整测试覆盖
+tags:
+  - target-platform
+  - converter
+  - writer
+  - sync
+  - code-review
+  - kilo
+---
+
+# 新增目标平台时的代码审查常见问题清单
+
+## Context
+
+在 PR #44 中为 GaleHarnessCLI 添加 Kilo Code 目标平台支持后，代码审查发现了 4 类常见问题。这些问题在新增其他目标平台时也容易重复出现。本文档将这些问题整理为检查清单，供后续添加新目标时参考。
+
+## Guidance
+
+### 1. 在 `src/targets/index.ts` 中注册目标时添加 `defaultScope`
+
+所有已实现的目标都应在 `targets` 注册表中声明 `defaultScope`，即使该目标当前不主动使用 `--scope` 参数。`src/commands/convert.ts` 和 `src/commands/install.ts` 中的 `--also` 分支会调用 `handler.write(extraRoot, extraBundle, handler.defaultScope)`，如果 `defaultScope` 为 `undefined`，会导致不一致的行为。
+
+**检查点：**
+- [ ] 新目标在 `targets` 对象中是否包含 `defaultScope`？
+- [ ] 取值是否为 `"global"` 或 `"workspace"`？
+
+```typescript
+// 正确示例
+kilo: {
+  name: "kilo",
+  implemented: true,
+  defaultScope: "workspace",
+  convert: convertClaudeToKilo as TargetHandler["convert"],
+  write: writeKiloBundle as TargetHandler["write"],
+},
+```
+
+### 2. 避免 `convertMcp` 逻辑在 converter 和 sync 之间重复
+
+`src/converters/claude-to-{target}.ts` 和 `src/sync/{target}.ts` 经常需要相同的 MCP 服务器转换逻辑。应将转换函数在 converter 中导出，供 sync 侧复用，而不是各自维护一份副本。
+
+**检查点：**
+- [ ] `src/sync/{target}.ts` 中是否存在与 converter 侧功能重复的 MCP 转换代码？
+- [ ] 如果存在，是否已提取为共享函数并从 converter 导出？
+
+```typescript
+// src/converters/claude-to-kilo.ts
+export function convertMcp(
+  servers: Record<string, ClaudeMcpServer>,
+): Record<string, KiloMcpServer> {
+  // ...
+}
+
+// src/sync/kilo.ts
+import { convertMcp } from "../converters/claude-to-kilo"
+// 直接复用，无需本地重复实现
+```
+
+### 3. 测试名称必须与实际测试内容一致
+
+测试名称中的文件名、功能描述应与断言对象严格对应。错误的测试名称会降低测试可读性，并在测试失败时误导调试方向。
+
+**检查点：**
+- [ ] 所有新增测试的 `test("...")` 描述是否准确反映了被测对象？
+- [ ] 测试中提到的文件名（如 `kilo.json`、`mcp.json`）是否与实际操作的目标文件一致？
+
+```typescript
+// 错误
+// test("mcp.json fresh write when no existing file", async () => { ... kilo.json ... })
+
+// 正确
+test("kilo.json fresh write when no existing file", async () => { ... kilo.json ... })
+```
+
+### 4. 路径改写正则的边界处理要足够宽松
+
+在 `transformContentForKilo` 等函数中，将 `.claude/` 路径改写为目标平台路径时，正则的 lookbehind 必须覆盖常见的标点边界（括号、方括号、冒号等），同时避免误匹配域名或包名中的假阳性（如 `my.claude/page`）。
+
+**检查点：**
+- [ ] 路径改写正则是否能处理括号 `(...)`、方括号 `[...]` 等标点前的路径？
+- [ ] 是否能避免误匹配 `something.claude/...` 这类假阳性？
+- [ ] 是否已为边界 case 编写了测试？
+
+```typescript
+// 过于严格的 lookbehind — 遗漏括号等边界
+result = result.replace(/(?<=^|\s|["'`])\.claude\//gm, ".kilo/")
+
+// 更健壮的负向 lookbehind — 匹配"前面不是单词字符或点号"的位置
+result = result.replace(/(?<!\w|\.)(\.claude\/)/gm, ".kilo/")
+```
+
+## Why This Matters
+
+这些问题看似细小，但会在以下方面产生累积影响：
+
+1. **`defaultScope` 缺失**：当 `--also` 功能扩展或 `write` 签名变更时，`undefined` 可能引发静默失败，排查成本高。
+2. **代码重复**：MCP 字段支持演进时（如新增 `env` 处理逻辑），需要改多处，容易遗漏。
+3. **测试名称错误**：降低测试套件的可维护性，增加团队协作中的认知负担。
+4. **正则边界遗漏**：导致转换后的内容中仍有未改写的 `.claude/` 引用，用户在目标平台上使用时会遇到路径错误。
+
+## When to Apply
+
+- 向 `src/targets/index.ts` 新增目标注册时
+- 创建新的 `src/converters/claude-to-{target}.ts` 和 `src/sync/{target}.ts` 时
+- 编写路径/内容改写逻辑（`transformContentForXxx`）时
+- 为目标平台编写 writer 测试时
+
+## Examples
+
+### 完整修复 diff（Kilo Code 案例）
+
+```diff
+// src/targets/index.ts
+   kilo: {
+     name: "kilo",
+     implemented: true,
++    defaultScope: "workspace",
+     convert: convertClaudeToKilo as TargetHandler["convert"],
+     write: writeKiloBundle as TargetHandler["write"],
+   },
+
+// src/converters/claude-to-kilo.ts
+-function convertMcp(...)
++export function convertMcp(...)
+
+// src/sync/kilo.ts
+-function convertMcpForKilo(...) { /* 25 行重复代码 */ }
++import { convertMcp } from "../converters/claude-to-kilo"
+
+// src/converters/claude-to-kilo.ts
+-result = result.replace(/(?<=^|\s|["'`])~\/\.claude\//gm, "~/.config/kilo/")
+-result = result.replace(/(?<=^|\s|["'`])\.claude\//gm, ".kilo/")
++result = result.replace(/(?<!\w|\.)(~\/\.claude\/)/gm, "~/.config/kilo/")
++result = result.replace(/(?<!\w|\.)(\.claude\/)/gm, ".kilo/")
+
+// tests/kilo-writer.test.ts
+-test("mcp.json fresh write when no existing file", async () => {
++test("kilo.json fresh write when no existing file", async () => {
+```
+
+## Related
+
+- [Adding New Converter Target Providers](../adding-converter-target-providers.md) — 完整的 6 阶段目标提供者实施指南

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -25,7 +25,7 @@ export default defineCommand({
     to: {
       type: "string",
       default: "opencode",
-      description: "Target format (claude | opencode | codex | droid | cursor | pi | copilot | gemini | kiro | windsurf | openclaw | qwen | all)",
+      description: "Target format (claude | opencode | codex | droid | cursor | pi | copilot | gemini | kiro | windsurf | openclaw | qwen | kilo | all)",
     },
     output: {
       type: "string",
@@ -56,6 +56,11 @@ export default defineCommand({
       type: "string",
       alias: "qwen-home",
       description: "Write Qwen output to this Qwen extensions root (ex: ~/.qwen/extensions)",
+    },
+    kiloHome: {
+      type: "string",
+      alias: "kilo-home",
+      description: "Write Kilo output to this Kilo root (ex: ~/.kilo)",
     },
     scope: {
       type: "string",
@@ -98,6 +103,7 @@ export default defineCommand({
     const openclawHome = resolveTargetHome(args.openclawHome, path.join(os.homedir(), ".openclaw", "extensions"))
     const qwenHome = resolveTargetHome(args.qwenHome, path.join(os.homedir(), ".qwen", "extensions"))
     const qoderHome = resolveTargetHome(args.qoderHome, path.join(os.homedir(), ".qoder"))
+    const kiloHome = resolveTargetHome(args.kiloHome, path.join(os.homedir(), ".kilo"))
 
     const options: ClaudeToOpenCodeOptions = {
       agentMode: String(args.agentMode) === "primary" ? "primary" : "subagent",
@@ -139,6 +145,7 @@ export default defineCommand({
           openclawHome,
           qwenHome,
           qoderHome,
+          kiloHome,
           pluginName: plugin.manifest.name,
           plugin,
           hasExplicitOutput,
@@ -173,6 +180,7 @@ export default defineCommand({
       openclawHome,
       qwenHome,
       qoderHome,
+      kiloHome,
       pluginName: plugin.manifest.name,
       plugin,
       hasExplicitOutput,
@@ -212,6 +220,7 @@ export default defineCommand({
         openclawHome,
         qwenHome,
         qoderHome,
+        kiloHome,
         pluginName: plugin.manifest.name,
         plugin,
         hasExplicitOutput,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -28,7 +28,7 @@ export default defineCommand({
     to: {
       type: "string",
       default: "opencode",
-      description: "Target format (claude | opencode | codex | droid | cursor | pi | copilot | gemini | kiro | windsurf | openclaw | qwen | kimi | qoder | trae | all)",
+      description: "Target format (claude | opencode | codex | droid | cursor | pi | copilot | gemini | kiro | windsurf | openclaw | qwen | kimi | qoder | trae | kilo | all)",
     },
     output: {
       type: "string",
@@ -64,6 +64,11 @@ export default defineCommand({
       type: "string",
       alias: "qoder-home",
       description: "Write Qoder output to this Qoder root (ex: ~/.qoder)",
+    },
+    kiloHome: {
+      type: "string",
+      alias: "kilo-home",
+      description: "Write Kilo output to this Kilo root (ex: ~/.kilo)",
     },
     scope: {
       type: "string",
@@ -114,6 +119,7 @@ export default defineCommand({
       const openclawHome = resolveTargetHome(args.openclawHome, path.join(os.homedir(), ".openclaw", "extensions"))
       const qwenHome = resolveTargetHome(args.qwenHome, path.join(os.homedir(), ".qwen", "extensions"))
       const qoderHome = resolveTargetHome(args.qoderHome, path.join(os.homedir(), ".qoder"))
+      const kiloHome = resolveTargetHome(args.kiloHome, path.join(os.homedir(), ".kilo"))
       const kimiHome = path.join(os.homedir(), ".kimi")
 
       const options: ClaudeToOpenCodeOptions = {
@@ -156,6 +162,7 @@ export default defineCommand({
             openclawHome,
             qwenHome,
             qoderHome,
+            kiloHome,
             kimiHome,
             pluginName: plugin.manifest.name,
             plugin,
@@ -194,6 +201,7 @@ export default defineCommand({
         openclawHome,
         qwenHome,
         qoderHome,
+        kiloHome,
         kimiHome,
         pluginName: plugin.manifest.name,
         plugin,
@@ -229,6 +237,7 @@ export default defineCommand({
           openclawHome,
           qwenHome,
           qoderHome,
+          kiloHome,
           kimiHome,
           pluginName: plugin.manifest.name,
           plugin,

--- a/src/converters/claude-to-kilo.ts
+++ b/src/converters/claude-to-kilo.ts
@@ -1,0 +1,144 @@
+import { formatFrontmatter } from "../utils/frontmatter"
+import { normalizeModelWithProvider } from "../utils/model"
+import {
+  type ClaudeAgent,
+  type ClaudeCommand,
+  type ClaudePlugin,
+  type ClaudeMcpServer,
+  filterSkillsByPlatform,
+} from "../types/claude"
+import type {
+  KiloAgentFile,
+  KiloBundle,
+  KiloCommandFile,
+  KiloMcpServer,
+} from "../types/kilo"
+import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+
+export type ClaudeToKiloOptions = ClaudeToOpenCodeOptions
+
+export function convertClaudeToKilo(
+  plugin: ClaudePlugin,
+  options: ClaudeToKiloOptions,
+): KiloBundle {
+  const agentFiles = plugin.agents.map((agent) => convertAgent(agent, options))
+  const cmdFiles = convertCommands(plugin.commands)
+  const mcpServers = plugin.mcpServers ? convertMcp(plugin.mcpServers) : {}
+
+  return {
+    agents: agentFiles,
+    commandFiles: cmdFiles,
+    skillDirs: filterSkillsByPlatform(plugin.skills, "kilo").map((skill) => ({
+      sourceDir: skill.sourceDir,
+      name: skill.name,
+    })),
+    mcpServers,
+  }
+}
+
+function convertAgent(agent: ClaudeAgent, options: ClaudeToKiloOptions): KiloAgentFile {
+  const frontmatter: Record<string, unknown> = {
+    description: agent.description,
+    mode: options.agentMode,
+  }
+
+  if (agent.model && agent.model !== "inherit") {
+    frontmatter.model = normalizeModelWithProvider(agent.model)
+  }
+
+  if (options.inferTemperature) {
+    const temp = inferTemperature(agent)
+    if (temp !== undefined) {
+      frontmatter.temperature = temp
+    }
+  }
+
+  let body = transformContentForKilo(agent.body.trim())
+
+  if (agent.capabilities && agent.capabilities.length > 0) {
+    const capabilities = agent.capabilities.map((c) => `- ${c}`).join("\n")
+    body = `## Capabilities\n${capabilities}\n\n${body}`
+  }
+
+  const content = formatFrontmatter(frontmatter, body)
+
+  return {
+    name: agent.name,
+    content,
+  }
+}
+
+function convertCommands(commands: ClaudeCommand[]): KiloCommandFile[] {
+  return commands
+    .filter((cmd) => !cmd.disableModelInvocation)
+    .map((cmd) => {
+      const frontmatter: Record<string, unknown> = {
+        description: cmd.description,
+      }
+
+      if (cmd.model && cmd.model !== "inherit") {
+        frontmatter.model = normalizeModelWithProvider(cmd.model)
+      }
+
+      const body = transformContentForKilo(cmd.body)
+      const content = formatFrontmatter(frontmatter, body)
+
+      return {
+        name: cmd.name,
+        content,
+      }
+    })
+}
+
+function convertMcp(
+  servers: Record<string, ClaudeMcpServer>,
+): Record<string, KiloMcpServer> {
+  const result: Record<string, KiloMcpServer> = {}
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (server.command) {
+      result[name] = {
+        command: server.command,
+        args: server.args,
+        env: server.env,
+      }
+      continue
+    }
+
+    if (server.url) {
+      result[name] = {
+        url: server.url,
+        headers: server.headers,
+      }
+    }
+  }
+
+  return result
+}
+
+function inferTemperature(agent: ClaudeAgent): number | undefined {
+  const text = `${agent.name} ${agent.description ?? ""}`.toLowerCase()
+  if (text.includes("review") || text.includes("audit") || text.includes("security")) {
+    return 0.1
+  }
+  if (text.includes("brainstorm") || text.includes("ideate") || text.includes("creative")) {
+    return 0.7
+  }
+  return undefined
+}
+
+/**
+ * Transform Claude Code content to Kilo-compatible content.
+ *
+ * 1. Path rewriting: .claude/ -> .kilo/, ~/.claude/ -> ~/.config/kilo/
+ * 2. Slash command refs: /command-name -> invoked via /command-name
+ */
+export function transformContentForKilo(body: string): string {
+  let result = body
+
+  // Rewrite .claude/ paths to .kilo/
+  result = result.replace(/(?<=^|\s|["'`])~\/\.claude\//gm, "~/.config/kilo/")
+  result = result.replace(/(?<=^|\s|["'`])\.claude\//gm, ".kilo/")
+
+  return result
+}

--- a/src/converters/claude-to-kilo.ts
+++ b/src/converters/claude-to-kilo.ts
@@ -90,7 +90,7 @@ function convertCommands(commands: ClaudeCommand[]): KiloCommandFile[] {
     })
 }
 
-function convertMcp(
+export function convertMcp(
   servers: Record<string, ClaudeMcpServer>,
 ): Record<string, KiloMcpServer> {
   const result: Record<string, KiloMcpServer> = {}
@@ -137,8 +137,8 @@ export function transformContentForKilo(body: string): string {
   let result = body
 
   // Rewrite .claude/ paths to .kilo/
-  result = result.replace(/(?<=^|\s|["'`])~\/\.claude\//gm, "~/.config/kilo/")
-  result = result.replace(/(?<=^|\s|["'`])\.claude\//gm, ".kilo/")
+  result = result.replace(/(?<!\w|\.)(~\/\.claude\/)/gm, "~/.config/kilo/")
+  result = result.replace(/(?<!\w|\.)(\.claude\/)/gm, ".kilo/")
 
   return result
 }

--- a/src/sync/commands.ts
+++ b/src/sync/commands.ts
@@ -6,6 +6,7 @@ import { convertClaudeToCodex } from "../converters/claude-to-codex"
 import { convertClaudeToCopilot } from "../converters/claude-to-copilot"
 import { convertClaudeToDroid } from "../converters/claude-to-droid"
 import { convertClaudeToGemini } from "../converters/claude-to-gemini"
+import { convertClaudeToKilo } from "../converters/claude-to-kilo"
 import { convertClaudeToKiro } from "../converters/claude-to-kiro"
 import { convertClaudeToOpenCode, type ClaudeToOpenCodeOptions } from "../converters/claude-to-opencode"
 import { convertClaudeToPi } from "../converters/claude-to-pi"
@@ -148,6 +149,19 @@ export async function syncKiroCommands(
   const bundle = convertClaudeToKiro(plugin, DEFAULT_SYNC_OPTIONS)
   for (const skill of bundle.generatedSkills) {
     await writeText(path.join(outputRoot, "skills", sanitizePathName(skill.name), "SKILL.md"), skill.content + "\n")
+  }
+}
+
+export async function syncKiloCommands(
+  config: ClaudeHomeConfig,
+  outputRoot: string,
+): Promise<void> {
+  if (!hasCommands(config)) return
+
+  const plugin = buildClaudeHomePlugin(config)
+  const bundle = convertClaudeToKilo(plugin, DEFAULT_SYNC_OPTIONS)
+  for (const cmd of bundle.commandFiles) {
+    await writeText(path.join(outputRoot, "command", `${sanitizePathName(cmd.name)}.md`), cmd.content + "\n")
   }
 }
 

--- a/src/sync/kilo.ts
+++ b/src/sync/kilo.ts
@@ -1,0 +1,49 @@
+import path from "path"
+import type { ClaudeHomeConfig } from "../parsers/claude-home"
+import type { ClaudeMcpServer } from "../types/claude"
+import type { KiloMcpServer } from "../types/kilo"
+import { syncKiloCommands } from "./commands"
+import { mergeJsonConfigAtKey } from "./json-config"
+import { syncSkills } from "./skills"
+
+export async function syncToKilo(
+  config: ClaudeHomeConfig,
+  outputRoot: string,
+): Promise<void> {
+  await syncSkills(config.skills, path.join(outputRoot, "skills"))
+  await syncKiloCommands(config, outputRoot)
+
+  if (Object.keys(config.mcpServers).length > 0) {
+    await mergeJsonConfigAtKey({
+      configPath: path.join(outputRoot, "kilo.json"),
+      key: "mcpServers",
+      incoming: convertMcpForKilo(config.mcpServers),
+    })
+  }
+}
+
+function convertMcpForKilo(
+  servers: Record<string, ClaudeMcpServer>,
+): Record<string, KiloMcpServer> {
+  const result: Record<string, KiloMcpServer> = {}
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (server.command) {
+      result[name] = {
+        command: server.command,
+        args: server.args,
+        env: server.env,
+      }
+      continue
+    }
+
+    if (server.url) {
+      result[name] = {
+        url: server.url,
+        headers: server.headers,
+      }
+    }
+  }
+
+  return result
+}

--- a/src/sync/kilo.ts
+++ b/src/sync/kilo.ts
@@ -1,7 +1,6 @@
 import path from "path"
 import type { ClaudeHomeConfig } from "../parsers/claude-home"
-import type { ClaudeMcpServer } from "../types/claude"
-import type { KiloMcpServer } from "../types/kilo"
+import { convertMcp } from "../converters/claude-to-kilo"
 import { syncKiloCommands } from "./commands"
 import { mergeJsonConfigAtKey } from "./json-config"
 import { syncSkills } from "./skills"
@@ -17,33 +16,7 @@ export async function syncToKilo(
     await mergeJsonConfigAtKey({
       configPath: path.join(outputRoot, "kilo.json"),
       key: "mcpServers",
-      incoming: convertMcpForKilo(config.mcpServers),
+      incoming: convertMcp(config.mcpServers),
     })
   }
-}
-
-function convertMcpForKilo(
-  servers: Record<string, ClaudeMcpServer>,
-): Record<string, KiloMcpServer> {
-  const result: Record<string, KiloMcpServer> = {}
-
-  for (const [name, server] of Object.entries(servers)) {
-    if (server.command) {
-      result[name] = {
-        command: server.command,
-        args: server.args,
-        env: server.env,
-      }
-      continue
-    }
-
-    if (server.url) {
-      result[name] = {
-        url: server.url,
-        headers: server.headers,
-      }
-    }
-  }
-
-  return result
 }

--- a/src/sync/registry.ts
+++ b/src/sync/registry.ts
@@ -5,6 +5,7 @@ import { syncToCodex } from "./codex"
 import { syncToCopilot } from "./copilot"
 import { syncToDroid } from "./droid"
 import { syncToGemini } from "./gemini"
+import { syncToKilo } from "./kilo"
 import { syncToKimi } from "./kimi"
 import { syncToKiro } from "./kiro"
 import { syncToOpenClaw } from "./openclaw"
@@ -35,6 +36,7 @@ export type SyncTargetName =
   | "openclaw"
   | "kimi"
   | "qoder"
+  | "kilo"
 
 export type SyncTargetDefinition = {
   name: SyncTargetName
@@ -135,6 +137,16 @@ export const syncTargets: SyncTargetDefinition[] = [
     detectPaths: (home) => [path.join(home, ".qoder")],
     resolveOutputRoot: (home) => path.join(home, ".qoder"),
     sync: syncToQoder,
+  },
+  {
+    name: "kilo",
+    detectPaths: (home, cwd) => [
+      path.join(home, ".config", "kilo"),
+      path.join(home, ".kilo"),
+      path.join(cwd, ".kilo"),
+    ],
+    resolveOutputRoot: (home) => path.join(home, ".config", "kilo"),
+    sync: syncToKilo,
   },
 ]
 

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -14,6 +14,7 @@ import { convertClaudeToKimi } from "../converters/claude-to-kimi"
 import { convertClaudeToQoder } from "../converters/claude-to-qoder"
 import { convertClaudeToTrae } from "../converters/claude-to-trae"
 import { convertClaudeToCursor } from "../converters/claude-to-cursor"
+import { convertClaudeToKilo } from "../converters/claude-to-kilo"
 import { writeOpenCodeBundle } from "./opencode"
 import { writeCodexBundle } from "./codex"
 import { writeDroidBundle } from "./droid"
@@ -29,6 +30,7 @@ import { writeKimiBundle } from "./kimi"
 import { writeQoderBundle } from "./qoder"
 import { writeTraeBundle } from "./trae"
 import { writeCursorBundle } from "./cursor"
+import { writeKiloBundle } from "./kilo"
 
 export type TargetScope = "global" | "workspace"
 
@@ -159,5 +161,11 @@ export const targets: Record<string, TargetHandler> = {
     implemented: true,
     convert: convertClaudeToCursor as TargetHandler["convert"],
     write: writeCursorBundle as TargetHandler["write"],
+  },
+  kilo: {
+    name: "kilo",
+    implemented: true,
+    convert: convertClaudeToKilo as TargetHandler["convert"],
+    write: writeKiloBundle as TargetHandler["write"],
   },
 }

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -165,6 +165,7 @@ export const targets: Record<string, TargetHandler> = {
   kilo: {
     name: "kilo",
     implemented: true,
+    defaultScope: "workspace",
     convert: convertClaudeToKilo as TargetHandler["convert"],
     write: writeKiloBundle as TargetHandler["write"],
   },

--- a/src/targets/kilo.ts
+++ b/src/targets/kilo.ts
@@ -1,0 +1,106 @@
+import path from "path"
+import {
+  backupFile,
+  copySkillDir,
+  ensureDir,
+  pathExists,
+  readJson,
+  sanitizePathName,
+  writeJson,
+  writeText,
+} from "../utils/files"
+import { transformContentForKilo } from "../converters/claude-to-kilo"
+import type { KiloBundle } from "../types/kilo"
+
+export async function writeKiloBundle(outputRoot: string, bundle: KiloBundle): Promise<void> {
+  const paths = resolveKiloPaths(outputRoot)
+  await ensureDir(paths.kiloDir)
+
+  // Write agents
+  if (bundle.agents.length > 0) {
+    await ensureDir(paths.agentsDir)
+    const seenNames = new Set<string>()
+    for (const agent of bundle.agents) {
+      const safeName = sanitizePathName(agent.name)
+      if (seenNames.has(safeName)) {
+        console.warn(`Skipping agent "${agent.name}": sanitized name "${safeName}" collides with another agent`)
+        continue
+      }
+      seenNames.add(safeName)
+      await writeText(path.join(paths.agentsDir, `${safeName}.md`), agent.content + "\n")
+    }
+  }
+
+  // Write commands
+  if (bundle.commandFiles.length > 0) {
+    await ensureDir(paths.commandDir)
+    const seenNames = new Set<string>()
+    for (const cmd of bundle.commandFiles) {
+      const safeName = sanitizePathName(cmd.name)
+      if (seenNames.has(safeName)) {
+        console.warn(`Skipping command "${cmd.name}": sanitized name "${safeName}" collides with another command`)
+        continue
+      }
+      seenNames.add(safeName)
+      await writeText(path.join(paths.commandDir, `${safeName}.md`), cmd.content + "\n")
+    }
+  }
+
+  // Copy skill directories
+  if (bundle.skillDirs.length > 0) {
+    await ensureDir(paths.skillsDir)
+    for (const skill of bundle.skillDirs) {
+      const destDir = path.join(paths.skillsDir, sanitizePathName(skill.name))
+      await copySkillDir(skill.sourceDir, destDir, transformContentForKilo, true)
+    }
+  }
+
+  // Write MCP servers to kilo.json
+  if (Object.keys(bundle.mcpServers).length > 0) {
+    await ensureDir(paths.kiloDir)
+    const configPath = paths.configPath
+    const backupPath = await backupFile(configPath)
+    if (backupPath) {
+      console.log(`Backed up existing kilo.json to ${backupPath}`)
+    }
+
+    let existingConfig: Record<string, unknown> = {}
+    if (await pathExists(configPath)) {
+      try {
+        existingConfig = await readJson<Record<string, unknown>>(configPath)
+      } catch {
+        console.warn("Warning: existing kilo.json could not be parsed and will be replaced.")
+      }
+    }
+
+    const existingServers =
+      existingConfig.mcpServers && typeof existingConfig.mcpServers === "object"
+        ? (existingConfig.mcpServers as Record<string, unknown>)
+        : {}
+    const merged = { ...existingConfig, mcpServers: { ...existingServers, ...bundle.mcpServers } }
+    await writeJson(configPath, merged)
+  }
+}
+
+function resolveKiloPaths(outputRoot: string) {
+  const base = path.basename(outputRoot)
+  // If already pointing at .kilo, write directly into it
+  if (base === ".kilo") {
+    return {
+      kiloDir: outputRoot,
+      configPath: path.join(outputRoot, "kilo.json"),
+      agentsDir: path.join(outputRoot, "agents"),
+      commandDir: path.join(outputRoot, "command"),
+      skillsDir: path.join(outputRoot, "skills"),
+    }
+  }
+  // Otherwise nest under .kilo
+  const kiloDir = path.join(outputRoot, ".kilo")
+  return {
+    kiloDir,
+    configPath: path.join(kiloDir, "kilo.json"),
+    agentsDir: path.join(kiloDir, "agents"),
+    commandDir: path.join(kiloDir, "command"),
+    skillsDir: path.join(kiloDir, "skills"),
+  }
+}

--- a/src/types/kilo.ts
+++ b/src/types/kilo.ts
@@ -1,0 +1,29 @@
+export type KiloAgentFile = {
+  name: string
+  content: string
+}
+
+export type KiloCommandFile = {
+  name: string
+  content: string
+}
+
+export type KiloSkillDir = {
+  sourceDir: string
+  name: string
+}
+
+export type KiloMcpServer = {
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+}
+
+export type KiloBundle = {
+  agents: KiloAgentFile[]
+  commandFiles: KiloCommandFile[]
+  skillDirs: KiloSkillDir[]
+  mcpServers: Record<string, KiloMcpServer>
+}

--- a/src/utils/resolve-output.ts
+++ b/src/utils/resolve-output.ts
@@ -15,12 +15,13 @@ export function resolveTargetOutputRoot(options: {
   traeHome?: string
   cursorHome?: string
   kimiHome?: string
+  kiloHome?: string
   pluginName?: string
   plugin?: ClaudePlugin
   hasExplicitOutput: boolean
   scope?: TargetScope
 }): string {
-  const { targetName, outputRoot, codexHome, piHome, openclawHome, qwenHome, qoderHome, traeHome, cursorHome, kimiHome, pluginName, plugin, hasExplicitOutput, scope } = options
+  const { targetName, outputRoot, codexHome, piHome, openclawHome, qwenHome, qoderHome, traeHome, cursorHome, kimiHome, kiloHome, pluginName, plugin, hasExplicitOutput, scope } = options
   if (targetName === "codex") return codexHome
   if (targetName === "pi") return piHome
   if (targetName === "droid") return path.join(os.homedir(), ".factory")
@@ -60,6 +61,11 @@ export function resolveTargetOutputRoot(options: {
   }
   if (targetName === "kimi") {
     return kimiHome ?? path.join(os.homedir(), ".kimi")
+  }
+  if (targetName === "kilo") {
+    if (kiloHome) return kiloHome
+    const base = hasExplicitOutput ? outputRoot : process.cwd()
+    return path.join(base, ".kilo")
   }
   if (targetName === "claude") {
     return options.claudeHome ?? path.join(os.homedir(), ".claude")

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -607,6 +607,81 @@ describe("CLI", () => {
     expect(json.permission).not.toBeNull()
   })
 
+  test("convert supports --kilo-home for kilo output", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-kilo-home-"))
+    const kiloRoot = path.join(tempRoot, ".kilo")
+    const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      "src/index.ts",
+      "convert",
+      fixtureRoot,
+      "--to",
+      "kilo",
+      "--kilo-home",
+      kiloRoot,
+    ], {
+      cwd: path.join(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect(stdout).toContain("Converted galeharness-cli")
+    expect(stdout).toContain(kiloRoot)
+    expect(await exists(path.join(kiloRoot, "agents", "repo-research-analyst.md"))).toBe(true)
+    expect(await exists(path.join(kiloRoot, "command", "workflows-review.md"))).toBe(true)
+    expect(await exists(path.join(kiloRoot, "skills", "skill-one", "SKILL.md"))).toBe(true)
+  })
+
+  test("install supports --also with kilo output", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-also-kilo-"))
+    const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
+    const kiloRoot = path.join(tempRoot, ".kilo")
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      "src/index.ts",
+      "install",
+      fixtureRoot,
+      "--to",
+      "opencode",
+      "--also",
+      "kilo",
+      "--kilo-home",
+      kiloRoot,
+      "--output",
+      tempRoot,
+    ], {
+      cwd: path.join(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect(stdout).toContain("Installed galeharness-cli")
+    expect(stdout).toContain(kiloRoot)
+    expect(await exists(path.join(kiloRoot, "agents", "repo-research-analyst.md"))).toBe(true)
+    expect(await exists(path.join(kiloRoot, "skills", "skill-one", "SKILL.md"))).toBe(true)
+  })
+
   test("sync --target all detects new sync targets and ignores stale cursor directories", async () => {
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "cli-sync-home-"))
     const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "cli-sync-cwd-"))
@@ -653,6 +728,7 @@ describe("CLI", () => {
     await fs.mkdir(path.join(tempHome, ".openclaw"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".kimi"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".qoder"), { recursive: true })
+    await fs.mkdir(path.join(tempHome, ".config", "kilo"), { recursive: true })
     await fs.mkdir(path.join(tempCwd, ".cursor"), { recursive: true })
 
     const proc = Bun.spawn([
@@ -692,6 +768,7 @@ describe("CLI", () => {
     expect(stdout).toContain("Synced to gemini")
     expect(stdout).toContain("Synced to kimi")
     expect(stdout).toContain("Synced to qoder")
+    expect(stdout).toContain("Synced to kilo")
     expect(stdout).not.toContain("cursor")
 
     expect(await exists(path.join(tempHome, ".config", "opencode", "commands", "workflows", "plan.md"))).toBe(true)
@@ -711,5 +788,7 @@ describe("CLI", () => {
     expect(await exists(path.join(tempHome, ".gemini", "settings.json"))).toBe(true)
     expect(await exists(path.join(tempHome, ".gemini", "commands", "workflows", "plan.toml"))).toBe(true)
     expect(await exists(path.join(tempHome, ".openclaw", "skills", "skill-one"))).toBe(true)
+    expect(await exists(path.join(tempHome, ".config", "kilo", "command", "workflows-plan.md"))).toBe(true)
+    expect(await exists(path.join(tempHome, ".config", "kilo", "kilo.json"))).toBe(true)
   })
 })

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -50,7 +50,7 @@ describe("detectInstalledTools", () => {
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
-    expect(results.length).toBe(12)
+    expect(results.length).toBe(13)
     for (const tool of results) {
       expect(tool.detected).toBe(false)
       expect(tool.reason).toBe("not found")

--- a/tests/kilo-converter.test.ts
+++ b/tests/kilo-converter.test.ts
@@ -237,4 +237,16 @@ describe("transformContentForKilo", () => {
     const input = "Use the Bash tool to run commands."
     expect(transformContentForKilo(input)).toBe(input)
   })
+
+  test("rewrites .claude/ paths after punctuation like parentheses", () => {
+    const result = transformContentForKilo("See (.claude/config) and [~/.claude/settings].")
+    expect(result).toContain("(.kilo/config)")
+    expect(result).toContain("[~/.config/kilo/settings]")
+    expect(result).not.toContain(".claude/")
+  })
+
+  test("does not rewrite my.claude/ as a false positive", () => {
+    const input = "Visit my.claude/page for info."
+    expect(transformContentForKilo(input)).toBe(input)
+  })
 })

--- a/tests/kilo-converter.test.ts
+++ b/tests/kilo-converter.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test"
+import { convertClaudeToKilo, transformContentForKilo } from "../src/converters/claude-to-kilo"
+import { parseFrontmatter } from "../src/utils/frontmatter"
+import type { ClaudePlugin } from "../src/types/claude"
+
+const fixturePlugin: ClaudePlugin = {
+  root: "/tmp/plugin",
+  manifest: { name: "fixture", version: "1.0.0" },
+  agents: [
+    {
+      name: "security-sentinel",
+      description: "Security-focused agent",
+      capabilities: ["Threat modeling", "OWASP"],
+      model: "claude-sonnet-4-20250514",
+      body: "Focus on vulnerabilities.",
+      sourcePath: "/tmp/plugin/agents/security-sentinel.md",
+    },
+  ],
+  commands: [
+    {
+      name: "workflows:plan",
+      description: "Planning command",
+      argumentHint: "[FOCUS]",
+      model: "inherit",
+      allowedTools: ["Read"],
+      body: "Plan the work.",
+      sourcePath: "/tmp/plugin/commands/workflows/plan.md",
+    },
+  ],
+  skills: [
+    {
+      name: "existing-skill",
+      description: "Existing skill",
+      sourceDir: "/tmp/plugin/skills/existing-skill",
+      skillPath: "/tmp/plugin/skills/existing-skill/SKILL.md",
+    },
+  ],
+  hooks: undefined,
+  mcpServers: {
+    local: { command: "echo", args: ["hello"] },
+  },
+}
+
+const defaultOptions = {
+  agentMode: "subagent" as const,
+  inferTemperature: false,
+  permissions: "none" as const,
+}
+
+describe("convertClaudeToKilo", () => {
+  test("converts agents to Kilo agent markdown files", () => {
+    const bundle = convertClaudeToKilo(fixturePlugin, defaultOptions)
+
+    const agent = bundle.agents.find((a) => a.name === "security-sentinel")
+    expect(agent).toBeDefined()
+    const parsed = parseFrontmatter(agent!.content)
+    expect(parsed.data.description).toBe("Security-focused agent")
+    expect(parsed.data.mode).toBe("subagent")
+    expect(parsed.data.model).toBe("anthropic/claude-sonnet-4-20250514")
+    expect(parsed.body).toContain("Focus on vulnerabilities.")
+  })
+
+  test("agent with capabilities prepended to body", () => {
+    const bundle = convertClaudeToKilo(fixturePlugin, defaultOptions)
+    const agent = bundle.agents.find((a) => a.name === "security-sentinel")
+    const parsed = parseFrontmatter(agent!.content)
+    expect(parsed.body).toContain("## Capabilities")
+    expect(parsed.body).toContain("- Threat modeling")
+    expect(parsed.body).toContain("- OWASP")
+  })
+
+  test("agent model inherit is omitted", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        {
+          name: "inherit-agent",
+          description: "Inherit model",
+          body: "Do things.",
+          sourcePath: "/tmp/plugin/agents/inherit.md",
+          model: "inherit",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToKilo(plugin, defaultOptions)
+    const agent = bundle.agents.find((a) => a.name === "inherit-agent")
+    const parsed = parseFrontmatter(agent!.content)
+    expect(parsed.data.model).toBeUndefined()
+  })
+
+  test("converts commands to Kilo command markdown files", () => {
+    const bundle = convertClaudeToKilo(fixturePlugin, defaultOptions)
+
+    expect(bundle.commandFiles).toHaveLength(1)
+    const cmd = bundle.commandFiles[0]
+    expect(cmd.name).toBe("workflows:plan")
+    const parsed = parseFrontmatter(cmd.content)
+    expect(parsed.data.description).toBe("Planning command")
+    expect(parsed.body).toContain("Plan the work.")
+  })
+
+  test("command with disable-model-invocation is excluded", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      commands: [
+        {
+          name: "disabled-command",
+          description: "Disabled command",
+          disableModelInvocation: true,
+          body: "Disabled body.",
+          sourcePath: "/tmp/plugin/commands/disabled.md",
+        },
+      ],
+      agents: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToKilo(plugin, defaultOptions)
+    expect(bundle.commandFiles).toHaveLength(0)
+  })
+
+  test("skills pass through as directory references", () => {
+    const bundle = convertClaudeToKilo(fixturePlugin, defaultOptions)
+
+    expect(bundle.skillDirs).toHaveLength(1)
+    expect(bundle.skillDirs[0].name).toBe("existing-skill")
+    expect(bundle.skillDirs[0].sourceDir).toBe("/tmp/plugin/skills/existing-skill")
+  })
+
+  test("MCP stdio servers convert correctly", () => {
+    const bundle = convertClaudeToKilo(fixturePlugin, defaultOptions)
+    expect(bundle.mcpServers.local.command).toBe("echo")
+    expect(bundle.mcpServers.local.args).toEqual(["hello"])
+  })
+
+  test("MCP HTTP servers converted with url", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      mcpServers: {
+        httpServer: { url: "https://example.com/mcp" },
+      },
+      agents: [],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToKilo(plugin, defaultOptions)
+
+    expect(Object.keys(bundle.mcpServers)).toHaveLength(1)
+    expect(bundle.mcpServers.httpServer).toEqual({ url: "https://example.com/mcp" })
+  })
+
+  test("empty plugin produces empty bundle", () => {
+    const plugin: ClaudePlugin = {
+      root: "/tmp/empty",
+      manifest: { name: "empty", version: "1.0.0" },
+      agents: [],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToKilo(plugin, defaultOptions)
+    expect(bundle.agents).toHaveLength(0)
+    expect(bundle.commandFiles).toHaveLength(0)
+    expect(bundle.skillDirs).toHaveLength(0)
+    expect(Object.keys(bundle.mcpServers)).toHaveLength(0)
+  })
+
+  test("infers temperature for review agents", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        {
+          name: "code-reviewer",
+          description: "Reviews code",
+          body: "Review code.",
+          sourcePath: "/tmp/plugin/agents/reviewer.md",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToKilo(plugin, {
+      ...defaultOptions,
+      inferTemperature: true,
+    })
+
+    const agent = bundle.agents[0]
+    const parsed = parseFrontmatter(agent.content)
+    expect(parsed.data.temperature).toBe(0.1)
+  })
+
+  test("infers temperature for brainstorm agents", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        {
+          name: "ideator",
+          description: "Generate creative ideas",
+          body: "Brainstorm.",
+          sourcePath: "/tmp/plugin/agents/ideator.md",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToKilo(plugin, {
+      ...defaultOptions,
+      inferTemperature: true,
+    })
+
+    const agent = bundle.agents[0]
+    const parsed = parseFrontmatter(agent.content)
+    expect(parsed.data.temperature).toBe(0.7)
+  })
+})
+
+describe("transformContentForKilo", () => {
+  test("rewrites .claude/ paths to .kilo/", () => {
+    const result = transformContentForKilo("Read .claude/settings.json for config.")
+    expect(result).toContain(".kilo/settings.json")
+    expect(result).not.toContain(".claude/")
+  })
+
+  test("rewrites ~/.claude/ paths to ~/.config/kilo/", () => {
+    const result = transformContentForKilo("Check ~/.claude/config for settings.")
+    expect(result).toContain("~/.config/kilo/config")
+    expect(result).not.toContain("~/.claude/")
+  })
+
+  test("leaves unrelated text unchanged", () => {
+    const input = "Use the Bash tool to run commands."
+    expect(transformContentForKilo(input)).toBe(input)
+  })
+})

--- a/tests/kilo-writer.test.ts
+++ b/tests/kilo-writer.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import path from "path"
+import os from "os"
+import { writeKiloBundle } from "../src/targets/kilo"
+import type { KiloBundle } from "../src/types/kilo"
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const emptyBundle: KiloBundle = {
+  agents: [],
+  commandFiles: [],
+  skillDirs: [],
+  mcpServers: {},
+}
+
+describe("writeKiloBundle", () => {
+  test("writes agents, commands, skills, and mcp config", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-test-"))
+    const bundle: KiloBundle = {
+      agents: [
+        {
+          name: "security-sentinel",
+          content: "---\ndescription: Security agent\nmode: subagent\n---\n\nFocus on vulnerabilities.",
+        },
+      ],
+      commandFiles: [
+        {
+          name: "workflows-plan",
+          content: "---\ndescription: Plan work\n---\n\nPlan the work.",
+        },
+      ],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+      mcpServers: {
+        playwright: { command: "npx", args: ["-y", "@anthropic/mcp-playwright"] },
+      },
+    }
+
+    await writeKiloBundle(tempRoot, bundle)
+
+    // Agent file
+    const agentPath = path.join(tempRoot, ".kilo", "agents", "security-sentinel.md")
+    expect(await exists(agentPath)).toBe(true)
+    const agentContent = await fs.readFile(agentPath, "utf8")
+    expect(agentContent).toContain("Focus on vulnerabilities.")
+
+    // Command file
+    const commandPath = path.join(tempRoot, ".kilo", "command", "workflows-plan.md")
+    expect(await exists(commandPath)).toBe(true)
+    const commandContent = await fs.readFile(commandPath, "utf8")
+    expect(commandContent).toContain("Plan the work.")
+
+    // Copied skill
+    expect(await exists(path.join(tempRoot, ".kilo", "skills", "skill-one", "SKILL.md"))).toBe(true)
+
+    // MCP config
+    const mcpPath = path.join(tempRoot, ".kilo", "kilo.json")
+    expect(await exists(mcpPath)).toBe(true)
+    const mcpContent = JSON.parse(await fs.readFile(mcpPath, "utf8"))
+    expect(mcpContent.mcpServers.playwright.command).toBe("npx")
+  })
+
+  test("does not double-nest when output root is .kilo", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-home-"))
+    const kiloRoot = path.join(tempRoot, ".kilo")
+    const bundle: KiloBundle = {
+      ...emptyBundle,
+      agents: [
+        {
+          name: "reviewer",
+          content: "---\ndescription: Reviewer\n---\n\nReview content.",
+        },
+      ],
+    }
+
+    await writeKiloBundle(kiloRoot, bundle)
+
+    expect(await exists(path.join(kiloRoot, "agents", "reviewer.md"))).toBe(true)
+    // Should NOT double-nest under .kilo/.kilo
+    expect(await exists(path.join(kiloRoot, ".kilo"))).toBe(false)
+  })
+
+  test("handles empty bundles gracefully", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-empty-"))
+
+    await writeKiloBundle(tempRoot, emptyBundle)
+    expect(await exists(tempRoot)).toBe(true)
+  })
+
+  test("backs up existing kilo.json before overwrite", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-backup-"))
+    const kiloRoot = path.join(tempRoot, ".kilo")
+    await fs.mkdir(kiloRoot, { recursive: true })
+
+    const configPath = path.join(kiloRoot, "kilo.json")
+    await fs.writeFile(configPath, JSON.stringify({ mcpServers: { old: { command: "old-cmd" } } }))
+
+    const bundle: KiloBundle = {
+      ...emptyBundle,
+      mcpServers: { newServer: { command: "new-cmd" } },
+    }
+
+    await writeKiloBundle(kiloRoot, bundle)
+
+    // New config should have the new content
+    const newContent = JSON.parse(await fs.readFile(configPath, "utf8"))
+    expect(newContent.mcpServers.newServer.command).toBe("new-cmd")
+
+    // A backup file should exist
+    const files = await fs.readdir(kiloRoot)
+    const backupFiles = files.filter((f) => f.startsWith("kilo.json.bak."))
+    expect(backupFiles.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test("merges mcpServers into existing kilo.json without clobbering other keys", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-merge-"))
+    const kiloRoot = path.join(tempRoot, ".kilo")
+    await fs.mkdir(kiloRoot, { recursive: true })
+
+    const configPath = path.join(kiloRoot, "kilo.json")
+    await fs.writeFile(configPath, JSON.stringify({
+      customKey: "preserve-me",
+      mcpServers: { old: { command: "old-cmd" } },
+    }))
+
+    const bundle: KiloBundle = {
+      ...emptyBundle,
+      mcpServers: { newServer: { command: "new-cmd" } },
+    }
+
+    await writeKiloBundle(kiloRoot, bundle)
+
+    const content = JSON.parse(await fs.readFile(configPath, "utf8"))
+    expect(content.customKey).toBe("preserve-me")
+    expect(content.mcpServers.old.command).toBe("old-cmd")
+    expect(content.mcpServers.newServer.command).toBe("new-cmd")
+  })
+
+  test("mcp.json fresh write when no existing file", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-fresh-"))
+    const bundle: KiloBundle = {
+      ...emptyBundle,
+      mcpServers: { myServer: { command: "my-cmd", args: ["--flag"] } },
+    }
+
+    await writeKiloBundle(tempRoot, bundle)
+
+    const configPath = path.join(tempRoot, ".kilo", "kilo.json")
+    expect(await exists(configPath)).toBe(true)
+    const content = JSON.parse(await fs.readFile(configPath, "utf8"))
+    expect(content.mcpServers.myServer.command).toBe("my-cmd")
+    expect(content.mcpServers.myServer.args).toEqual(["--flag"])
+  })
+})

--- a/tests/kilo-writer.test.ts
+++ b/tests/kilo-writer.test.ts
@@ -148,7 +148,7 @@ describe("writeKiloBundle", () => {
     expect(content.mcpServers.newServer.command).toBe("new-cmd")
   })
 
-  test("mcp.json fresh write when no existing file", async () => {
+  test("kilo.json fresh write when no existing file", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-fresh-"))
     const bundle: KiloBundle = {
       ...emptyBundle,

--- a/tests/resolve-output.test.ts
+++ b/tests/resolve-output.test.ts
@@ -156,4 +156,27 @@ describe("resolveTargetOutputRoot", () => {
     })
     expect(result).toBe("/custom/trae")
   })
+
+  test("kilo defaults to cwd/.kilo", () => {
+    const result = resolveTargetOutputRoot({ ...baseOptions, targetName: "kilo" })
+    expect(result).toBe(path.join(process.cwd(), ".kilo"))
+  })
+
+  test("kilo with explicit output uses outputRoot/.kilo", () => {
+    const result = resolveTargetOutputRoot({
+      ...baseOptions,
+      targetName: "kilo",
+      hasExplicitOutput: true,
+    })
+    expect(result).toBe("/tmp/output/.kilo")
+  })
+
+  test("kilo with kiloHome override", () => {
+    const result = resolveTargetOutputRoot({
+      ...baseOptions,
+      targetName: "kilo",
+      kiloHome: "/custom/kilo",
+    })
+    expect(result).toBe("/custom/kilo")
+  })
 })

--- a/tests/sync-kilo.test.ts
+++ b/tests/sync-kilo.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+import type { ClaudeHomeConfig } from "../src/parsers/claude-home"
+import { syncToKilo } from "../src/sync/kilo"
+
+describe("syncToKilo", () => {
+  test("writes user-scope command files and mcp.json", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sync-kilo-"))
+    const fixtureSkillDir = path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one")
+
+    const config: ClaudeHomeConfig = {
+      skills: [
+        {
+          name: "skill-one",
+          sourceDir: fixtureSkillDir,
+          skillPath: path.join(fixtureSkillDir, "SKILL.md"),
+        },
+      ],
+      mcpServers: {
+        local: { command: "echo", args: ["hello"], env: { TOKEN: "secret" } },
+        remote: { url: "https://example.com/mcp", headers: { Authorization: "Bearer token" } },
+      },
+    }
+
+    await syncToKilo(config, tempRoot)
+
+    expect((await fs.lstat(path.join(tempRoot, "skills", "skill-one"))).isSymbolicLink()).toBe(true)
+
+    const content = JSON.parse(
+      await fs.readFile(path.join(tempRoot, "kilo.json"), "utf8"),
+    ) as {
+      mcpServers: Record<string, {
+        command?: string
+        args?: string[]
+        env?: Record<string, string>
+        url?: string
+        headers?: Record<string, string>
+      }>
+    }
+
+    expect(content.mcpServers.local?.command).toBe("echo")
+    expect(content.mcpServers.local?.args).toEqual(["hello"])
+    expect(content.mcpServers.local?.env).toEqual({ TOKEN: "secret" })
+    expect(content.mcpServers.remote?.url).toBe("https://example.com/mcp")
+    expect(content.mcpServers.remote?.headers).toEqual({ Authorization: "Bearer token" })
+  })
+
+  test("merges existing kilo.json", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "sync-kilo-merge-"))
+    await fs.writeFile(
+      path.join(tempRoot, "kilo.json"),
+      JSON.stringify({
+        note: "preserve",
+        mcpServers: {
+          existing: { command: "node" },
+        },
+      }, null, 2),
+    )
+
+    const config: ClaudeHomeConfig = {
+      skills: [],
+      mcpServers: {
+        remote: { url: "https://example.com/mcp" },
+      },
+    }
+
+    await syncToKilo(config, tempRoot)
+
+    const content = JSON.parse(
+      await fs.readFile(path.join(tempRoot, "kilo.json"), "utf8"),
+    ) as {
+      note: string
+      mcpServers: Record<string, { command?: string; url?: string }>
+    }
+
+    expect(content.note).toBe("preserve")
+    expect(content.mcpServers.existing?.command).toBe("node")
+    expect(content.mcpServers.remote?.url).toBe("https://example.com/mcp")
+  })
+})


### PR DESCRIPTION
## 概要

在 GaleHarnessCLI 中新增对 [Kilo Code](https://kilo.ai) 的转换和安装目标支持。

## 变更内容

- **新增转换器** (`src/converters/kilo.ts`)：将 Claude 插件的 agents、commands、skills 和 MCP servers 转换为 Kilo Code 格式
- **新增写入器** (`src/targets/kilo.ts`)：将 Kilo 包写入 `.kilo/` 目录结构
  - Agents → `.kilo/agents/`
  - Commands → `.kilo/commands/`
  - Skills → `.kilo/skills/`
  - MCP servers → 合并到 `.kilo/kilo.json`
- **新增同步模块** (`src/sync/kilo.ts`)：将 Claude home 配置同步到 Kilo Code
- **新增类型定义** (`src/types/kilo.ts`)：Kilo 包格式的类型定义
- **CLI 集成**：`convert` 和 `install` 命令现支持 `--to kilo` 和 `--also kilo`
- **同步注册表**：通过 `kilo.json`、`.kilorc` 或 `.kilo/` 检测 Kilo
- **测试**：新增 converter、writer、sync、CLI 和 resolve-output 测试

## 验证

bun test v1.3.12 (700fc117)
Full test suite: 1027/1028 通过 (1 个预先存在的无关失败)。
