### PR TITLE
fix(upstream-sync): 修复 Python 3.9 下 Path.write_text() 不支持 newline 参数的兼容性问题

### DIFF
--- a/scripts/upstream-sync/generate-batch.py
+++ b/scripts/upstream-sync/generate-batch.py
@@ -127,7 +127,8 @@ def write_commit_range(
     ]
     for commit in commits:
         lines.append(f"  - {commit.filename} {commit.sha} {commit.subject}")
-    (batch_dir / "commit-range.txt").write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    with (batch_dir / "commit-range.txt").open("w", encoding="utf-8", newline="\n") as f:
+        f.write("\n".join(lines) + "\n")
 
 
 def suggested_worktree_name(batch_dir: Path, commit: CommitMetadata) -> str:
@@ -217,7 +218,8 @@ def write_readme(
         ]
     )
 
-    (batch_dir / "README.md").write_text("\n".join(lines), encoding="utf-8", newline="\n")
+    with (batch_dir / "README.md").open("w", encoding="utf-8", newline="\n") as f:
+        f.write("\n".join(lines))
 
 
 def run_adaptation(raw_patch: Path, adapted_patch: Path, rules_path: Path) -> None:
@@ -287,7 +289,8 @@ def main() -> int:
             raw_patch_path = raw_dir / filename
             adapted_patch_path = adapted_dir / filename
 
-            raw_patch_path.write_text(format_patch(upstream_repo, sha), encoding="utf-8", newline="\n")
+            with raw_patch_path.open("w", encoding="utf-8", newline="\n") as f:
+                f.write(format_patch(upstream_repo, sha))
             run_adaptation(raw_patch_path, adapted_patch_path, rules_path)
 
             exported_commits.append(


### PR DESCRIPTION
## 问题

`scripts/upstream-sync/generate-batch.py` 中有 3 处使用了 `Path.write_text(newline="\n")` 参数，而 `newline` 参数仅在 Python 3.10+ 的 `Path.write_text()` 中才被支持。在 Python 3.9 环境下运行时，会抛出 `TypeError: write_text() got an unexpected keyword argument 'newline'`，导致脚本无法正常执行。

涉及的 3 处调用：
- `write_commit_range()` 中写入 `commit-range.txt`
- `write_readme()` 中写入 `README.md`
- `main()` 中写入原始补丁文件

## 修复方案

将所有 `Path.write_text(..., newline="\n")` 调用替换为 `Path.open("w", encoding="utf-8", newline="\n")` 上下文管理器写入方式。该写法兼容 Python 3.9，同时保留了跨平台换行符一致性（始终使用 `\n`）。

## 背景

本修复是 PR #43 类型注解修复的后续补充，PR #43 解决了 Python 3.9 的类型注解语法兼容性，而本 PR 解决运行时 `newline` 参数兼容性问题。两者共同确保 `generate-batch.py` 在 Python 3.9 下可以正常执行。

## 测试

全量测试通过（1030/1030）。