### PR TITLE
fix(codex): truncate copied skill descriptions

### DIFF
--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -1,3 +1,5 @@
+import { formatFrontmatter, parseFrontmatter } from "./frontmatter"
+
 export type CodexInvocationTargets = {
   promptTargets: Record<string, string>
   skillTargets: Record<string, string>
@@ -6,6 +8,8 @@ export type CodexInvocationTargets = {
 export type CodexTransformOptions = {
   unknownSlashBehavior?: "prompt" | "preserve"
 }
+
+const CODEX_DESCRIPTION_MAX_LENGTH = 1024
 
 /**
  * Transform Claude Code content to Codex-compatible content.
@@ -20,11 +24,14 @@ export type CodexTransformOptions = {
  * 4. Claude config paths: .claude/ -> .codex/
  */
 export function transformContentForCodex(
-  body: string,
+  content: string,
   targets?: CodexInvocationTargets,
   options: CodexTransformOptions = {},
 ): string {
-  let result = body
+  const hasFrontmatter = content.startsWith("---\n") || content.startsWith("---\r\n")
+  const parsed = hasFrontmatter ? parseFrontmatter(content) : null
+
+  let result = parsed ? parsed.body : content
   const promptTargets = targets?.promptTargets ?? {}
   const skillTargets = targets?.skillTargets ?? {}
   const unknownSlashBehavior = options.unknownSlashBehavior ?? "prompt"
@@ -69,7 +76,16 @@ export function transformContentForCodex(
     return `$${skillName} skill`
   })
 
-  return result
+  if (!parsed) {
+    return result
+  }
+
+  const frontmatter = { ...parsed.data }
+  if (typeof frontmatter.description === "string") {
+    frontmatter.description = truncateCodexDescription(frontmatter.description)
+  }
+
+  return formatFrontmatter(frontmatter, result)
 }
 
 export function normalizeCodexName(value: string): string {
@@ -83,4 +99,12 @@ export function normalizeCodexName(value: string): string {
     .replace(/-+/g, "-")
     .replace(/^-+|-+$/g, "")
   return normalized || "item"
+}
+
+function truncateCodexDescription(description: string): string {
+  if (description.length <= CODEX_DESCRIPTION_MAX_LENGTH) {
+    return description
+  }
+
+  return `${description.slice(0, CODEX_DESCRIPTION_MAX_LENGTH - 3).trimEnd()}...`
 }

--- a/tests/codex-writer.test.ts
+++ b/tests/codex-writer.test.ts
@@ -4,6 +4,7 @@ import path from "path"
 import os from "os"
 import { mergeCodexConfig, renderCodexConfig, writeCodexBundle } from "../src/targets/codex"
 import type { CodexBundle } from "../src/types/codex"
+import { parseFrontmatter } from "../src/utils/frontmatter"
 
 async function exists(filePath: string): Promise<boolean> {
   try {
@@ -417,6 +418,46 @@ Workflow handoff:
     expect(installedSkill).not.toContain("/prompts:users")
     expect(installedSkill).not.toContain("/prompts:settings")
     expect(installedSkill).not.toContain("https://prompts:www.proofeditor.ai")
+  })
+
+  test("truncates copied skill descriptions to Codex's frontmatter limit", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-skill-description-"))
+    const sourceSkillDir = path.join(tempRoot, "source-skill")
+    await fs.mkdir(sourceSkillDir, { recursive: true })
+
+    const longDescription = "A".repeat(1100)
+    await fs.writeFile(
+      path.join(sourceSkillDir, "SKILL.md"),
+      `---
+name: proof
+description: ${longDescription}
+---
+
+Share a markdown document with Proof.
+`,
+    )
+
+    const bundle: CodexBundle = {
+      prompts: [],
+      skillDirs: [{ name: "proof", sourceDir: sourceSkillDir }],
+      generatedSkills: [],
+      invocationTargets: {
+        promptTargets: {},
+        skillTargets: {},
+      },
+    }
+
+    await writeCodexBundle(tempRoot, bundle)
+
+    const installedSkill = await fs.readFile(
+      path.join(tempRoot, ".codex", "skills", "proof", "SKILL.md"),
+      "utf8",
+    )
+    const parsed = parseFrontmatter(installedSkill)
+
+    expect(typeof parsed.data.description).toBe("string")
+    expect((parsed.data.description as string).length).toBeLessThanOrEqual(1024)
+    expect(parsed.body).toContain("Share a markdown document with Proof.")
   })
 })
 


### PR DESCRIPTION
## Summary

Codex skill installation now trims copied skill frontmatter descriptions to the 1024-character limit before writing `SKILL.md`. This keeps long upstream skill descriptions from producing invalid Codex output while preserving the transformed body content.

## Testing

- `bun test`

🤖 Generated with [GaleHarnessCLI](https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI)