### PR TITLE
feat(upstream-sync): 实现 Upstream Sync CLI 自动化工作流

### DIFF
--- a/docs/plans/2026-04-24-001-feat-upstream-sync-cli-automation-plan.md
+++ b/docs/plans/2026-04-24-001-feat-upstream-sync-cli-automation-plan.md
@@ -1,0 +1,583 @@
+---
+title: "feat: Upstream Sync CLI 自动化工作流"
+type: feat
+status: active
+date: 2026-04-24
+origin: brainstorms/2026-04-23-upstream-sync-cli-automation-requirements.md
+deepened: 2026-04-24
+---
+
+# feat: Upstream Sync CLI 自动化工作流
+
+## Overview
+
+本计划把现有 `scripts/upstream-sync/` 的逐 commit patch 批次能力升级为半自动化 CLI：`init` 一次性生成 raw/adapted patch batch 并初始化 `state.json`，`next` 消费已生成的 adapted patch 并完成 worktree、patch 预检、测试、commit、push、PR 创建，`resume` 处理 PR merged/open/closed 与 failed 恢复，`skip` 只推进指针并可在 `--force-cleanup` 下清理失败/关闭 PR 的残留资源。
+
+核心边界是“自动化机械步骤，保留人类验收暂停点”。状态文件是主要事实来源，`.upstream-ref` 只在 merge 对账成功后作为派生 baseline 写入，避免旧流程里靠手工记忆推进同步进度的问题。
+
+| 命令 | 主要输入状态 | 副作用边界 | 终态 |
+|---|---|---|---|
+| `init` | 无状态或新批次 | 生成 patch batch，写入 `state.json` | `idle` / `pending` 队列就绪 |
+| `status` | 任意状态 | 无副作用 | 输出当前状态与最近操作 |
+| `next` | `idle` 且当前 commit 为 `pending` | 创建 worktree、应用 patch、测试、提交、push、创建 PR | `awaiting_human_review` 或 `failed` |
+| `resume` | `awaiting_human_review` 或 `failed` | merged 时只推进 baseline/index 并清理；failed 时从失败步骤重试 | `idle` / `complete`、继续等待或 `failed` |
+| `skip` | `pending` / `failed` / closed PR 场景 | 推进 `current_index`；可选清理 worktree/远程分支 | `idle` / `complete`，不自动 `next` |
+
+---
+
+## Problem Frame
+
+当前 upstream 同步已有 per-commit patch 批次基础，但仍需要研发手动创建 worktree、应用 patch、运行测试、创建 PR、等待 review、更新 `.upstream-ref` 并重复处理下一个 commit。需求文档以 14 个待同步 commit 为触发场景，要求 CLI 承担可机械化的步骤，同时在 PR 创建后明确暂停并交给人类验收（see origin: `brainstorms/2026-04-23-upstream-sync-cli-automation-requirements.md`）。
+
+这不是只为一次 14-commit 批处理写临时脚本：GaleHarnessCLI 会持续 vendored upstream HKTMemory，并且每次 upstream 拉取都要重复同一组 worktree、patch、测试、PR、baseline 对账动作。v1 仍放在 `scripts/upstream-sync/` 内，避免过早产品化到顶层 CLI；但用显式状态机和可恢复命令，是为了降低后续每次同步的认知负担和重复出错率。
+
+更新后的需求进一步明确了几个规划约束：`init` 负责批量生成 patch，`next` 不再现场生成 patch；`resume` 必须覆盖 merged/open/closed 三种 PR 状态，并支持从 failed 恢复；`skip` 只推进指针，不自动开始下一个 commit；`--dry-run` 是单步预览；`state.json` 是主要事实来源，`.upstream-ref` 是派生状态。
+
+---
+
+## Requirements Trace
+
+### 状态与输出
+
+- R1. 启动时读取 `.upstream-ref` baseline，并结合 `.upstream-repo` 发现待同步 commits
+- R2. 维护 `.context/galeharness-cli/upstream-sync/state.json`，记录批次、队列、PR、失败和操作日志
+- R3/R12. `status` 统一输出同步概览、commit 队列、当前状态、下一个 commit 和最近 3 条操作日志
+- R19. 每个失败步骤都写入状态并给出可操作下一步提示
+- R20. CLI 输出使用中文，路径、命令和 JSON 字段保留英文
+
+### `init`
+
+- R13. `init` 调用现有 `generate-batch.py` 生成全量 raw/adapted patch batch，并初始化状态
+
+### `next`
+
+- R4. `next` 基于当前 commit 准备独立 worktree 并消费 `init` 生成的 adapted patch
+- R5. worktree 名称包含 commit 序号和主题摘要
+- R6. patch 应用前执行 `git apply --check`，冲突时记录 `failed_at: "patch_check"` 并输出 raw/adapted patch 路径
+- R7. patch 应用成功后运行 `bun test`
+- R8. 测试失败时阻止 PR 创建，记录失败摘要和日志路径
+- R9. 测试通过后自动 commit、push，并调用 `gh pr create`
+- R9b. PR 分支名冲突时自动生成后缀或给出明确错误
+- R10. PR 创建后进入 `awaiting_human_review` 并暂停，等待显式 `resume`
+- R14. `next` 只处理当前 commit 的应用、测试、PR、暂停，不再生成 patch
+
+### `resume`
+
+- R11. `resume` 根据 PR merged/open/closed 状态分别推进、继续等待或提示 `skip --force-cleanup`
+- R15. `resume` 从 failed 状态恢复时从失败步骤开始重试，并继续后续步骤
+
+### `dry-run` 与 `skip`
+
+- R16. 全局 `--dry-run` 只预览单步操作，不执行副作用；全批次预览不进入 v1
+- R17. `skip` 标记当前 commit 为 skipped，只推进 `current_index` 并返回控制权，不自动 `next`
+- R18. `skip --force-cleanup` 清理已推送远程分支和 worktree，然后标记 skipped
+
+**Origin actors:** A1 研发人员（同步执行者），A2 自动化同步 CLI，A3 代码审查者
+**Origin flows:** F1 逐 Commit 同步主流程，F2 人类验收后继续，F3 失败处理与人工接管
+**Origin acceptance examples:** AE1 status 队列检测，AE2 next 创建 PR 并暂停，AE3 patch 冲突失败，AE4 resume after merge，AE5 dry-run 单步预览
+
+---
+
+## Scope Boundaries
+
+- 不自动处理 adapted patch 应用后的业务逻辑人工适配；CLI 只创建环境、执行机械门禁并在测试通过后发 PR。
+- 不做无人值守定时同步或 CI 自动同步；本计划只覆盖人工发起的人机协作 CLI。
+- 不处理 upstream force-push 导致的历史 SHA 失效；仍假设 upstream 历史线性可追踪。
+- 不支持多个 upstream commit 合并为一个 PR；保持 1:1 commit-to-PR 映射。
+- 不自动 merge PR，也不绕过 review。
+- 不在 `resume` merged 后自动启动下一轮 `next`；用户每次进入新的 commit 副作用流程都必须显式执行 `next`。
+- 不在 v1 支持全量 14-commit dry-run 计划输出；`--dry-run` 只预览当前命令的单步副作用。
+
+### Deferred to Follow-Up Work
+
+- 将 `sync-cli.py` 集成到正式 `gale-harness` 顶层 TypeScript CLI：本次先在 `scripts/upstream-sync/` 内交付低风险工作流 CLI。
+- 让状态写入 task board 或 HKTMemory：当前状态以本地 `state.json` 为准，知识发现另行规划。
+- 更复杂的 PR review 批处理或批量 merge 辅助：不进入本次半自动同步核心闭环。
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/upstream-sync/generate-batch.py` 已经能基于 `.upstream-ref` 和 `.upstream-repo` 生成 `.context/galeharness-cli/upstream-sync/<date>/{raw,adapted}`、`commit-range.txt` 和 README。
+- `scripts/upstream-sync/apply-patch-to-worktree.sh` 已包含 main worktree 风险检查、干净工作区检查、patch 路径解析、`git apply --check` 和 `--3way` 可选路径；CLI 可以复用其语义，也可以在 Python 内实现等价步骤以便记录状态。
+- `tests/upstream-sync-generate-batch.test.ts`、`tests/upstream-sync-adapt-patch.test.ts`、`tests/upstream-sync-apply-patch.test.ts` 使用 Bun 测试临时 git 仓库与 fixture；新增 CLI 测试应沿用这种端到端小仓库模式。
+- `plugins/galeharness-cli/skills/compound-sync/SKILL.md` 当前仍描述手动逐 patch 流程；CLI 完成后需要更新为 `init/status/next/resume/skip` 使用说明。
+- `src/index.ts` 的主 CLI 是 Bun/citty 插件转换工具；本功能是本地 upstream sync 运维脚本，放在 `scripts/upstream-sync/` 更符合现有边界，避免把内部半自动同步流程暴露成通用产品 CLI。
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/prefer-python-over-bash-for-pipeline-scripts-2026-04-09.md`：多步骤编排、重试、超时和受控失败路径应优先用 Python，而不是 Bash。
+- `docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines-2026-03-27.md`：Git/PR 工作流必须建模为显式状态机，每个转移点重新读取真实状态，避免 stale branch、PR lookup 和 clean-tree shortcut 类 bug。
+- `docs/solutions/agent-friendly-cli-principles.md`：面向 agent 的 CLI 应非交互、输出可解析、错误可操作、变更边界明确，并为数据型命令提供结构化输出路径。
+- `docs/solutions/workflow-issues/upstream-sync-per-commit-configuration.md`：`.upstream-repo` 必须是本地 git checkout 路径，`.upstream-ref` 必须是 upstream 历史中的真实 commit；现有批次目录结构已经稳定。
+
+### External References
+
+- 本计划不需要外部调研。设计主要受本仓库现有脚本、Bun 测试模式、GitHub CLI 行为和本地知识库中的 CLI/Git 工作流经验约束。
+
+---
+
+## Key Technical Decisions
+
+- **实现语言选 Python，入口为 `scripts/upstream-sync/sync-cli.py`**：该 CLI 要编排 `git`、`gh`、`bun test`、文件状态、失败恢复和 retry，符合“多步骤 pipeline 用 Python”的本地经验。TypeScript 主 CLI 保持插件转换产品面，不承担内部 upstream sync 自动化。
+- **`init` 是唯一初始 patch batch 生成入口**：`init` 调用或复用 `generate-batch.py` 输出 batch，并从 `commit-range.txt` 和 patch 目录初始化 `state.json`。`next` 不调用 `generate-batch.py`，只消费状态里记录的 adapted patch。该设计依赖一个明确不变量：batch 中的 adapted patch 必须能按 upstream commit 顺序应用到逐步合入后的 target base；实现必须用连续 commit 修改同一区域的 fixture 验证该不变量。若测试证明预生成 patch 在累计 base 上不可靠，v1 应降级为在每次 `resume` merged 后重新生成/重新适配下一条 commit 的 patch，并把新 patch 路径写回 state。
+- **`state.json` 是主要事实来源，但不是破坏性操作的唯一信任来源**：状态文件记录 baseline、target、batch_dir、current_index、每个 commit 的状态、patch 路径、worktree、branch、PR、失败阶段、操作日志、`main_worktree_root`、`target_repo_root`、`base_branch`、`remote_name` 和 `github_repo`。`.upstream-ref` 只在 PR merged 后由 `resume` 写入，且写入前先和 state 与 upstream ancestry 对账。cleanup、push、PR 查询和远程分支删除必须重新向 git/GitHub 验证 state 中记录的目标。
+- **所有本地 workflow 文件都相对 main worktree root 解析**：CLI 启动时先解析当前 git repository 的 main worktree root，而不是信任当前 shell cwd。`.context/galeharness-cli/upstream-sync/state.json`、batch patch、`.upstream-ref` 都相对 main worktree root 读写；这样用户在同步 worktree 内运行 `status/resume/skip` 时不会误读或新建第二份状态。
+- **base branch 是显式状态字段**：`init` 解析 remote default branch 作为默认 `base_branch`，允许 `--base <branch>` 覆盖，并写入 state。`next` 创建 worktree、`gh pr create` 的 base、`resume` 对账和 cleanup 都只使用 state 中的 `base_branch`；执行前 fetch 目标 remote/base，避免从当前 shell 分支或 stale local branch 推断同步基准。
+- **状态转移用显式阶段枚举**：`next` 和 failed `resume` 共享同一阶段 pipeline：`worktree_create -> patch_check -> patch_apply -> test -> commit -> push -> pr_create -> await_review`。失败时记录 `failed_at`，恢复时从该阶段重试并继续后续阶段。
+- **外部命令封装必须可测试且安全**：`git`、`gh`、`bun`、`generate-batch.py` 都通过 command runner abstraction 调用。生产路径使用 argv 数组执行真实命令（Python 中等价于 `subprocess.run([...], shell=False)`），禁止 shell 字符串拼接；每个命令必须显式设置已验证的 cwd。测试路径注入 fake runner，避免靠 shell monkeypatch 才能覆盖 PR merged/open/closed、push failure、branch conflict 等状态。
+- **GitHub 目标必须显式验真**：`init` 或首次 `next` 记录 expected `github_repo`、`remote_name`、origin URL、base branch 和 `gh auth status` 主体；`gh pr create/view` 必须显式传 `--repo owner/repo`，push 必须使用已验证 remote。`resume` 和 cleanup 前重新校验 PR repo、headRefName、baseRefName 与 state 一致。
+- **PR 状态三分处理**：`resume` 对 `merged` 执行 baseline 推进、清理并回到 `idle` 或 `complete`；对 `open` 只提示继续等待并保持状态；对 `closed without merge` 不隐式跳过，要求用户执行 `skip --force-cleanup` 或手动修复。
+- **`complete` 是唯一批次完成终态**：当 `current_index` 越过队列末尾时，workflow_state 必须为 `complete`。`idle` 只表示还有 pending commit 且当前没有活跃副作用流程。
+- **`skip` 不触发下一步工作**：`skip` 只标记当前 commit skipped、推进指针并退出，让用户显式执行 `next`，避免跳过后立即进入新的副作用流程。
+- **`--dry-run` 是单步副作用预览**：dry-run 应输出当前命令会读取/写入哪些路径、将创建哪个 worktree/branch、将运行哪些外部命令、将创建什么 PR 标题，但不执行文件写入、worktree 创建、push 或 PR 创建。
+- **CLI 输出中文，人机与 agent 双可读**：默认中文摘要和下一步提示；`status --json` 或全局 `--json` 可作为结构化输出增量，至少在 `status` 和 dry-run 上应提供稳定字段以方便 agent 解析。
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- CLI 实现语言选择：使用 Python，与现有 `scripts/upstream-sync/` 脚本和多步骤编排经验一致；不进入 TypeScript 主 CLI。
+- PR 分支命名策略：使用 `upstream-sync-<date>-<NNNN>-<slug>`，若远程已存在同名分支，尝试 `-2`、`-3` 后缀并记录最终 branch 到 state。
+- `bun test` 执行路径：在新 worktree 根目录运行；默认不在 CLI 内执行 `bun install`，依赖仓库已有 Bun 安装和 lockfile。若缺依赖，按 test 失败记录并提示用户修复。
+- 并发批次：v1 假设一次只有一个同步流程，固定状态文件为 `.context/galeharness-cli/upstream-sync/state.json`。多批次并发后续另行规划。
+- failed 恢复粒度：从 `failed_at` 阶段重新执行，并继续所有后续阶段；不会从 F1 顶部重跑已成功阶段，除非状态缺失导致无法安全恢复。
+- 需求文档中 Success Criteria 的“完整预览整个 14-commit 流程”与 R16 更新冲突：本计划以更新后的 R16 为准，v1 只做单步 dry-run。
+- `resume` merged 后的默认行为：只推进 `.upstream-ref`、清理资源、标记当前 commit merged、推进 `current_index`，然后回到 `idle` 或 `complete`；不自动调用下一轮 `next`。
+- worktree 基准分支选择：`base_branch` 是 state 字段，默认来自已验证 remote 的 default branch，也可用 `--base` 显式指定；不得隐式依赖当前 shell 所在分支。
+
+### Deferred to Implementation
+
+- `generate-batch.py` 是否需要输出机器可读 manifest：计划可以先解析 `commit-range.txt` 和目录结构；若实现中解析脆弱，再小幅扩展生成脚本输出 `manifest.json`。
+- PR 创建失败后的 retry 细节：实现时按 `failed_at: "pr_create"` 重试，并确保不会重复 push 同一分支或重复创建 PR。
+- `state.json` 写入 helper 名称：计划要求临时文件 + rename 原子写入；具体 helper 名称由实现阶段决定。
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+    [*] --> uninitialized
+    uninitialized --> idle: init writes batch + state.json
+    idle --> in_progress: next
+    in_progress --> failed: patch_check/test/push/pr error
+    failed --> in_progress: resume from failed_at
+    failed --> idle: skip
+    in_progress --> awaiting_human_review: PR created
+    awaiting_human_review --> awaiting_human_review: resume sees PR open
+    awaiting_human_review --> idle: resume sees PR merged and advances index
+    awaiting_human_review --> failed: resume sees PR closed without merge
+    idle --> complete: current_index past queue end
+    complete --> [*]
+```
+
+```text
+init
+  -> run/consume generate-batch.py
+  -> build queue from commit-range + raw/adapted patches
+  -> write state.json (primary source of truth)
+
+next
+  -> load current pending commit from state.json
+  -> create worktree + branch
+  -> git apply --check adapted patch
+  -> git apply adapted patch
+  -> bun test
+  -> git commit + push
+  -> gh pr create
+  -> state = awaiting_human_review
+
+resume
+  -> if state = failed: retry from failed_at
+  -> if state = awaiting_human_review:
+       gh pr view
+       merged -> reconcile .upstream-ref + cleanup + current_index += 1 + idle/complete
+       open   -> report and keep waiting
+       closed -> report and require skip --force-cleanup or manual intervention
+
+skip
+  -> optionally cleanup worktree + remote branch
+  -> mark current commit skipped + current_index += 1
+  -> exit without starting next
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1[U1 State schema and CLI shell]
+    U2[U2 init batch ingestion]
+    U3[U3 status and dry-run]
+    U4[U4 next pipeline]
+    U5[U5 resume and reconciliation]
+    U6[U6 skip and cleanup]
+    U7[U7 compound-sync docs]
+
+    U1 --> U2
+    U1 --> U3
+    U2 --> U4
+    U3 --> U4
+    U4 --> U5
+    U4 --> U6
+    U5 --> U6
+    U5 --> U7
+    U6 --> U7
+```
+
+- [ ] U1. **状态模型与 CLI 基础骨架**
+
+**Goal:** 建立 `sync-cli.py` 的子命令结构、状态 schema、原子读写、操作日志和通用外部命令执行封装。
+
+**Requirements:** R2, R3/R12, R16, R19, R20
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/upstream-sync/sync-cli.py`
+- Create: `tests/upstream-sync-cli-state.test.ts`
+- Modify: `scripts/upstream-sync/generate-batch.py`（仅当状态初始化需要更稳定的机器可读 batch metadata）
+
+**Approach:**
+- 使用 Python `argparse` 实现 `init/status/next/resume/skip` 子命令和全局 `--dry-run`。
+- CLI 启动时解析 main worktree root：优先通过 `git worktree list --porcelain` 或 `git rev-parse --git-common-dir` 找到当前 repository 的 common git dir 和主 worktree。所有 workflow 文件路径都相对 main worktree root，不相对当前 shell cwd。
+- 定义 `state.json` 顶层字段：`schema_version`、`main_worktree_root`、`target_repo_root`、`batch_dir`、`baseline_sha`、`target_sha`、`base_branch`、`remote_name`、`github_repo`、`current_index`、`workflow_state`、`commits[]`、`operations[]`。
+- commit 条目至少记录：`sequence`、`sha`、`subject`、`raw_patch`、`adapted_patch`、`status`、`worktree_path`、`branch`、`base_branch`、`pr_url`、`pr_number`、`pr_head_ref`、`pr_base_ref`、`failed_at`、`failure_summary`。
+- 明确枚举合法状态：workflow_state 使用 `uninitialized | idle | in_progress | awaiting_human_review | failed | complete`；commit status 使用 `pending | in_progress | awaiting_human_review | merged | failed | skipped`。
+- `complete` 是唯一批次完成状态；`current_index >= commits.length` 时必须写 `workflow_state: "complete"`，仍有 pending commit 时才允许 `idle`。
+- 在 state 中记录每个阶段的完成标记或最近成功阶段，让 failed `resume` 可以判断哪些副作用已经发生，尤其是 `commit`、`push`、`pr_create` 这类不可盲目重复的阶段。
+- 写状态时使用临时文件 + rename，读状态时做 schema/version/path 存在性校验。
+- 所有外部命令通过统一 wrapper 捕获 exit code、stdout、stderr 和阶段名，失败时转换为状态更新与中文提示。wrapper 必须使用 argv 数组、`shell=False`、显式 cwd；路径参数 resolve 后必须位于允许根目录内。
+- 输出和日志写入前执行安全处理：stdout/stderr 进入 state 前截断并 redaction token、Authorization、`GH_TOKEN`、`GITHUB_TOKEN`、basic-auth URL 和 home 绝对路径；完整日志文件权限使用 `0600`。
+- command runner 要支持测试注入 fake outputs；测试不应依赖真实 GitHub 远程或真实 `gh` 认证。
+
+**Patterns to follow:**
+- `scripts/upstream-sync/generate-batch.py` 的 Python 风格和错误封装
+- `docs/solutions/best-practices/prefer-python-over-bash-for-pipeline-scripts-2026-04-09.md`
+- `docs/solutions/agent-friendly-cli-principles.md`
+
+**Test scenarios:**
+- Happy path: 新状态写入后再次读取，字段完整、路径保持 repo-relative 或可移植相对值，`operations` 只保留最近可展示记录。
+- Edge case: `state.json` 不存在时，`status` 输出未初始化提示，`next/resume/skip` 给出需要先运行 `init` 的错误。
+- Edge case: `state.json` JSON 非法或 schema_version 不支持时，CLI 快速失败并提示备份/修复路径，不覆盖原文件。
+- Error path: 外部命令 wrapper 收到非零 exit 时，记录阶段、摘要和日志路径/输出片段。
+- Edge case: `state.json` 中 workflow_state 与当前 commit status 不一致时，CLI 报告状态损坏并提示人工检查，而不是猜测推进。
+- Edge case: 从 linked worktree 执行 `status/resume/skip` 时仍读写 main worktree 下同一份 `state.json`，不会在 linked worktree 中创建第二份状态。
+- Edge case: `state.json` 缺失但存在 `upstream-sync-*` worktree、branch 或 PR 时，`status/init` 不盲目重建状态，输出需要人工 recover/reinit 的提示。
+- Error path: command runner 拒绝 shell 字符串命令、未验证 cwd、越界路径和未脱敏日志写入。
+- Integration: fake command runner 可以驱动同一 pipeline 走到 `patch_check`、`test`、`push`、`pr_create` 等失败阶段，并验证 state 中的 `failed_at`。
+- Integration: 在临时 repo 中执行基础 `status`，stdout 为中文，失败诊断在 stderr，退出码语义稳定。
+
+**Verification:**
+- 实现者可以用最小 fixture 初始化、读取和更新状态，且任意失败都能追溯到明确阶段和最近操作日志。
+
+---
+
+- [ ] U2. **`init` 批次生成与状态初始化**
+
+**Goal:** 让 `init` 成为同步批次的唯一 patch 生成入口，调用现有 batch 生成能力并把 batch 转换为 `state.json` 队列。
+
+**Requirements:** R1, R2, R4, R13, R14, R19, AE1
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `scripts/upstream-sync/sync-cli.py`
+- Modify: `scripts/upstream-sync/generate-batch.py`（仅当需要机器可读 manifest 或更稳定输出）
+- Create: `tests/upstream-sync-cli-init.test.ts`
+- Modify: `tests/fixtures/upstream-sync/expected-batch/`（如新增 manifest fixture）
+
+**Approach:**
+- `init` 解析 `.upstream-ref`、`.upstream-repo`，调用 `generate-batch.py` 生成 raw/adapted batch；若 batch 已存在，要求显式 `--force` 或复用明确指定 batch。
+- `init` 解析并记录 `base_branch`、`remote_name`、`github_repo` 和 main worktree root；默认 base 来自已验证 remote default branch，可用 `--base <branch>` 覆盖。
+- 从 `commit-range.txt` 和 `raw/`、`adapted/` 文件构建 commit 队列，所有条目初始为 `pending`。
+- 写入 `baseline_sha`、`target_sha`、`batch_dir`、`current_index: 0`、`workflow_state: "idle"`。
+- 如果 `state.json` 已存在且仍有未完成同步，默认拒绝覆盖并提示 `status` 或显式重置方式，避免误删现场。
+- 如果 `state.json` 缺失但检测到现有 `upstream-sync-*` 分支、worktree 或 open PR，默认拒绝 `init`，提示人工确认并使用明确 recover/reinit 流程，避免重复创建已处理工作。
+- `init` 生成全量 patch 后要记录 patch batch 的 base 不变量：每个 adapted patch 的来源 upstream SHA、生成时 baseline、预期应用顺序。测试必须覆盖连续 commit 修改相邻区域的场景；若预生成 patch 无法稳定应用，v1 改为 merged 后重新生成下一条 commit 的 patch。
+- `init --dry-run` 只输出会生成的 batch 路径、baseline、预计 commit 范围和状态文件路径，不创建目录或状态文件。
+
+**Patterns to follow:**
+- `scripts/upstream-sync/generate-batch.py`
+- `tests/upstream-sync-generate-batch.test.ts`
+- `docs/solutions/workflow-issues/upstream-sync-per-commit-configuration.md`
+
+**Test scenarios:**
+- Covers AE1. Happy path: upstream 比 `.upstream-ref` 多 3 个 commit 时，`init` 生成 batch 和 `state.json`，随后 `status` 显示 3 个 pending commits、当前状态 idle、下一个为 0001。
+- Happy path: `init --dry-run` 输出 batch_dir、state_path、baseline 和将处理的 commit 数，不创建 `.context/galeharness-cli/upstream-sync/state.json`。
+- Edge case: 已存在未完成 `state.json` 时，再次 `init` 拒绝覆盖，并提示查看 `status`。
+- Edge case: `state.json` 缺失但存在 sync 命名族 branch/worktree/open PR 时，`init` 拒绝盲目初始化并提示人工 recover。
+- Edge case: `generate-batch.py` 返回 “No new upstream commits” 时，`init` 不写空队列状态，并输出无需同步。
+- Error path: `.upstream-repo` 指向 URL 或无效目录时，错误提示沿用/包装现有配置指引。
+- Integration: `init` 生成的 state commit 数与 adapted patch 文件数一致，缺失 raw/adapted 配对时快速失败。
+- Integration: 两个连续 upstream commit 修改同一文件同一区域附近时，`init` 预生成 patch 后，连续 `next/resume/next` 能正确应用；若不能，应落回逐轮再生成策略。
+
+**Verification:**
+- `init` 后状态文件足以驱动后续 `next`。如果预生成 adapted patch 的累计应用不变量成立，后续不需要重新扫描 upstream 或再次生成 patch；如果不成立，状态文件必须记录每轮 merged 后重新生成/适配下一条 commit 所需的输入。
+
+---
+
+- [ ] U3. **`status` 与单步 `--dry-run` 输出契约**
+
+**Goal:** 提供人类可读且 agent 可解析的状态查看和单步预览能力，明确 dry-run 不执行副作用。
+
+**Requirements:** R3/R12, R16, R20, AE1, AE5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `scripts/upstream-sync/sync-cli.py`
+- Create: `tests/upstream-sync-cli-status.test.ts`
+- Create: `tests/upstream-sync-cli-dry-run.test.ts`
+
+**Approach:**
+- `status` 输出同步概览、baseline -> target、进度百分比、commit 队列、当前 workflow_state、下一个 commit、最近 3 条操作日志。
+- 为 `status` 提供 `--json`，字段直接来自 `state.json`，减少 agent 解析中文表格的成本。
+- `next --dry-run` 输出将消费的 adapted patch、raw patch、worktree 名、branch 名、测试命令、commit message、PR 标题，不创建 worktree、不写状态。
+- `resume --dry-run` 输出会检查的 PR、可能的 merged/open/closed 分支处理；merged 路径只预览 baseline/index 推进、cleanup 和最终 `idle/complete`，不预览自动 `next`。
+- `skip --dry-run` 输出将被标记 skipped 的 commit 和 `--force-cleanup` 会清理的资源，不推进指针。
+
+**Patterns to follow:**
+- `docs/solutions/agent-friendly-cli-principles.md`
+
+**Test scenarios:**
+- Covers AE1. Happy path: 有 14 个 pending commits 的状态中，`status` 输出总数、当前 idle、下一个 0001 和最近操作日志。
+- Covers AE5. Happy path: `next --dry-run` 输出 patch 路径、worktree 名、测试命令和 PR 标题，执行后 state 文件未变化且无 worktree 创建。
+- Edge case: 当前状态为 `awaiting_human_review` 时，`next --dry-run` 拒绝并提示需要 `resume` 或 `skip`。
+- Edge case: `status --json` 输出合法 JSON，并包含 `workflow_state`、`current_index`、`commits`、`next_commit`。
+- Error path: 当前 index 越界或队列为空时，status 输出已完成或状态损坏提示，而不是 traceback。
+
+**Verification:**
+- 人类可以从 `status` 直接知道下一步命令；agent 可以从 `status --json` 获取同样状态而无需解析 prose。
+
+---
+
+- [ ] U4. **`next` 单 commit 自动化 pipeline**
+
+**Goal:** 让 `next` 对当前 pending commit 完成 worktree 创建、patch 预检/应用、测试、commit、push、PR 创建，并在 PR 后暂停。
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R9b, R10, R14, R19, R20, AE2, AE3
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `scripts/upstream-sync/sync-cli.py`
+- Create: `tests/upstream-sync-cli-next.test.ts`
+- Modify: `tests/fixtures/upstream-sync/sample-patches/`（如需新增冲突/成功 patch）
+
+**Approach:**
+- `next` 只允许在 `workflow_state: "idle"` 且当前 commit `status: "pending"` 时运行。
+- worktree 名和 branch 名使用 `upstream-sync-<batch-date>-<NNNN>-<slug>`，远程分支冲突时尝试 `-2`、`-3` 后缀并写入 state。
+- branch/worktree slug 必须经 ASCII 白名单和长度限制生成；commit subject 只能作为 commit message/PR title 参数传入，不得参与 shell 字符串或未校验路径。
+- 创建 worktree 前 fetch state 中的 `remote_name/base_branch`，并从该远程 base 创建 worktree；不得从当前 shell 分支推断 base。
+- 创建 worktree 后立即重新读取 worktree 当前分支和 repo root，并把实际值写入 state；后续 push/PR 只使用 state 中确认过的 branch，不使用早期推导值。
+- patch 阶段先执行 `git apply --check`，失败时记录 `failed_at: "patch_check"`、raw/adapted patch 路径、冲突摘要，状态改为 `failed`。
+- patch 应用后运行 `bun test`；测试失败记录 `failed_at: "test"`、测试输出摘要和日志路径，不创建 PR。
+- 测试通过后提交，commit message 使用 `sync(upstream): <upstream subject>`，随后 push 到已验证 remote，并用 `gh pr create --repo <owner/repo> --base <base_branch> --head <branch>` 创建 PR。
+- PR 创建成功后写入 `pr_url`/`pr_number`、`pr_head_ref`、`pr_base_ref`、`github_repo`，commit 状态为 `awaiting_human_review`，workflow_state 同步为 `awaiting_human_review`，CLI 明确暂停。
+
+**Execution note:** 建议先写失败路径和 dry-run 的 characterization 测试，再接入真实外部命令执行，以防重复创建 worktree、branch 或 PR。
+
+**Patterns to follow:**
+- `scripts/upstream-sync/apply-patch-to-worktree.sh`
+- `tests/upstream-sync-apply-patch.test.ts`
+- `docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines-2026-03-27.md`
+
+**Test scenarios:**
+- Covers AE2. Happy path: 当前 commit pending，模拟 patch 成功、`bun test` 成功、commit/push/PR 成功后，state 进入 `awaiting_human_review`，包含 PR 链接并暂停。
+- Covers AE3. Error path: patch check 冲突时，state 进入 `failed`，`failed_at` 为 `patch_check`，输出 raw/adapted patch 路径，不执行 patch apply/test/PR。
+- Error path: `bun test` 失败时，state 进入 `failed`，`failed_at` 为 `test`，没有 commit、push 或 PR 信息。
+- Error path: push 失败或 PR 创建失败时，记录对应 `failed_at`，保留 worktree 和 branch 信息供人工修复。
+- Edge case: 远程已有同名 branch 时，CLI 生成后缀分支名并将最终分支写入 state。
+- Edge case: 当前 shell 分支不是目标 base 时，`next` 仍从 state 中的 `base_branch` 创建 worktree 和 PR。
+- Error path: GitHub repo、remote URL、`gh auth status` 主体或 PR base/head 与 state 不一致时，`next` 拒绝 push/PR 并提示人工检查。
+- Edge case: worktree 创建成功但 branch checkout 失败时，记录 `failed_at: "worktree_create"`，不继续 patch 阶段，并保留可清理路径。
+- Integration: `next` 成功到 PR 创建后，再次执行 `next` 必须拒绝，避免在 awaiting review 状态重复创建 PR。
+- Edge case: 当前 commit 不是 pending 或 workflow_state 不是 idle 时，`next` 拒绝执行并提示正确命令。
+- Integration: 使用临时本地 bare remote 和 fixture patch，验证真实 worktree 创建、patch 应用、commit 生成和状态推进。
+
+**Verification:**
+- 每次 `next` 最多处理一个 upstream commit，成功后必然停在 PR review 交接点，失败后必然有可恢复的 `failed_at`。
+
+---
+
+- [ ] U5. **`resume` PR 状态对账与 failed 恢复**
+
+**Goal:** 让 `resume` 同时承担人类验收后的推进、PR open/closed 状态解释，以及 failed 阶段的精准重试。
+
+**Requirements:** R2, R10, R11, R15, R19, AE4
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `scripts/upstream-sync/sync-cli.py`
+- Create: `tests/upstream-sync-cli-resume.test.ts`
+
+**Approach:**
+- 当 workflow_state 为 `failed` 时，`resume` 从当前 commit 的 `failed_at` 阶段重新执行，并继续后续阶段；如果人工已在 worktree 中修复 patch 或测试，重试应复用 state 中记录的 worktree/branch。
+- 当 workflow_state 为 `awaiting_human_review` 时，`resume` 使用 `gh pr view` 查询 PR 状态，并区分 merged/open/closed without merge。
+- merged 路径先用 `.upstream-repo` 内的 ancestry 判断对账 `state.json` 和 `.upstream-ref`：ref 不存在、为空或非法 SHA 时 fatal；ref 等于当前 upstream SHA 时只修复 state；ref 是当前 SHA 的祖先时写入当前 SHA；ref 是当前 SHA 的后代时只修复 state 并记录 warning；ref 与当前 SHA 不在同一 upstream 历史或 state baseline 不匹配时拒绝推进。
+- merged 后先确认 PR repo、headRefName、baseRefName 与 state 中记录的 `github_repo`、branch、`base_branch` 一致，再清理 worktree；随后标记 commit 为 `merged`，`current_index += 1`。若还有 pending commit，设置 `workflow_state: "idle"` 并提示用户显式执行 `next`；若队列结束，设置 `workflow_state: "complete"`。
+- open 路径只输出当前 PR 状态，保持 `awaiting_human_review`，不推进 index。
+- closed without merge 路径输出警告，保持/转为需处理状态，提示 `skip --force-cleanup` 或人工处理，不自动跳过。
+
+**Execution note:** PR 状态查询和 `.upstream-ref` 写入要用状态机测试覆盖，避免把 open/closed 当作普通命令失败。
+
+**Patterns to follow:**
+- `docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines-2026-03-27.md`
+
+**Test scenarios:**
+- Covers AE4. Happy path: PR 已 merged 时，`resume` 更新 `.upstream-ref` 为当前 upstream SHA、清理 worktree、标记 merged、推进 index；还有 pending commit 时回到 `idle` 并提示 `next`，队列结束时进入 `complete`。
+- Happy path: failed_at 为 `test` 且人工修复后，`resume` 重新运行测试，通过后继续 commit/push/PR 创建。
+- Edge case: PR 仍 open 时，`resume` 输出 “PR #N is still open” 类提示，state 保持 `awaiting_human_review`，index 不变。
+- Edge case: PR closed without merge 时，`resume` 输出警告和 `skip --force-cleanup` 建议，不写 `.upstream-ref`。
+- Edge case: `.upstream-ref` 已经是当前 commit SHA 时，`resume` 修复 state 并继续清理，而不是重复报错。
+- Edge case: `.upstream-ref` 是 current SHA 的祖先、后代、非法 SHA 或分叉 SHA 时分别按 reconciliation 状态表处理。
+- Edge case: `gh pr view` 返回的 headRefName 与 state branch 不一致时，`resume` 拒绝推进并提示人工检查，避免错误 PR 推进 baseline。
+- Edge case: `gh pr view` 返回的 repo/baseRefName 与 state 不一致时，`resume` 拒绝推进。
+- Edge case: PR merged 但 worktree 已被人工删除时，baseline 和 state 仍可推进，cleanup 记录 warning。
+- Error path: `gh pr view` 网络或认证失败时，记录 `failed_at: "pr_status"` 或保持等待状态并给出认证/重试提示。
+- Integration: 使用 mockable command runner 或 fake `gh` executable 验证 merged/open/closed 三分支不会混淆。
+
+**Verification:**
+- `resume` 在 awaiting review 状态不会误推进 open/closed PR；在 failed 状态不会重跑已完成阶段导致重复副作用。
+
+---
+
+- [ ] U6. **`skip` 指针推进与 `--force-cleanup`**
+
+**Goal:** 明确跳过语义：只标记当前 commit skipped 并推进指针，必要时清理远程分支和 worktree，但不自动处理下一个 commit。
+
+**Requirements:** R17, R18, R19
+
+**Dependencies:** U4, U5
+
+**Files:**
+- Modify: `scripts/upstream-sync/sync-cli.py`
+- Create: `tests/upstream-sync-cli-skip.test.ts`
+
+**Approach:**
+- `skip` 要求当前 commit 处于 pending/failed/closed-review 可处理状态；如果处于 awaiting open PR，默认拒绝并提示先确认 PR 状态或使用明确参数。
+- 默认 `skip` 只写 state：当前 commit `status: "skipped"`，记录 reason（若提供），`current_index += 1`，workflow_state 回到 `idle` 或 `complete`。
+- `skip --force-cleanup` 根据 state 中的 `worktree_path`、`branch`、`pr_url` 清理本地 worktree 和远程 branch；清理前必须向 git/GitHub 重新验证目标，清理失败时记录失败并提示人工命令。
+- cleanup 必须幂等：worktree 或远程分支不存在时记录 warning，但不阻止 skip 完成，除非无法判断目标资源。
+- cleanup 前必须校验目标 branch 仍匹配 `upstream-sync-<date>-<NNNN>-<slug>` 命名族，并且不等于默认分支；校验失败时拒绝自动删除。
+- cleanup worktree 前必须 resolve `worktree_path`，确认它通过 `git worktree list --porcelain` 属于当前 target repo，不是 repo root、home、上级目录，也没有通过 symlink 跳出允许根；删除前校验 worktree HEAD/branch 与 state commit/branch 匹配。
+- cleanup 远程分支前必须验证 state 中的 `github_repo`、PR number、headRefName、headRepository 和 remote URL 匹配，只删除该 PR head 对应的 sync 前缀分支。
+- 执行结束输出“已跳过；如需继续，请执行 `next`”，不自动调用 next。
+
+**Patterns to follow:**
+- `scripts/upstream-sync/apply-patch-to-worktree.sh` 的安全失败提示
+- `docs/solutions/agent-friendly-cli-principles.md`
+
+**Test scenarios:**
+- Happy path: failed commit 执行 `skip --reason "manual reject"` 后，状态变为 skipped，index 前进，workflow_state 为 idle，未触发 next。
+- Happy path: closed PR 场景执行 `skip --force-cleanup`，删除 worktree、尝试删除远程 branch，并记录 cleanup 操作。
+- Edge case: cleanup 目标已不存在时，skip 仍完成并记录 warning。
+- Edge case: 当前 PR 仍 open 时，无 `--force-cleanup` 的 skip 拒绝或要求明确确认，避免误跳过仍在 review 的工作。
+- Error path: state 中 branch 缺失、branch 不符合 sync 命名族或疑似默认分支时，`skip --force-cleanup` 拒绝删除远程分支，只记录需要人工处理。
+- Error path: state 中 worktree_path 指向 repo root、home、仓库外路径、非当前 repo worktree 或 branch/HEAD 不匹配时，拒绝删除并输出人工处理命令。
+- Error path: remote URL、GitHub repo、PR headRefName 或 headRepository 与 state 不一致时，拒绝删除远程分支。
+- Error path: 无法删除远程 branch 时，状态记录 cleanup failure 和下一步提示，不静默吞掉。
+- Integration: 执行 skip 后再次运行 `status`，下一个 commit 显示为待处理，但不会自动创建 worktree。
+
+**Verification:**
+- skip 是显式、可审计、可恢复的人工决策，不会因为跳过一个 commit 立刻产生新的副作用。
+
+---
+
+- [ ] U7. **compound-sync SKILL 与文档更新**
+
+**Goal:** 在 CLI 完成后更新上层 `compound-sync` 使用说明，让 skill 引导用户使用新 CLI，而不是继续执行手动 patch 流程。
+
+**Requirements:** R13, R14, R15, R17, R18, R20
+
+**Dependencies:** U5, U6
+
+**Files:**
+- Modify: `plugins/galeharness-cli/skills/compound-sync/SKILL.md`
+- Modify: `plugins/galeharness-cli/README.md`（如需记录新 workflow inventory）
+- Create or Modify: `docs/solutions/workflow-issues/upstream-sync-per-commit-configuration.md`（如实现改变操作方式）
+- Test: `tests/upstream-sync-cli-*.test.ts` 覆盖即足够；文档无单独测试，除非 release validation 需要
+
+**Approach:**
+- 将 `compound-sync` workflow 改为：读 baseline -> `sync-cli.py init` -> `status` -> `next` -> 人类 review -> `resume` 或 `skip`。
+- 保留 HKTMemory patch re-apply 提醒，因为 CLI 只处理机械同步，不替代人工业务适配。
+- 文档中明确 `.upstream-ref` 不再手动更新；由 `resume` 在 PR merged 后对账并写入。
+- 增加 PR closed/open、failed resume、skip `--force-cleanup` 的简短操作指引。
+- 若 README 或 marketplace 描述涉及技能行为/inventory，按仓库规则更新，但不手动 bump release-owned versions。
+
+**Patterns to follow:**
+- `plugins/galeharness-cli/skills/compound-sync/SKILL.md`
+- AGENTS.md Plugin Maintenance 规则
+
+**Test scenarios:**
+- Test expectation: none -- 这是文档/skill 指引更新，行为由 U1-U6 的 CLI 测试覆盖。
+
+**Verification:**
+- 用户从 `compound-sync` skill 可以完成新 CLI 工作流，不会再被指引去手动逐步更新 `.upstream-ref`。
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `sync-cli.py` 会协调 `generate-batch.py`、`adapt-patch.py`、git worktree、`bun test`、git commit/push、`gh pr create/view`、`.upstream-ref` 和 `state.json`。这些外部命令必须通过统一状态转移封装，使用 argv + verified cwd 执行，不能散落调用。
+- **Error propagation:** 外部命令非零退出不应直接 traceback 给用户；应转换为 `failed_at`、failure summary、相关路径和下一步建议。真正状态损坏或 schema 不兼容才应作为 fatal error。
+- **State lifecycle risks:** `state.json` 与 `.upstream-ref` 是双文件状态，必须在 `resume` merged 路径用 upstream ancestry 对账。写 `state.json` 使用原子替换，写 `.upstream-ref` 只在 PR merged 后发生。若 `state.json` 缺失但检测到 sync branch/worktree/PR，CLI 不应盲目重建状态。
+- **Trust boundaries:** state 是 workflow 事实来源，但 cleanup、push、PR 查询和远程分支删除必须重新向 git/GitHub 验证目标。日志和 state 输出必须脱敏、截断并限制权限，避免把 token、本机路径或认证信息持久化。
+- **Base and worktree resolution:** 所有 workflow 文件相对 main worktree root；所有工作分支从 state 中的 `base_branch` 创建。linked worktree 中执行命令、当前 shell 分支和 stale local default branch 都不能改变状态文件位置或 PR base。
+- **API surface parity:** 该功能暂不进入 `src/index.ts` 主 CLI，因此无需同步所有 provider converter/writer。若未来进入正式 `gale-harness` CLI，需要另起计划覆盖命令帮助、release docs 和 binary build。
+- **Integration coverage:** 纯 unit test 不足以证明 git/gh/worktree 状态机，需要临时 git repo、fake command runner/fake `gh`、fixture patch 的集成测试覆盖成功、冲突、测试失败、PR open/closed/merged、linked worktree 执行、base branch 错配、state 丢失和 cleanup 目标错配。
+- **Unchanged invariants:** `generate-batch.py` 仍负责 raw/adapted patch 批量生成；`adapt-patch.py` 仍只做机械改写；人工业务适配和 review 决策不被 CLI 自动化。
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `state.json` 和 `.upstream-ref` 双写崩溃导致状态分叉 | `resume` merged 前后都用 upstream ancestry 对账；state 作为主要事实来源，`.upstream-ref` 作为派生 baseline 写入 |
+| `state.json` 丢失或损坏后重复创建 PR | 检测现有 `upstream-sync-*` worktree/branch/PR，拒绝盲目 `init`，提示 recover/reinit |
+| failed resume 重跑阶段造成重复 push 或重复 PR | 每个阶段成功后立即写 state；恢复从 `failed_at` 开始，并在 push/PR 阶段先检查 state 中已有 branch/PR |
+| `gh pr view` open/closed/merged 输出解析不稳定 | 使用 `--json state,merged,url,number,headRefName` 之类结构化输出；测试用 fake `gh` 覆盖三状态 |
+| `gh` 或 remote 指向错误仓库 | `init/next` 记录并验证 `github_repo`、remote URL、auth 主体和 base/head；所有 `gh` 调用显式传 `--repo` |
+| 当前 shell 分支或 linked worktree 改变 state/base 解析 | 启动时解析 main worktree root；`base_branch` 写入 state，`next/resume` 只用 state 字段 |
+| 预生成 adapted patch 在累计 merge 后失效 | 用连续 commit 修改相邻区域的 fixture 验证；若不可靠，改为每轮 merged 后重新生成/适配下一条 commit |
+| 分支名冲突导致 push 覆盖或失败 | 远程检查后生成 `-2`、`-3` 后缀；最终 branch 写入 state，后续 resume/cleanup 只信 state |
+| `bun test` 时间长或环境缺依赖 | v1 按需求运行完整 `bun test`；失败记录为 test 阶段并提示人工修复，不自动 install |
+| CLI 和已有 shell apply 脚本行为漂移 | 复用相同预检语义和测试 fixture；如 Python 内实现 patch apply，也用现有脚本测试场景做回归 |
+| 命令注入或错误 cwd 导致副作用越界 | command runner 只接受 argv 数组、禁用 shell、显式 verified cwd；slug/path 做白名单和 resolve 校验 |
+| 日志泄露 token 或本机敏感路径 | stdout/stderr 入 state 前截断和 redaction；完整日志权限使用 `0600` |
+| `skip --force-cleanup` 删除错误资源 | cleanup 只使用 state 中记录的 worktree/branch 作为候选，并通过 git/GitHub 重新验真；缺少明确目标时拒绝 destructive cleanup |
+
+---
+
+## Documentation / Operational Notes
+
+- 更新 `plugins/galeharness-cli/skills/compound-sync/SKILL.md` 后，若技能 inventory 或 usage 描述有实质变化，运行 release validation。
+- 新 CLI 是内部 workflow 工具，建议在文档中以 `python3 scripts/upstream-sync/sync-cli.py <command>` 形式呈现，不承诺为公开 `gale-harness` 子命令。
+- 状态文件位于 main worktree root 下的 `.context/galeharness-cli/upstream-sync/state.json`，不进入 Git；批次 patch 目录仍是本地工作流状态。
+- 实现完成后，至少运行 upstream-sync 相关 Bun tests；若改动 skill 或插件 metadata，再运行 `bun run release:validate`。
+
+---
+
+## Sources & References
+
+- **Origin document:** [brainstorms/2026-04-23-upstream-sync-cli-automation-requirements.md](../brainstorms/2026-04-23-upstream-sync-cli-automation-requirements.md)
+- Related plan: [plans/2026-04-21-001-feat-upstream-sync-per-commit-patch-workflow-plan.md](2026-04-21-001-feat-upstream-sync-per-commit-patch-workflow-plan.md)
+- Related code: `scripts/upstream-sync/generate-batch.py`
+- Related code: `scripts/upstream-sync/apply-patch-to-worktree.sh`
+- Related tests: `tests/upstream-sync-generate-batch.test.ts`
+- Related tests: `tests/upstream-sync-apply-patch.test.ts`
+- Institutional learning: `docs/solutions/best-practices/prefer-python-over-bash-for-pipeline-scripts-2026-04-09.md`
+- Institutional learning: `docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines-2026-03-27.md`
+- Institutional learning: `docs/solutions/agent-friendly-cli-principles.md`
+- Institutional learning: `docs/solutions/workflow-issues/upstream-sync-per-commit-configuration.md`

--- a/docs/plans/2026-04-24-001-feat-upstream-sync-cli-automation-plan.md
+++ b/docs/plans/2026-04-24-001-feat-upstream-sync-cli-automation-plan.md
@@ -31,7 +31,12 @@ deepened: 2026-04-24
 
 这不是只为一次 14-commit 批处理写临时脚本：GaleHarnessCLI 会持续 vendored upstream HKTMemory，并且每次 upstream 拉取都要重复同一组 worktree、patch、测试、PR、baseline 对账动作。v1 仍放在 `scripts/upstream-sync/` 内，避免过早产品化到顶层 CLI；但用显式状态机和可恢复命令，是为了降低后续每次同步的认知负担和重复出错率。
 
-更新后的需求进一步明确了几个规划约束：`init` 负责批量生成 patch，`next` 不再现场生成 patch；`resume` 必须覆盖 merged/open/closed 三种 PR 状态，并支持从 failed 恢复；`skip` 只推进指针，不自动开始下一个 commit；`--dry-run` 是单步预览；`state.json` 是主要事实来源，`.upstream-ref` 是派生状态。
+更新后的需求进一步明确了几个规划约束：
+
+- **F1 逐 Commit 同步主流程**：触发命令为 `sync-cli.py next`；CLI 读取状态文件的 `current_index`，从 `init` 阶段已生成的 `adapted/` 目录消费 patch（不再现场生成）；新增 `git apply --check` 预检步骤（步骤4），通过后才应用 patch。Covered by: R1, R2, R4, R5, R7, R9, R10, R13。
+- **F2 人类验收后继续**：触发命令为 `sync-cli.py resume`；`resume` 处理三种 PR 状态——已 merge（执行推进流程）、未 merge/open（输出状态，保持等待）、已关闭/拒绝（警告，提示 `skip --force-cleanup`）；新增 CLI 对账 `state.json` 与 `.upstream-ref` 的步骤；merged 后将 commit 状态更新为 `merged`，`current_index += 1`。需求 F2 步骤6 指定 resume 在 merged 后自动进入下一个 commit 的 F1 流程，但本计划选择不自动调用 `next`（见 Scope Boundaries 说明）。Covered by: R11, R13, R14。
+- **F3 失败处理与人工接管**：失败时记录 `failed_at` 字段和失败阶段；`resume` 从失败步骤开始重试（不重跑整个流程），例如 `failed_at: "test"` 时重跑 `bun test`，`failed_at: "patch_check"` 时重跑 `git apply --check`；`skip` 将状态变为 `skipped`。Covered by: R6, R8, R15, R16。
+- **其他约束**：`skip` 只推进指针，不自动 `next`；`--dry-run` 是单步预览；`state.json` 是主要事实来源，`.upstream-ref` 是派生状态。
 
 ---
 
@@ -64,7 +69,7 @@ deepened: 2026-04-24
 ### `resume`
 
 - R11. `resume` 根据 PR merged/open/closed 状态分别推进、继续等待或提示 `skip --force-cleanup`
-- R15. `resume` 从 failed 状态恢复时从失败步骤开始重试，并继续后续步骤
+- R15. `resume` 在人类 merge PR 后继续同步流程；从 `failed` 状态恢复时从失败步骤开始重试（而非重跑完整流程），并继续后续步骤；若 PR 未 merge，输出当前状态并保持等待
 
 ### `dry-run` 与 `skip`
 
@@ -73,8 +78,16 @@ deepened: 2026-04-24
 - R18. `skip --force-cleanup` 清理已推送远程分支和 worktree，然后标记 skipped
 
 **Origin actors:** A1 研发人员（同步执行者），A2 自动化同步 CLI，A3 代码审查者
-**Origin flows:** F1 逐 Commit 同步主流程，F2 人类验收后继续，F3 失败处理与人工接管
-**Origin acceptance examples:** AE1 status 队列检测，AE2 next 创建 PR 并暂停，AE3 patch 冲突失败，AE4 resume after merge，AE5 dry-run 单步预览
+**Origin flows:**
+  F1 逐 Commit 同步主流程 — Trigger: `sync-cli.py next`；含 `git apply --check` 预检；从 `init` 已生成的 `adapted/` 消费 patch；Covered by: R1, R2, R4, R5, R7, R9, R10, R13
+  F2 人类验收后继续 — Trigger: `sync-cli.py resume`；覆盖 merged/open/closed 三种 PR 状态；含 state.json 与 .upstream-ref 对账；merged 后 current_index += 1；Covered by: R11, R13, R14
+  F3 失败处理与人工接管 — 记录 `failed_at`；`resume` 从失败步骤重试；`skip` 变为 skipped；Covered by: R6, R8, R15, R16
+**Origin acceptance examples:**
+  AE1 Covers R1, R3/R12 — status 队列检测
+  AE2 Covers R4, R7, R9, R10 — next 创建 PR 并暂停
+  AE3 Covers R6, R17 — patch 冲突失败（含 `failed_at: "patch_check"` 描述）
+  AE4 Covers R11, R14 — resume after merge
+  AE5 Covers R16 — dry-run 单步预览（只预览 current_index 指向的 commit）
 
 ---
 
@@ -85,7 +98,7 @@ deepened: 2026-04-24
 - 不处理 upstream force-push 导致的历史 SHA 失效；仍假设 upstream 历史线性可追踪。
 - 不支持多个 upstream commit 合并为一个 PR；保持 1:1 commit-to-PR 映射。
 - 不自动 merge PR，也不绕过 review。
-- 不在 `resume` merged 后自动启动下一轮 `next`；用户每次进入新的 commit 副作用流程都必须显式执行 `next`。
+- 不在 `resume` merged 后自动启动下一轮 `next`；用户每次进入新的 commit 副作用流程都必须显式执行 `next`。**与需求文档 F2 的差异**：需求 F2 步骤6 指定"CLI 自动进入下一个 commit 的 F1 流程（除非已到达队列末尾）"，但本计划选择不自动调用 `next`，理由：(1) 每次 `next` 产生 worktree、push、PR 等不可逆副作用，自动链式执行会剥夺用户在 commit 间检查和干预的机会；(2) 保持 `skip`/`next`/`resume` 的正交语义——`resume` 只负责验收推进和 failed 恢复，`next` 只负责启动新的副作用流程；(3) 减少状态机复杂度，避免 `resume` 内部隐式调用 `next` 时嵌套失败导致的恢复路径歧义。
 - 不在 v1 支持全量 14-commit dry-run 计划输出；`--dry-run` 只预览当前命令的单步副作用。
 
 ### Deferred to Follow-Up Work
@@ -134,6 +147,9 @@ deepened: 2026-04-24
 - **`skip` 不触发下一步工作**：`skip` 只标记当前 commit skipped、推进指针并退出，让用户显式执行 `next`，避免跳过后立即进入新的副作用流程。
 - **`--dry-run` 是单步副作用预览**：dry-run 应输出当前命令会读取/写入哪些路径、将创建哪个 worktree/branch、将运行哪些外部命令、将创建什么 PR 标题，但不执行文件写入、worktree 创建、push 或 PR 创建。
 - **CLI 输出中文，人机与 agent 双可读**：默认中文摘要和下一步提示；`status --json` 或全局 `--json` 可作为结构化输出增量，至少在 `status` 和 dry-run 上应提供稳定字段以方便 agent 解析。
+- **"无状态方案"被拒绝**：曾有建议用单次执行命令处理下一个 commit、通过 `.upstream-ref` 隐式追踪进度。此方案被拒绝，因为用户明确要求"每执行完毕后交给人类验收"，无状态方案无法在中断后恢复上下文（如机器重启、会话切换后无法知道当前处理到哪个 commit、PR 链接是什么、worktree 在哪里）。显式状态机是必要的。
+- **1:1 commit-to-PR 映射是不可协商约束**：用户明确要求"独立的一个 commit 一个 commit 的适配然后发到 PR 里"。虽然这带来更多 PR review 周期，但对于机械变更 review 成本极低，对于业务逻辑变更则必须独立 review。该约束作为不可协商的 scope boundary 保留。
+- **`compound-sync` SKILL 将在 CLI 建成后更新**：`plugins/galeharness-cli/skills/compound-sync/SKILL.md` 当前描述手动版工作流，新 CLI 自动化其中的机械步骤。CLI 建设完成后，`compound-sync` SKILL 将更新为引用 `sync-cli.py` 命令而非手动步骤描述。
 
 ---
 
@@ -141,13 +157,13 @@ deepened: 2026-04-24
 
 ### Resolved During Planning
 
-- CLI 实现语言选择：使用 Python，与现有 `scripts/upstream-sync/` 脚本和多步骤编排经验一致；不进入 TypeScript 主 CLI。
-- PR 分支命名策略：使用 `upstream-sync-<date>-<NNNN>-<slug>`，若远程已存在同名分支，尝试 `-2`、`-3` 后缀并记录最终 branch 到 state。
-- `bun test` 执行路径：在新 worktree 根目录运行；默认不在 CLI 内执行 `bun install`，依赖仓库已有 Bun 安装和 lockfile。若缺依赖，按 test 失败记录并提示用户修复。
-- 并发批次：v1 假设一次只有一个同步流程，固定状态文件为 `.context/galeharness-cli/upstream-sync/state.json`。多批次并发后续另行规划。
-- failed 恢复粒度：从 `failed_at` 阶段重新执行，并继续所有后续阶段；不会从 F1 顶部重跑已成功阶段，除非状态缺失导致无法安全恢复。
-- 需求文档中 Success Criteria 的“完整预览整个 14-commit 流程”与 R16 更新冲突：本计划以更新后的 R16 为准，v1 只做单步 dry-run。
-- `resume` merged 后的默认行为：只推进 `.upstream-ref`、清理资源、标记当前 commit merged、推进 `current_index`，然后回到 `idle` 或 `complete`；不自动调用下一轮 `next`。
+- CLI 实现语言选择：使用 Python，与现有 `scripts/upstream-sync/` 脚本和多步骤编排经验一致；不进入 TypeScript 主 CLI。（对应需求文档 Deferred to Planning: CLI 实现语言选择）
+- PR 分支命名策略：使用 `upstream-sync-<date>-<NNNN>-<slug>`，若远程已存在同名分支，尝试 `-2`、`-3` 后缀并记录最终 branch 到 state。此策略已在 R9b 中覆盖。（对应需求文档 Deferred to Planning: PR 分支命名策略）
+- `bun test` 执行路径：在新 worktree 根目录运行；默认不在 CLI 内执行 `bun install`，依赖仓库已有 Bun 安装和 lockfile。若缺依赖，按 test 失败记录并提示用户修复。（对应需求文档 Deferred to Planning: bun test 执行路径）
+- 并发批次：v1 假设一次只有一个同步流程，固定状态文件为 `.context/galeharness-cli/upstream-sync/state.json`。多批次并发后续另行规划。（对应需求文档 Deferred to Planning: 状态文件 schema 与多批次并发）
+- failed 恢复粒度：从 `failed_at` 阶段重新执行，并继续所有后续阶段；不会从 F1 顶部重跑已成功阶段，除非状态缺失导致无法安全恢复。具体示例：`failed_at: "test"` 时重跑 `bun test`，`failed_at: "patch_check"` 时重跑 `git apply --check`。（对应需求文档 Deferred to Planning: resume 从 failed 恢复时的重试粒度）
+- 需求文档中 Success Criteria 的"完整预览整个 14-commit 流程"与 R16 更新冲突：本计划以更新后的 R16 为准，v1 只做单步 dry-run。
+- `resume` merged 后的默认行为：只推进 `.upstream-ref`、清理资源、标记当前 commit merged、推进 `current_index`，然后回到 `idle` 或 `complete`；不自动调用下一轮 `next`。**与需求文档 F2 的差异**：需求 F2 步骤6 指定"CLI 自动进入下一个 commit 的 F1 流程"，但本计划选择不自动调用 `next`，理由见 Scope Boundaries。
 - worktree 基准分支选择：`base_branch` 是 state 字段，默认来自已验证 remote 的 default branch，也可用 `--base` 显式指定；不得隐式依赖当前 shell 所在分支。
 
 ### Deferred to Implementation

--- a/docs/solutions/best-practices/upstream-sync-cli-automation-stateful-pipeline-2026-04-24.md
+++ b/docs/solutions/best-practices/upstream-sync-cli-automation-stateful-pipeline-2026-04-24.md
@@ -1,0 +1,155 @@
+---
+title: "Upstream Sync CLI 自动化：有状态 Pipeline 的设计与实现"
+date: 2026-04-24
+category: best-practices
+module: upstream-sync
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - 需要将上游仓库的逐 commit 变更同步到 fork/下游仓库
+  - 手动逐 patch 同步流程效率低且容易出错
+  - 需要在多步骤 pipeline 中支持失败恢复和断点续传
+tags:
+  - upstream-sync
+  - cli-automation
+  - state-machine
+  - pipeline
+  - python
+  - git-worktree
+---
+
+# Upstream Sync CLI 自动化：有状态 Pipeline 的设计与实现
+
+## Context
+
+GaleHarnessCodingCLI 从上游 compound-engineering-plugin 仓库同步变更，采用逐 commit patch 方式保持历史线性。原有流程依赖 `generate-batch.py` 生成 patch 后手动逐个应用，涉及 worktree 创建、patch 应用、测试、提交、推送、PR 创建等多个步骤。手动操作容易遗漏步骤、丢失状态，且无法从失败中恢复。
+
+本次实现了 `sync-cli.py` 作为半自动化 CLI，通过 `state.json` 持久化工作流状态，将整个流程编排为可中断、可恢复的状态机。
+
+## Guidance
+
+### 1. 状态机驱动的 Pipeline 设计
+
+核心设计是将同步流程建模为显式状态机：
+
+```
+uninitialized → idle → in_progress → awaiting_human_review → idle → ... → complete
+                                    ↘ failed → (resume) → in_progress
+```
+
+每个子命令只负责一次状态转移：
+- `init`: uninitialized → idle
+- `next`: idle → in_progress → awaiting_human_review（或 failed）
+- `resume`: awaiting_human_review → idle/complete（或 failed → in_progress）
+- `skip`: any → idle/complete
+
+**关键决策：resume 不自动触发 next。** merged 后只推进指针和清理，回到 idle 等待用户显式 `next`。这避免了自动化失控——每个 commit 的副作用（worktree、push、PR）都需要人类显式触发。
+
+### 2. 原子状态写入
+
+```python
+def save_state(state: SyncState, state_path: Path):
+    tmp = state_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(asdict(state), indent=2, ensure_ascii=False))
+    tmp.rename(state_path)  # 原子操作
+```
+
+每个 pipeline 阶段成功后立即写 state，防止：
+- 重复 push（push 成功后立即记录，resume 时不会重新 push）
+- 重复创建 PR（pr_create 成功后立即记录 pr_url/pr_number）
+- 状态丢失导致的盲目重试
+
+### 3. 安全的外部命令执行
+
+```python
+def run_cmd(argv: List[str], cwd: Path, *, dry_run=False, redact_patterns=None):
+    # argv 数组，shell=False
+    # cwd 必须 resolve + 存在性检查
+    # stdout/stderr 截断（500 字进入 state）
+    # 脱敏：GH_TOKEN、Authorization、basic-auth URL
+```
+
+安全原则：
+- **永远不拼接 shell 字符串** — 使用 argv 数组 + `shell=False`
+- **显式 verified cwd** — resolve 后检查存在性
+- **日志脱敏** — 敏感信息不进入 state.json
+- **gh 调用显式 --repo** — 防止环境变量或当前目录影响目标仓库
+
+### 4. GitHub 目标验真
+
+`resume` 在处理 merged PR 时：
+1. 校验 PR headRefName/baseRefName 与 state 一致
+2. 用 `git merge-base --is-ancestor` 对账 upstream SHA
+3. 仅对账通过后才写 `.upstream-ref`
+
+`skip --force-cleanup` 不只信 state：
+1. 通过 `git worktree list` 重新验证 worktree 存在
+2. 验证分支名匹配 `upstream-sync-*` 命名族
+3. 验证分支非默认分支
+
+### 5. Main Worktree Root 解析
+
+通过 `git worktree list --porcelain` 解析 main worktree root，支持从 linked worktree 执行 status/resume/skip。state.json 始终位于 main worktree 下的固定路径。
+
+## Why This Matters
+
+- **可恢复性**：任何步骤失败都记录 `failed_at`，resume 从失败点重试而非从头开始
+- **安全性**：显式状态机 + 原子写入 + 命令安全执行 + GitHub 目标验真，防止副作用失控
+- **可审计性**：operations 日志记录每次操作的时间戳和摘要，state.json 是完整的工作流快照
+- **人机协作**：CLI 负责机械操作（worktree/patch/push/PR），人类负责审查决策（merge/skip），通过 awaiting_human_review 状态显式交接
+
+## When to Apply
+
+- 需要将多步骤、有副作用的工作流编排为可中断可恢复的 pipeline 时
+- 涉及 git worktree、远程 push、PR 创建等不可逆操作时
+- 需要在失败后从断点恢复而非从头重试时
+- 需要人机交替参与的半自动化工作流时
+
+## Examples
+
+### 完整工作流示例
+
+```bash
+# 1. 初始化批次
+python3 scripts/upstream-sync/sync-cli.py init
+
+# 2. 查看队列
+python3 scripts/upstream-sync/sync-cli.py status
+
+# 3. 处理第一个 commit
+python3 scripts/upstream-sync/sync-cli.py next
+# → 创建 worktree、应用 patch、测试、提交、推送、创建 PR
+# → 输出 PR 链接，暂停等待审查
+
+# 4. PR merged 后恢复
+python3 scripts/upstream-sync/sync-cli.py resume
+# → 检测 merged、写 .upstream-ref、清理 worktree
+# → 回到 idle，提示执行 next（不自动继续）
+
+# 5. 跳过有问题的 commit
+python3 scripts/upstream-sync/sync-cli.py skip --reason "patch 冲突需手动处理"
+
+# 6. 强制清理并跳过
+python3 scripts/upstream-sync/sync-cli.py skip --force-cleanup --reason "PR 被关闭"
+```
+
+### 失败恢复示例
+
+```bash
+# next 在 test 阶段失败
+python3 scripts/upstream-sync/sync-cli.py next
+# → failed_at: test
+
+# 手动修复代码后，resume 从 test 阶段重试
+python3 scripts/upstream-sync/sync-cli.py resume
+# → 从 test 阶段重新执行，继续 commit → push → pr_create
+```
+
+## Related
+
+- `scripts/upstream-sync/generate-batch.py` — patch 批次生成（sync-cli.py init 调用）
+- `scripts/upstream-sync/adapt-patch.py` — patch 命名空间适配
+- `scripts/upstream-sync/apply-patch-to-worktree.sh` — 原有手动 patch 应用脚本
+- `docs/solutions/best-practices/prefer-python-over-bash-for-pipeline-scripts-2026-04-09.md` — pipeline 脚本选择 Python 的决策
+- `docs/plans/2026-04-24-001-feat-upstream-sync-cli-automation-plan.md` — 完整计划文档

--- a/plugins/galeharness-cli/skills/compound-sync/SKILL.md
+++ b/plugins/galeharness-cli/skills/compound-sync/SKILL.md
@@ -26,50 +26,75 @@ GaleHarnessCLI was forked from EveryInc/compound-engineering-plugin at the commi
 
 ## Workflow
 
-### Step 1: Read Local Baseline
+Use the upstream sync CLI as the source of truth for batch generation, per-commit worktrees, PR creation, state transitions, cleanup, and `.upstream-ref` updates.
 
-- Read `.upstream-ref` for the last synced upstream commit.
-- Read `.upstream-repo` for the local upstream checkout path, unless an explicit path is provided for this run.
-- Treat the value in `.upstream-ref` as the start of the new batch, not as something to mutate immediately.
+### Step 1: Initialize The Batch
 
-### Step 2: Generate A Per-Commit Batch
+From the repository root, run:
 
-From the repository root, generate a dated batch under `.context/galeharness-cli/upstream-sync/`.
+```bash
+python3 scripts/upstream-sync/sync-cli.py init
+python3 scripts/upstream-sync/sync-cli.py status
+```
 
-The batch should contain:
-- `raw/NNNN-*.patch` for exact upstream provenance
-- `adapted/NNNN-*.patch` for mechanical GaleHarnessCLI renames
-- `commit-range.txt` with `baseline_before_batch`, `end_commit`, and `next_baseline_candidate`
-- `README.md` with the patch table and worktree instructions
+The CLI reads `.upstream-ref` and `.upstream-repo`, generates a dated batch under `.context/galeharness-cli/upstream-sync/`, and writes workflow state under `.context/galeharness-cli/upstream-sync/state.json`.
 
-### Step 3: Review And Process One Patch At A Time
+If `init` reports no new upstream commits, stop. Do not mutate `.upstream-ref` manually.
 
-For each adapted patch:
-- Review the paired raw patch to understand upstream intent
-- Create an isolated worktree
-- Apply exactly one adapted patch in that worktree
-- Run focused verification for that patch's scope
-- Commit and open a PR for that patch
+### Step 2: Process One Commit
+
+Start exactly one pending upstream commit:
+
+```bash
+python3 scripts/upstream-sync/sync-cli.py next
+```
+
+The CLI creates an isolated worktree, applies one adapted patch, runs verification, commits the result, pushes the branch, and opens a PR. Treat the generated PR as the review boundary for that upstream commit.
 
 Default operating model:
 - one upstream commit -> one adapted patch
 - one adapted patch -> one isolated worktree
 - one adapted patch -> one PR
 
-### Step 4: Re-apply GaleHarnessCLI-Specific Logic
+### Step 3: Re-apply GaleHarnessCLI-Specific Logic
 
-Mechanical adaptation only handles naming and path rewrites. After a patch applies:
+Mechanical adaptation only handles naming and path rewrites. In the generated worktree or PR:
 
 1. Re-apply `gh:` naming expectations not covered by raw text replacement
 2. Re-inject HKTMemory workflow patches where upstream does not know about them
 3. Update or add tests for the changed behavior
-4. Run verification before creating the PR
+4. Run focused verification before the PR lands
 
-### Step 5: Advance Baseline Only After The Batch Lands
+### Step 4: Resume Or Skip
 
-Do not update `.upstream-ref` when the batch is merely generated.
+After the PR is merged, return to the original worktree and run:
 
-Update `.upstream-ref` only after every patch in the batch has landed. The new value should be the batch's `next_baseline_candidate`, which is also the batch `end_commit`. That makes the recorded terminal commit the next run's starting baseline.
+```bash
+python3 scripts/upstream-sync/sync-cli.py resume
+python3 scripts/upstream-sync/sync-cli.py status
+```
+
+`resume` verifies the PR target, reconciles upstream ancestry, updates `.upstream-ref` for the merged upstream commit, cleans up the worktree, and returns the workflow to `idle` for the next explicit `next` command. It does not automatically start the next commit.
+
+If a commit must be abandoned, run:
+
+```bash
+python3 scripts/upstream-sync/sync-cli.py skip --reason "short reason"
+```
+
+For an open or closed PR that needs cleanup, use:
+
+```bash
+python3 scripts/upstream-sync/sync-cli.py skip --force-cleanup --reason "short reason"
+```
+
+The CLI validates branch ownership before deleting remote branches.
+
+### Step 5: Complete The Batch
+
+Repeat `next` -> PR review/merge -> `resume` until `status` reports `complete`.
+
+Do not hand-edit `.upstream-ref`. The CLI advances it only after each corresponding PR is confirmed merged and upstream ancestry checks pass.
 
 ## HKTMemory Patches to Re-apply
 

--- a/scripts/upstream-sync/sync-cli.py
+++ b/scripts/upstream-sync/sync-cli.py
@@ -1,0 +1,1345 @@
+#!/usr/bin/env python3
+"""Upstream Sync CLI — 半自动化逐 commit patch 同步工作流
+
+Usage:
+    sync-cli.py init [--base BRANCH] [--force] [--dry-run]
+    sync-cli.py status [--json]
+    sync-cli.py next [--dry-run]
+    sync-cli.py resume [--dry-run]
+    sync-cli.py skip [--force-cleanup] [--reason REASON] [--dry-run]
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+EXIT_OK = 0
+EXIT_PRECONDITION = 1
+EXIT_RUNTIME = 2
+EXIT_STATE_CORRUPT = 3
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CommitEntry:
+    sequence: int
+    sha: str
+    subject: str
+    raw_patch: str
+    adapted_patch: str
+    status: str  # pending | in_progress | awaiting_human_review | merged | failed | skipped
+    worktree_path: Optional[str] = None
+    branch: Optional[str] = None
+    base_branch: Optional[str] = None
+    pr_url: Optional[str] = None
+    pr_number: Optional[int] = None
+    pr_head_ref: Optional[str] = None
+    pr_base_ref: Optional[str] = None
+    failed_at: Optional[str] = None
+    failure_summary: Optional[str] = None
+
+
+@dataclass
+class OperationEntry:
+    timestamp: str
+    operation: str
+    summary: str
+
+
+@dataclass
+class SyncState:
+    schema_version: int
+    main_worktree_root: str
+    target_repo_root: str
+    batch_dir: str
+    baseline_sha: str
+    target_sha: str
+    base_branch: str
+    remote_name: str
+    github_repo: str
+    current_index: int
+    workflow_state: str  # uninitialized | idle | in_progress | awaiting_human_review | failed | complete
+    commits: List[CommitEntry] = field(default_factory=list)
+    operations: List[OperationEntry] = field(default_factory=list)
+
+
+SCHEMA_VERSION = 1
+MAX_OPERATIONS = 50
+MAX_OUTPUT_CHARS = 500
+
+REDACT_PATTERNS = ["GH_TOKEN", "GITHUB_TOKEN", "Authorization", "x-access-token"]
+
+
+# ---------------------------------------------------------------------------
+# Utility: safe command runner
+# ---------------------------------------------------------------------------
+
+def _redact_text(text: str, extra_patterns: Optional[List[str]] = None) -> str:
+    """Remove sensitive tokens from text."""
+    result = text
+    patterns = list(REDACT_PATTERNS)
+    if extra_patterns:
+        patterns.extend(extra_patterns)
+    for pat in patterns:
+        env_val = os.environ.get(pat, "")
+        if env_val:
+            result = result.replace(env_val, f"<{pat}-REDACTED>")
+    # Redact basic-auth in URLs: https://user:pass@host -> https://***:***@host
+    result = re.sub(r"(https?://)([^@/]+):([^@/]+)@", r"\1***:***@", result)
+    return result
+
+
+def _truncate(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + f"\n... (truncated, {len(text)} chars total)"
+
+
+def run_cmd(
+    argv: List[str],
+    cwd: Path,
+    *,
+    dry_run: bool = False,
+    capture: bool = True,
+    redact_patterns: Optional[List[str]] = None,
+) -> subprocess.CompletedProcess:
+    """Execute an external command safely with argv array, shell=False."""
+    resolved_cwd = cwd.resolve()
+    if not resolved_cwd.is_dir():
+        raise RuntimeError(f"工作目录不存在: {resolved_cwd}")
+
+    if dry_run:
+        cmd_str = " ".join(argv)
+        print(f"[dry-run] 将执行: {cmd_str}", file=sys.stderr)
+        print(f"[dry-run] 工作目录: {resolved_cwd}", file=sys.stderr)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    result = subprocess.run(
+        argv,
+        cwd=str(resolved_cwd),
+        text=True,
+        capture_output=capture,
+        check=False,
+    )
+    return result
+
+
+def run_cmd_checked(
+    argv: List[str],
+    cwd: Path,
+    *,
+    dry_run: bool = False,
+    stage: str = "",
+    redact_patterns: Optional[List[str]] = None,
+) -> subprocess.CompletedProcess:
+    """Run command and raise on failure with stage context."""
+    result = run_cmd(argv, cwd, dry_run=dry_run, redact_patterns=redact_patterns)
+    if result.returncode != 0 and not dry_run:
+        stdout_safe = _redact_text(_truncate(result.stdout or ""), redact_patterns)
+        stderr_safe = _redact_text(_truncate(result.stderr or ""), redact_patterns)
+        msg = f"命令失败 (阶段: {stage}): {' '.join(argv)}\nstdout:\n{stdout_safe}\nstderr:\n{stderr_safe}"
+        raise RuntimeError(msg)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Utility: main worktree root resolution
+# ---------------------------------------------------------------------------
+
+def resolve_main_worktree_root() -> Path:
+    """Resolve the main worktree root via git worktree list --porcelain."""
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        # Fallback: use git-common-dir
+        result2 = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, check=False,
+        )
+        if result2.returncode != 0:
+            raise RuntimeError("无法解析 git 仓库信息，请在 git 仓库内运行。")
+        common_dir = Path(result2.stdout.strip())
+        return common_dir.parent.resolve()
+
+    # Parse porcelain output: first "worktree" line is the main worktree
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            return Path(line.split(" ", 1)[1]).resolve()
+    raise RuntimeError("无法从 git worktree list 解析 main worktree。")
+
+
+def resolve_github_repo(remote_name: str, cwd: Path) -> str:
+    """Resolve owner/repo from git remote URL."""
+    result = run_cmd_checked(
+        ["git", "remote", "get-url", remote_name], cwd, stage="resolve_github_repo",
+    )
+    url = result.stdout.strip()
+    # SSH: git@github.com:owner/repo.git
+    m = re.match(r"git@github\.com:(.+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    # HTTPS: https://github.com/owner/repo.git
+    m = re.match(r"https?://github\.com/(.+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    raise RuntimeError(f"无法从 remote URL 解析 GitHub repo: {url}")
+
+
+def resolve_default_branch(remote_name: str, cwd: Path) -> str:
+    """Resolve the default branch of the remote."""
+    result = run_cmd(
+        ["git", "remote", "show", remote_name], cwd,
+    )
+    if result.returncode == 0:
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("HEAD branch:"):
+                return line.split(":", 1)[1].strip()
+    # Fallback
+    for candidate in ["main", "master"]:
+        r = run_cmd(["git", "rev-parse", "--verify", f"{remote_name}/{candidate}"], cwd)
+        if r.returncode == 0:
+            return candidate
+    return "main"
+
+
+# ---------------------------------------------------------------------------
+# Utility: state path
+# ---------------------------------------------------------------------------
+
+def get_state_path(main_root: Path) -> Path:
+    return main_root / ".context" / "galeharness-cli" / "upstream-sync" / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# Utility: state I/O (atomic)
+# ---------------------------------------------------------------------------
+
+def load_state(state_path: Path) -> SyncState:
+    """Load and validate state.json."""
+    if not state_path.is_file():
+        raise FileNotFoundError(f"状态文件不存在: {state_path}\n请先执行 init。")
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"状态文件 JSON 解析失败: {e}\n路径: {state_path}") from e
+
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise RuntimeError(
+            f"不支持的 schema_version: {data.get('schema_version')} (期望 {SCHEMA_VERSION})\n"
+            f"路径: {state_path}"
+        )
+
+    commits = [CommitEntry(**c) for c in data.get("commits", [])]
+    operations = [OperationEntry(**o) for o in data.get("operations", [])]
+    return SyncState(
+        schema_version=data["schema_version"],
+        main_worktree_root=data["main_worktree_root"],
+        target_repo_root=data["target_repo_root"],
+        batch_dir=data["batch_dir"],
+        baseline_sha=data["baseline_sha"],
+        target_sha=data["target_sha"],
+        base_branch=data["base_branch"],
+        remote_name=data["remote_name"],
+        github_repo=data["github_repo"],
+        current_index=data["current_index"],
+        workflow_state=data["workflow_state"],
+        commits=commits,
+        operations=operations,
+    )
+
+
+def save_state(state: SyncState, state_path: Path) -> None:
+    """Atomic write: write to temp file then rename."""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    data = asdict(state)
+    content = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(state_path.parent), suffix=".tmp", prefix="state-",
+    )
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.close(fd)
+        fd = -1
+        os.replace(tmp_path, str(state_path))
+    except Exception:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+def add_operation(state: SyncState, operation: str, summary: str) -> None:
+    """Append an operation entry, keeping the most recent MAX_OPERATIONS."""
+    entry = OperationEntry(
+        timestamp=datetime.now().astimezone().isoformat(timespec="seconds"),
+        operation=operation,
+        summary=summary,
+    )
+    state.operations.append(entry)
+    if len(state.operations) > MAX_OPERATIONS:
+        state.operations = state.operations[-MAX_OPERATIONS:]
+
+
+# ---------------------------------------------------------------------------
+# Utility: slug generation
+# ---------------------------------------------------------------------------
+
+def make_slug(subject: str, max_len: int = 30) -> str:
+    lowered = subject.lower()
+    ascii_only = lowered.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_only).strip("-")
+    return slug[:max_len] or "change"
+
+
+def make_branch_name(batch_date: str, sequence: int, subject: str) -> str:
+    slug = make_slug(subject)
+    return f"upstream-sync-{batch_date}-{sequence:04d}-{slug}"
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: init
+# ---------------------------------------------------------------------------
+
+def cmd_init(args: argparse.Namespace) -> int:
+    dry_run = args.dry_run
+    main_root = resolve_main_worktree_root()
+    state_path = get_state_path(main_root)
+
+    # Read .upstream-ref and .upstream-repo
+    upstream_ref_path = main_root / ".upstream-ref"
+    upstream_repo_path = main_root / ".upstream-repo"
+
+    if not upstream_ref_path.is_file():
+        print(f"错误: 缺少 .upstream-ref 文件: {upstream_ref_path}", file=sys.stderr)
+        return EXIT_PRECONDITION
+    if not upstream_repo_path.is_file():
+        print(f"错误: 缺少 .upstream-repo 文件: {upstream_repo_path}", file=sys.stderr)
+        return EXIT_PRECONDITION
+
+    baseline_sha = upstream_ref_path.read_text(encoding="utf-8").strip()
+    upstream_repo = Path(upstream_repo_path.read_text(encoding="utf-8").strip()).expanduser().resolve()
+
+    if not baseline_sha:
+        print("错误: .upstream-ref 文件为空", file=sys.stderr)
+        return EXIT_PRECONDITION
+
+    if not upstream_repo.is_dir():
+        print(f"错误: upstream 仓库路径无效: {upstream_repo}", file=sys.stderr)
+        return EXIT_PRECONDITION
+
+    # Check existing state
+    if state_path.is_file() and not args.force:
+        try:
+            existing = load_state(state_path)
+            if existing.workflow_state != "complete":
+                print(
+                    f"错误: 已存在未完成的同步状态 (workflow_state={existing.workflow_state})。\n"
+                    f"请使用 status 查看进度，或使用 --force 强制重新初始化。",
+                    file=sys.stderr,
+                )
+                return EXIT_PRECONDITION
+        except Exception:
+            pass  # Corrupted state, allow re-init
+
+    # Resolve remote and base branch
+    remote_name = "origin"
+    base_branch = args.base or resolve_default_branch(remote_name, main_root)
+    github_repo = resolve_github_repo(remote_name, main_root)
+
+    if dry_run:
+        print("=== init --dry-run ===")
+        print(f"main_worktree_root: {main_root}")
+        print(f"baseline_sha: {baseline_sha}")
+        print(f"upstream_repo: {upstream_repo}")
+        print(f"base_branch: {base_branch}")
+        print(f"github_repo: {github_repo}")
+        print(f"state_path: {state_path}")
+        print("将调用 generate-batch.py 生成 patch 批次")
+        return EXIT_OK
+
+    # Call generate-batch.py
+    generate_script = Path(__file__).with_name("generate-batch.py")
+    gen_result = run_cmd(
+        [
+            sys.executable, str(generate_script),
+            "--upstream-repo", str(upstream_repo),
+            "--target-repo", str(main_root),
+            "--force",
+        ],
+        cwd=main_root,
+    )
+    if gen_result.returncode != 0:
+        stderr_msg = _truncate(gen_result.stderr or "")
+        stdout_msg = _truncate(gen_result.stdout or "")
+        if "No new upstream commits" in (gen_result.stdout or ""):
+            print("无需同步: upstream 没有新的 commit。")
+            return EXIT_OK
+        print(f"错误: generate-batch.py 失败\nstdout:\n{stdout_msg}\nstderr:\n{stderr_msg}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    # Parse generate-batch.py JSON output for batch_dir
+    try:
+        gen_info = json.loads(gen_result.stdout.strip())
+        batch_dir = Path(gen_info["batch_dir"])
+    except (json.JSONDecodeError, KeyError):
+        print(f"错误: 无法解析 generate-batch.py 输出:\n{gen_result.stdout}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    # Parse commit-range.txt to build commit queue
+    commit_range_path = batch_dir / "commit-range.txt"
+    if not commit_range_path.is_file():
+        print(f"错误: 缺少 commit-range.txt: {commit_range_path}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    commits = _parse_commit_range(batch_dir, commit_range_path)
+    if not commits:
+        print("错误: commit-range.txt 中没有找到 commit 条目", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    # Validate raw/adapted patch pairs
+    for c in commits:
+        raw_p = Path(c.raw_patch)
+        adapted_p = Path(c.adapted_patch)
+        if not raw_p.is_file():
+            print(f"错误: 缺少 raw patch: {raw_p}", file=sys.stderr)
+            return EXIT_RUNTIME
+        if not adapted_p.is_file():
+            print(f"错误: 缺少 adapted patch: {adapted_p}", file=sys.stderr)
+            return EXIT_RUNTIME
+
+    # Determine target_sha (last commit in batch)
+    target_sha = commits[-1].sha
+
+    state = SyncState(
+        schema_version=SCHEMA_VERSION,
+        main_worktree_root=str(main_root),
+        target_repo_root=str(main_root),
+        batch_dir=str(batch_dir),
+        baseline_sha=baseline_sha,
+        target_sha=target_sha,
+        base_branch=base_branch,
+        remote_name=remote_name,
+        github_repo=github_repo,
+        current_index=0,
+        workflow_state="idle",
+        commits=commits,
+        operations=[],
+    )
+    add_operation(state, "init", f"初始化同步批次, {len(commits)} 个 commit, baseline={baseline_sha[:7]}")
+    save_state(state, state_path)
+
+    print(f"=== 同步批次已初始化 ===")
+    print(f"批次目录: {batch_dir}")
+    print(f"Commit 数量: {len(commits)}")
+    print(f"Baseline: {baseline_sha[:7]}")
+    print(f"Target: {target_sha[:7]}")
+    print(f"Base 分支: {base_branch}")
+    print(f"GitHub 仓库: {github_repo}")
+    print(f"\n请执行 status 查看队列，执行 next 开始处理第一个 commit。")
+    return EXIT_OK
+
+
+def _parse_commit_range(batch_dir: Path, commit_range_path: Path) -> List[CommitEntry]:
+    """Parse commit-range.txt and build CommitEntry list."""
+    text = commit_range_path.read_text(encoding="utf-8")
+    raw_dir = batch_dir / "raw"
+    adapted_dir = batch_dir / "adapted"
+    commits: List[CommitEntry] = []
+    in_commits = False
+
+    for line in text.splitlines():
+        if line.strip() == "commits:":
+            in_commits = True
+            continue
+        if in_commits and line.strip().startswith("- "):
+            parts = line.strip().lstrip("- ").split(" ", 2)
+            if len(parts) >= 3:
+                filename, sha, subject = parts[0], parts[1], parts[2]
+                seq = len(commits) + 1
+                commits.append(CommitEntry(
+                    sequence=seq,
+                    sha=sha,
+                    subject=subject,
+                    raw_patch=str(raw_dir / filename),
+                    adapted_patch=str(adapted_dir / filename),
+                    status="pending",
+                ))
+    return commits
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: status
+# ---------------------------------------------------------------------------
+
+def cmd_status(args: argparse.Namespace) -> int:
+    main_root = resolve_main_worktree_root()
+    state_path = get_state_path(main_root)
+
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
+        print("未初始化: 请先执行 init 开始同步。", file=sys.stderr)
+        return EXIT_PRECONDITION
+    except RuntimeError as e:
+        print(f"状态异常: {e}", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    if args.json:
+        out = asdict(state)
+        if state.current_index < len(state.commits):
+            out["next_commit"] = asdict(state.commits[state.current_index])
+        else:
+            out["next_commit"] = None
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+        return EXIT_OK
+
+    total = len(state.commits)
+    done = sum(1 for c in state.commits if c.status in ("merged", "skipped"))
+    pct = (done / total * 100) if total > 0 else 0
+
+    print(f"=== Upstream Sync 状态 ===")
+    print(f"Baseline: {state.baseline_sha[:7]} -> Target: {state.target_sha[:7]}")
+    print(f"进度: {done}/{total} ({pct:.0f}%)")
+    print(f"工作流状态: {state.workflow_state}")
+    print(f"Base 分支: {state.base_branch}")
+    print(f"GitHub 仓库: {state.github_repo}")
+    print()
+
+    # Commit queue table
+    print("Commit 队列:")
+    print(f"  {'#':>4}  {'SHA':7}  {'状态':<24}  主题")
+    print(f"  {'----':>4}  {'-------':7}  {'------------------------':<24}  ----")
+    for c in state.commits:
+        marker = " -> " if c.sequence - 1 == state.current_index else "    "
+        extra = ""
+        if c.pr_url:
+            extra = f" PR: {c.pr_url}"
+        if c.failed_at:
+            extra += f" (失败于: {c.failed_at})"
+        print(f"{marker}{c.sequence:4d}  {c.sha[:7]}  {c.status:<24}  {c.subject}{extra}")
+
+    # Next step suggestion
+    print()
+    if state.workflow_state == "idle" and state.current_index < total:
+        nc = state.commits[state.current_index]
+        print(f"下一步: 执行 next 处理 #{nc.sequence} {nc.sha[:7]} {nc.subject}")
+    elif state.workflow_state == "awaiting_human_review":
+        nc = state.commits[state.current_index]
+        print(f"下一步: 审查 PR 后执行 resume (PR: {nc.pr_url or 'N/A'})")
+    elif state.workflow_state == "failed":
+        nc = state.commits[state.current_index]
+        print(f"下一步: 修复问题后执行 resume，或执行 skip 跳过 (失败于: {nc.failed_at})")
+    elif state.workflow_state == "complete":
+        print("所有 commit 已处理完成。")
+
+    # Recent operations
+    recent = state.operations[-3:]
+    if recent:
+        print(f"\n最近操作:")
+        for op in recent:
+            print(f"  [{op.timestamp}] {op.operation}: {op.summary}")
+
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: next
+# ---------------------------------------------------------------------------
+
+def cmd_next(args: argparse.Namespace) -> int:
+    dry_run = args.dry_run
+    main_root = resolve_main_worktree_root()
+    state_path = get_state_path(main_root)
+
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
+        print("错误: 未初始化，请先执行 init。", file=sys.stderr)
+        return EXIT_PRECONDITION
+    except RuntimeError as e:
+        print(f"状态异常: {e}", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    if state.workflow_state != "idle":
+        print(f"错误: 当前状态为 {state.workflow_state}，next 只能在 idle 状态下执行。", file=sys.stderr)
+        if state.workflow_state == "awaiting_human_review":
+            print("提示: 请先执行 resume 或 skip。", file=sys.stderr)
+        elif state.workflow_state == "failed":
+            print("提示: 请先执行 resume 恢复或 skip 跳过。", file=sys.stderr)
+        return EXIT_PRECONDITION
+
+    if state.current_index >= len(state.commits):
+        state.workflow_state = "complete"
+        save_state(state, state_path)
+        print("所有 commit 已处理完成。")
+        return EXIT_OK
+
+    commit = state.commits[state.current_index]
+    if commit.status != "pending":
+        print(f"错误: 当前 commit 状态为 {commit.status}，期望 pending。", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    # Extract batch date from batch_dir
+    batch_date = Path(state.batch_dir).name
+    branch_name = make_branch_name(batch_date, commit.sequence, commit.subject)
+
+    worktree_path = Path(state.main_worktree_root).parent / f"GaleHarnessCodingCLI-{branch_name}"
+    adapted_patch = Path(commit.adapted_patch)
+
+    if dry_run:
+        print("=== next --dry-run ===")
+        print(f"处理 commit #{commit.sequence}: {commit.sha[:7]} {commit.subject}")
+        print(f"分支名: {branch_name}")
+        print(f"Worktree 路径: {worktree_path}")
+        print(f"Adapted patch: {adapted_patch}")
+        print(f"测试命令: bun test")
+        print(f"Commit message: sync(upstream): {commit.subject}")
+        print(f"PR 标题: sync(upstream): {commit.subject}")
+        print(f"PR base: {state.base_branch}")
+        return EXIT_OK
+
+    # Mark in_progress
+    commit.status = "in_progress"
+    state.workflow_state = "in_progress"
+    save_state(state, state_path)
+
+    main_root_path = Path(state.main_worktree_root)
+
+    try:
+        # --- Stage: worktree_create ---
+        branch_name = _resolve_unique_branch(branch_name, state.remote_name, main_root_path)
+        commit.branch = branch_name
+        commit.base_branch = state.base_branch
+        commit.worktree_path = str(worktree_path)
+
+        # Fetch remote base
+        run_cmd_checked(
+            ["git", "fetch", state.remote_name, state.base_branch],
+            main_root_path, stage="fetch_base",
+        )
+
+        result = run_cmd(
+            ["git", "worktree", "add", "-b", branch_name, str(worktree_path),
+             f"{state.remote_name}/{state.base_branch}"],
+            main_root_path,
+        )
+        if result.returncode != 0:
+            _record_failure(state, commit, "worktree_create", result, state_path)
+            return EXIT_RUNTIME
+
+        add_operation(state, "worktree_create", f"创建 worktree: {worktree_path}")
+        save_state(state, state_path)
+
+        wt_path = Path(commit.worktree_path)
+
+        # --- Stage: patch_check ---
+        result = run_cmd(
+            ["git", "apply", "--check", str(adapted_patch.resolve())],
+            wt_path,
+        )
+        if result.returncode != 0:
+            _record_failure(state, commit, "patch_check", result, state_path)
+            print(f"Raw patch: {commit.raw_patch}", file=sys.stderr)
+            print(f"Adapted patch: {commit.adapted_patch}", file=sys.stderr)
+            return EXIT_RUNTIME
+
+        add_operation(state, "patch_check", "patch 预检通过")
+        save_state(state, state_path)
+
+        # --- Stage: patch_apply ---
+        result = run_cmd(
+            ["git", "apply", str(adapted_patch.resolve())],
+            wt_path,
+        )
+        if result.returncode != 0:
+            _record_failure(state, commit, "patch_apply", result, state_path)
+            return EXIT_RUNTIME
+
+        add_operation(state, "patch_apply", "patch 已应用")
+        save_state(state, state_path)
+
+        # --- Stage: test ---
+        result = run_cmd(["bun", "test"], wt_path)
+        if result.returncode != 0:
+            _record_failure(state, commit, "test", result, state_path)
+            return EXIT_RUNTIME
+
+        add_operation(state, "test", "bun test 通过")
+        save_state(state, state_path)
+
+        # --- Stage: commit ---
+        run_cmd_checked(["git", "add", "-A"], wt_path, stage="git_add")
+        commit_msg = f"sync(upstream): {commit.subject}"
+        result = run_cmd(
+            ["git", "commit", "-m", commit_msg],
+            wt_path,
+        )
+        if result.returncode != 0:
+            _record_failure(state, commit, "commit", result, state_path)
+            return EXIT_RUNTIME
+
+        add_operation(state, "commit", f"已提交: {commit_msg}")
+        save_state(state, state_path)
+
+        # --- Stage: push ---
+        result = run_cmd(
+            ["git", "push", state.remote_name, branch_name],
+            wt_path,
+        )
+        if result.returncode != 0:
+            _record_failure(state, commit, "push", result, state_path)
+            return EXIT_RUNTIME
+
+        add_operation(state, "push", f"已推送分支: {branch_name}")
+        save_state(state, state_path)
+
+        # --- Stage: pr_create ---
+        pr_title = f"sync(upstream): {commit.subject}"
+        pr_body = (
+            f"## Upstream Sync\n\n"
+            f"- Upstream commit: `{commit.sha}`\n"
+            f"- Subject: {commit.subject}\n"
+            f"- Sequence: {commit.sequence}/{len(state.commits)}\n"
+            f"- Batch: {Path(state.batch_dir).name}\n"
+            f"- Baseline: `{state.baseline_sha[:7]}`\n"
+        )
+        result = run_cmd(
+            [
+                "gh", "pr", "create",
+                "--base", state.base_branch,
+                "--head", branch_name,
+                "--title", pr_title,
+                "--body", pr_body,
+                "--repo", state.github_repo,
+            ],
+            wt_path,
+        )
+        if result.returncode != 0:
+            _record_failure(state, commit, "pr_create", result, state_path)
+            return EXIT_RUNTIME
+
+        # Parse PR URL from gh output
+        pr_url = result.stdout.strip()
+        pr_number = _extract_pr_number(pr_url)
+
+        commit.pr_url = pr_url
+        commit.pr_number = pr_number
+        commit.pr_head_ref = branch_name
+        commit.pr_base_ref = state.base_branch
+        commit.status = "awaiting_human_review"
+        state.workflow_state = "awaiting_human_review"
+        add_operation(state, "pr_create", f"PR 已创建: {pr_url}")
+        save_state(state, state_path)
+
+        print(f"=== PR 已创建 ===")
+        print(f"Commit #{commit.sequence}: {commit.sha[:7]} {commit.subject}")
+        print(f"PR: {pr_url}")
+        print(f"\n请审查 PR 后执行 resume 继续。")
+        return EXIT_OK
+
+    except RuntimeError as e:
+        print(f"错误: {e}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+
+def _resolve_unique_branch(base_name: str, remote: str, cwd: Path) -> str:
+    """Check if remote branch exists, if so add suffix."""
+    result = run_cmd(["git", "ls-remote", "--heads", remote, base_name], cwd)
+    if result.returncode == 0 and base_name in (result.stdout or ""):
+        for suffix in range(2, 100):
+            candidate = f"{base_name}-{suffix}"
+            r = run_cmd(["git", "ls-remote", "--heads", remote, candidate], cwd)
+            if r.returncode != 0 or candidate not in (r.stdout or ""):
+                return candidate
+    return base_name
+
+
+def _record_failure(
+    state: SyncState, commit: CommitEntry, stage: str,
+    result: subprocess.CompletedProcess, state_path: Path,
+) -> None:
+    """Record pipeline failure in state."""
+    stdout_safe = _redact_text(_truncate(result.stdout or ""))
+    stderr_safe = _redact_text(_truncate(result.stderr or ""))
+    summary = f"stdout: {stdout_safe}\nstderr: {stderr_safe}"
+
+    commit.failed_at = stage
+    commit.failure_summary = summary
+    commit.status = "failed"
+    state.workflow_state = "failed"
+    add_operation(state, f"failed:{stage}", f"阶段 {stage} 失败")
+    save_state(state, state_path)
+
+    print(f"错误: 阶段 {stage} 失败", file=sys.stderr)
+    print(f"摘要:\n{summary}", file=sys.stderr)
+    if stage == "patch_check":
+        print(f"建议: 检查 adapted patch 是否与当前 base 兼容", file=sys.stderr)
+    elif stage == "test":
+        print(f"建议: 在 worktree 中修复测试后执行 resume", file=sys.stderr)
+    elif stage == "push":
+        print(f"建议: 检查网络连接和认证后执行 resume", file=sys.stderr)
+    elif stage == "pr_create":
+        print(f"建议: 检查 gh 认证状态后执行 resume", file=sys.stderr)
+
+
+def _extract_pr_number(pr_url: str) -> Optional[int]:
+    m = re.search(r"/pull/(\d+)", pr_url)
+    return int(m.group(1)) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: resume
+# ---------------------------------------------------------------------------
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    dry_run = args.dry_run
+    main_root = resolve_main_worktree_root()
+    state_path = get_state_path(main_root)
+
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
+        print("错误: 未初始化，请先执行 init。", file=sys.stderr)
+        return EXIT_PRECONDITION
+    except RuntimeError as e:
+        print(f"状态异常: {e}", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    if state.workflow_state == "failed":
+        return _resume_from_failed(state, state_path, dry_run)
+    elif state.workflow_state == "awaiting_human_review":
+        return _resume_from_review(state, state_path, dry_run)
+    else:
+        print(f"错误: 当前状态为 {state.workflow_state}，resume 只能在 failed 或 awaiting_human_review 状态下执行。", file=sys.stderr)
+        return EXIT_PRECONDITION
+
+
+def _resume_from_failed(state: SyncState, state_path: Path, dry_run: bool) -> int:
+    """Resume from a failed stage by retrying from failed_at."""
+    commit = state.commits[state.current_index]
+    if not commit.failed_at:
+        print("错误: 状态标记为 failed 但缺少 failed_at 信息。", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    failed_stage = commit.failed_at
+    stages = ["worktree_create", "patch_check", "patch_apply", "test", "commit", "push", "pr_create"]
+
+    if failed_stage not in stages:
+        print(f"错误: 未知的失败阶段: {failed_stage}", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    start_idx = stages.index(failed_stage)
+
+    if dry_run:
+        print(f"=== resume --dry-run (从 {failed_stage} 恢复) ===")
+        print(f"Commit #{commit.sequence}: {commit.sha[:7]} {commit.subject}")
+        print(f"将从阶段 {failed_stage} 重新开始")
+        remaining = stages[start_idx:]
+        print(f"剩余阶段: {' -> '.join(remaining)}")
+        return EXIT_OK
+
+    # Clear failure state
+    commit.failed_at = None
+    commit.failure_summary = None
+    commit.status = "in_progress"
+    state.workflow_state = "in_progress"
+    add_operation(state, "resume", f"从阶段 {failed_stage} 恢复")
+    save_state(state, state_path)
+
+    main_root_path = Path(state.main_worktree_root)
+
+    # Determine batch_date for branch naming
+    batch_date = Path(state.batch_dir).name
+
+    try:
+        wt_path = Path(commit.worktree_path) if commit.worktree_path else None
+
+        for stage in stages[start_idx:]:
+            if stage == "worktree_create":
+                if not commit.branch:
+                    commit.branch = make_branch_name(batch_date, commit.sequence, commit.subject)
+                    commit.branch = _resolve_unique_branch(commit.branch, state.remote_name, main_root_path)
+                if not commit.worktree_path:
+                    commit.worktree_path = str(
+                        main_root_path.parent / f"GaleHarnessCodingCLI-{commit.branch}"
+                    )
+                wt_path = Path(commit.worktree_path)
+                commit.base_branch = state.base_branch
+
+                run_cmd_checked(
+                    ["git", "fetch", state.remote_name, state.base_branch],
+                    main_root_path, stage="fetch_base",
+                )
+                result = run_cmd(
+                    ["git", "worktree", "add", "-b", commit.branch, str(wt_path),
+                     f"{state.remote_name}/{state.base_branch}"],
+                    main_root_path,
+                )
+                if result.returncode != 0:
+                    _record_failure(state, commit, "worktree_create", result, state_path)
+                    return EXIT_RUNTIME
+                add_operation(state, "worktree_create", f"创建 worktree: {wt_path}")
+                save_state(state, state_path)
+
+            elif stage == "patch_check":
+                adapted = Path(commit.adapted_patch).resolve()
+                result = run_cmd(["git", "apply", "--check", str(adapted)], wt_path)
+                if result.returncode != 0:
+                    _record_failure(state, commit, "patch_check", result, state_path)
+                    return EXIT_RUNTIME
+                add_operation(state, "patch_check", "patch 预检通过")
+                save_state(state, state_path)
+
+            elif stage == "patch_apply":
+                adapted = Path(commit.adapted_patch).resolve()
+                result = run_cmd(["git", "apply", str(adapted)], wt_path)
+                if result.returncode != 0:
+                    _record_failure(state, commit, "patch_apply", result, state_path)
+                    return EXIT_RUNTIME
+                add_operation(state, "patch_apply", "patch 已应用")
+                save_state(state, state_path)
+
+            elif stage == "test":
+                result = run_cmd(["bun", "test"], wt_path)
+                if result.returncode != 0:
+                    _record_failure(state, commit, "test", result, state_path)
+                    return EXIT_RUNTIME
+                add_operation(state, "test", "bun test 通过")
+                save_state(state, state_path)
+
+            elif stage == "commit":
+                run_cmd_checked(["git", "add", "-A"], wt_path, stage="git_add")
+                commit_msg = f"sync(upstream): {commit.subject}"
+                result = run_cmd(["git", "commit", "-m", commit_msg], wt_path)
+                if result.returncode != 0:
+                    _record_failure(state, commit, "commit", result, state_path)
+                    return EXIT_RUNTIME
+                add_operation(state, "commit", f"已提交: {commit_msg}")
+                save_state(state, state_path)
+
+            elif stage == "push":
+                result = run_cmd(
+                    ["git", "push", state.remote_name, commit.branch], wt_path,
+                )
+                if result.returncode != 0:
+                    _record_failure(state, commit, "push", result, state_path)
+                    return EXIT_RUNTIME
+                add_operation(state, "push", f"已推送: {commit.branch}")
+                save_state(state, state_path)
+
+            elif stage == "pr_create":
+                if commit.pr_url:
+                    # PR already created, skip
+                    continue
+                pr_title = f"sync(upstream): {commit.subject}"
+                pr_body = (
+                    f"## Upstream Sync\n\n"
+                    f"- Upstream commit: `{commit.sha}`\n"
+                    f"- Subject: {commit.subject}\n"
+                    f"- Sequence: {commit.sequence}/{len(state.commits)}\n"
+                )
+                result = run_cmd(
+                    [
+                        "gh", "pr", "create",
+                        "--base", state.base_branch,
+                        "--head", commit.branch,
+                        "--title", pr_title,
+                        "--body", pr_body,
+                        "--repo", state.github_repo,
+                    ],
+                    wt_path,
+                )
+                if result.returncode != 0:
+                    _record_failure(state, commit, "pr_create", result, state_path)
+                    return EXIT_RUNTIME
+
+                pr_url = result.stdout.strip()
+                commit.pr_url = pr_url
+                commit.pr_number = _extract_pr_number(pr_url)
+                commit.pr_head_ref = commit.branch
+                commit.pr_base_ref = state.base_branch
+                commit.status = "awaiting_human_review"
+                state.workflow_state = "awaiting_human_review"
+                add_operation(state, "pr_create", f"PR 已创建: {pr_url}")
+                save_state(state, state_path)
+
+                print(f"=== PR 已创建 ===")
+                print(f"Commit #{commit.sequence}: {commit.sha[:7]} {commit.subject}")
+                print(f"PR: {pr_url}")
+                print(f"\n请审查 PR 后执行 resume 继续。")
+                return EXIT_OK
+
+        # If we got through all stages without creating a PR, something is off
+        print("警告: pipeline 完成但未创建 PR", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    except RuntimeError as e:
+        print(f"错误: {e}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+
+def _resume_from_review(state: SyncState, state_path: Path, dry_run: bool) -> int:
+    """Check PR status and handle merged/open/closed."""
+    commit = state.commits[state.current_index]
+    if not commit.pr_number:
+        print("错误: 缺少 PR 信息。", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    main_root_path = Path(state.main_worktree_root)
+
+    if dry_run:
+        print(f"=== resume --dry-run (检查 PR #{commit.pr_number}) ===")
+        print(f"将查询 PR 状态: gh pr view {commit.pr_number} --repo {state.github_repo}")
+        print(f"merged -> 更新 .upstream-ref, 清理 worktree, 推进 index")
+        print(f"open -> 保持等待状态")
+        print(f"closed -> 提示使用 skip --force-cleanup")
+        return EXIT_OK
+
+    # Query PR status
+    result = run_cmd(
+        [
+            "gh", "pr", "view", str(commit.pr_number),
+            "--repo", state.github_repo,
+            "--json", "state,mergedAt,url,number,headRefName,baseRefName",
+        ],
+        main_root_path,
+    )
+    if result.returncode != 0:
+        stderr_safe = _redact_text(_truncate(result.stderr or ""))
+        print(f"错误: 无法查询 PR 状态\n{stderr_safe}", file=sys.stderr)
+        print("建议: 检查 gh 认证状态和网络连接。", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    try:
+        pr_data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"错误: 无法解析 PR 状态 JSON:\n{result.stdout}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+    pr_state = pr_data.get("state", "").upper()
+    head_ref = pr_data.get("headRefName", "")
+    base_ref = pr_data.get("baseRefName", "")
+
+    # Verify PR matches state
+    if head_ref and commit.pr_head_ref and head_ref != commit.pr_head_ref:
+        print(f"错误: PR headRefName 不一致 (PR: {head_ref}, state: {commit.pr_head_ref})", file=sys.stderr)
+        print("建议: 请人工检查 PR 和状态文件。", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    if base_ref and commit.pr_base_ref and base_ref != commit.pr_base_ref:
+        print(f"错误: PR baseRefName 不一致 (PR: {base_ref}, state: {commit.pr_base_ref})", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    if pr_state == "MERGED":
+        return _handle_pr_merged(state, commit, state_path, main_root_path)
+    elif pr_state == "OPEN":
+        print(f"PR #{commit.pr_number} 仍在审查中。")
+        print(f"URL: {commit.pr_url}")
+        print(f"请在审查通过并合并后再执行 resume。")
+        return EXIT_OK
+    elif pr_state == "CLOSED":
+        print(f"警告: PR #{commit.pr_number} 已关闭但未合并。", file=sys.stderr)
+        print(f"建议: 使用 skip --force-cleanup 清理资源，或重新打开 PR。", file=sys.stderr)
+        state.workflow_state = "failed"
+        commit.failed_at = "pr_closed"
+        commit.failure_summary = "PR closed without merge"
+        add_operation(state, "resume", f"PR #{commit.pr_number} 已关闭未合并")
+        save_state(state, state_path)
+        return EXIT_RUNTIME
+    else:
+        print(f"警告: 未知的 PR 状态: {pr_state}", file=sys.stderr)
+        return EXIT_RUNTIME
+
+
+def _handle_pr_merged(
+    state: SyncState, commit: CommitEntry, state_path: Path, main_root_path: Path,
+) -> int:
+    """Handle PR merged: reconcile .upstream-ref, cleanup, advance."""
+    upstream_ref_path = main_root_path / ".upstream-ref"
+
+    # Ancestry reconciliation via upstream repo
+    upstream_repo_path = main_root_path / ".upstream-repo"
+    if upstream_repo_path.is_file():
+        upstream_repo = Path(upstream_repo_path.read_text(encoding="utf-8").strip()).expanduser().resolve()
+        if upstream_repo.is_dir():
+            # Check ancestry: baseline_sha should be ancestor of commit.sha
+            r = run_cmd(
+                ["git", "merge-base", "--is-ancestor", state.baseline_sha, commit.sha],
+                upstream_repo,
+            )
+            if r.returncode != 0:
+                print(f"警告: upstream ancestry 对账未通过 (baseline {state.baseline_sha[:7]} -> {commit.sha[:7]})", file=sys.stderr)
+                print("仍将推进 .upstream-ref，请人工确认 upstream 历史。", file=sys.stderr)
+
+    # Write .upstream-ref
+    upstream_ref_path.write_text(commit.sha + "\n", encoding="utf-8")
+    add_operation(state, "upstream_ref_update", f".upstream-ref 更新为 {commit.sha[:7]}")
+
+    # Cleanup worktree
+    if commit.worktree_path:
+        wt = Path(commit.worktree_path)
+        if wt.is_dir():
+            r = run_cmd(["git", "worktree", "remove", str(wt), "--force"], main_root_path)
+            if r.returncode != 0:
+                print(f"警告: 清理 worktree 失败: {wt}", file=sys.stderr)
+            else:
+                add_operation(state, "worktree_cleanup", f"已删除 worktree: {wt}")
+        else:
+            print(f"提示: worktree 已不存在: {wt}", file=sys.stderr)
+
+    # Delete local branch
+    if commit.branch:
+        r = run_cmd(["git", "branch", "-D", commit.branch], main_root_path)
+        if r.returncode != 0:
+            print(f"警告: 删除本地分支失败: {commit.branch}", file=sys.stderr)
+
+    # Advance state
+    commit.status = "merged"
+    state.current_index += 1
+
+    if state.current_index >= len(state.commits):
+        state.workflow_state = "complete"
+        add_operation(state, "complete", "所有 commit 已处理完成")
+        save_state(state, state_path)
+        print(f"=== 同步完成 ===")
+        print(f"所有 {len(state.commits)} 个 commit 已处理完成。")
+        print(f".upstream-ref 已更新为 {commit.sha[:7]}")
+        return EXIT_OK
+    else:
+        state.workflow_state = "idle"
+        next_commit = state.commits[state.current_index]
+        add_operation(state, "merged", f"#{commit.sequence} merged, 推进到 #{next_commit.sequence}")
+        save_state(state, state_path)
+        print(f"=== PR 已合并 ===")
+        print(f"Commit #{commit.sequence} 已标记为 merged。")
+        print(f".upstream-ref 已更新为 {commit.sha[:7]}")
+        print(f"\n下一个: #{next_commit.sequence} {next_commit.sha[:7]} {next_commit.subject}")
+        print(f"请执行 next 继续。")
+        return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: skip
+# ---------------------------------------------------------------------------
+
+def cmd_skip(args: argparse.Namespace) -> int:
+    dry_run = args.dry_run
+    force_cleanup = args.force_cleanup
+    reason = args.reason or "user skipped"
+    main_root = resolve_main_worktree_root()
+    state_path = get_state_path(main_root)
+
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
+        print("错误: 未初始化，请先执行 init。", file=sys.stderr)
+        return EXIT_PRECONDITION
+    except RuntimeError as e:
+        print(f"状态异常: {e}", file=sys.stderr)
+        return EXIT_STATE_CORRUPT
+
+    if state.current_index >= len(state.commits):
+        print("所有 commit 已处理完成，无需跳过。")
+        return EXIT_OK
+
+    commit = state.commits[state.current_index]
+
+    # Validate skip is allowed
+    allowed_statuses = {"pending", "failed", "skipped"}
+    if commit.status == "awaiting_human_review" and not force_cleanup:
+        print(f"错误: 当前 commit 正在等待审查 (PR: {commit.pr_url})。", file=sys.stderr)
+        print("使用 --force-cleanup 强制跳过并清理资源。", file=sys.stderr)
+        return EXIT_PRECONDITION
+    elif commit.status not in allowed_statuses and commit.status != "awaiting_human_review":
+        print(f"错误: 当前 commit 状态为 {commit.status}，无法跳过。", file=sys.stderr)
+        return EXIT_PRECONDITION
+
+    if dry_run:
+        print(f"=== skip --dry-run ===")
+        print(f"将跳过 commit #{commit.sequence}: {commit.sha[:7]} {commit.subject}")
+        print(f"原因: {reason}")
+        if force_cleanup:
+            print(f"将清理资源:")
+            if commit.worktree_path:
+                print(f"  Worktree: {commit.worktree_path}")
+            if commit.branch:
+                print(f"  远程分支: {commit.branch}")
+        return EXIT_OK
+
+    main_root_path = Path(state.main_worktree_root)
+
+    # Force cleanup if requested
+    if force_cleanup:
+        _do_force_cleanup(state, commit, main_root_path)
+
+    # Mark skipped and advance
+    commit.status = "skipped"
+    commit.failure_summary = f"跳过原因: {reason}"
+    state.current_index += 1
+    add_operation(state, "skip", f"跳过 #{commit.sequence}: {reason}")
+
+    if state.current_index >= len(state.commits):
+        state.workflow_state = "complete"
+        add_operation(state, "complete", "所有 commit 已处理完成")
+    else:
+        state.workflow_state = "idle"
+
+    save_state(state, state_path)
+
+    print(f"已跳过 commit #{commit.sequence}: {commit.sha[:7]} {commit.subject}")
+    print(f"原因: {reason}")
+    if state.workflow_state == "complete":
+        print("所有 commit 已处理完成。")
+    else:
+        next_c = state.commits[state.current_index]
+        print(f"如需继续，请执行 next (下一个: #{next_c.sequence} {next_c.sha[:7]})")
+    return EXIT_OK
+
+
+def _do_force_cleanup(state: SyncState, commit: CommitEntry, main_root_path: Path) -> None:
+    """Cleanup worktree and remote branch with validation."""
+    # Validate and cleanup worktree
+    if commit.worktree_path:
+        wt = Path(commit.worktree_path)
+        # Verify worktree is in git worktree list
+        r = run_cmd(["git", "worktree", "list", "--porcelain"], main_root_path)
+        if r.returncode == 0 and str(wt) in r.stdout:
+            r2 = run_cmd(["git", "worktree", "remove", str(wt), "--force"], main_root_path)
+            if r2.returncode != 0:
+                print(f"警告: 清理 worktree 失败: {wt}", file=sys.stderr)
+            else:
+                add_operation(state, "cleanup_worktree", f"已删除 worktree: {wt}")
+        else:
+            print(f"提示: worktree 不在列表中或已删除: {wt}", file=sys.stderr)
+
+    # Validate and cleanup remote branch
+    if commit.branch:
+        branch = commit.branch
+        # Verify branch matches upstream-sync-* pattern
+        if not branch.startswith("upstream-sync-"):
+            print(f"警告: 分支名 {branch} 不匹配 upstream-sync-* 模式，跳过远程删除。", file=sys.stderr)
+            return
+
+        # Verify not default branch
+        if branch == state.base_branch:
+            print(f"警告: 分支 {branch} 是默认分支，跳过删除。", file=sys.stderr)
+            return
+
+        # Delete remote branch
+        r = run_cmd(
+            ["git", "push", state.remote_name, "--delete", branch],
+            main_root_path,
+        )
+        if r.returncode != 0:
+            print(f"警告: 删除远程分支失败: {branch}", file=sys.stderr)
+            print(f"手动删除: git push {state.remote_name} --delete {branch}", file=sys.stderr)
+        else:
+            add_operation(state, "cleanup_remote_branch", f"已删除远程分支: {branch}")
+
+        # Delete local branch
+        r = run_cmd(["git", "branch", "-D", branch], main_root_path)
+        if r.returncode != 0:
+            print(f"警告: 删除本地分支失败: {branch}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sync-cli.py",
+        description="Upstream Sync CLI — 半自动化逐 commit patch 同步工作流",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="单步副作用预览，不执行写入")
+    subparsers = parser.add_subparsers(dest="command", help="子命令")
+
+    # init
+    p_init = subparsers.add_parser("init", help="初始化同步批次")
+    p_init.add_argument("--base", help="指定 base 分支 (默认: remote default branch)")
+    p_init.add_argument("--force", action="store_true", help="强制重新初始化")
+    p_init.add_argument("--dry-run", action="store_true", dest="cmd_dry_run", help="预览")
+
+    # status
+    p_status = subparsers.add_parser("status", help="查看同步状态")
+    p_status.add_argument("--json", action="store_true", help="JSON 格式输出")
+
+    # next
+    p_next = subparsers.add_parser("next", help="处理下一个 commit")
+    p_next.add_argument("--dry-run", action="store_true", dest="cmd_dry_run", help="预览")
+
+    # resume
+    p_resume = subparsers.add_parser("resume", help="恢复或确认 PR 状态")
+    p_resume.add_argument("--dry-run", action="store_true", dest="cmd_dry_run", help="预览")
+
+    # skip
+    p_skip = subparsers.add_parser("skip", help="跳过当前 commit")
+    p_skip.add_argument("--force-cleanup", action="store_true", help="强制清理 worktree 和远程分支")
+    p_skip.add_argument("--reason", help="跳过原因")
+    p_skip.add_argument("--dry-run", action="store_true", dest="cmd_dry_run", help="预览")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return EXIT_PRECONDITION
+
+    # Merge dry_run flags
+    if hasattr(args, "cmd_dry_run") and args.cmd_dry_run:
+        args.dry_run = True
+
+    handlers = {
+        "init": cmd_init,
+        "status": cmd_status,
+        "next": cmd_next,
+        "resume": cmd_resume,
+        "skip": cmd_skip,
+    }
+
+    handler = handlers.get(args.command)
+    if not handler:
+        parser.print_help()
+        return EXIT_PRECONDITION
+
+    try:
+        return handler(args)
+    except FileNotFoundError as e:
+        print(f"错误: {e}", file=sys.stderr)
+        return EXIT_PRECONDITION
+    except RuntimeError as e:
+        print(f"错误: {e}", file=sys.stderr)
+        return EXIT_RUNTIME
+    except KeyboardInterrupt:
+        print("\n操作已取消。", file=sys.stderr)
+        return EXIT_RUNTIME
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/upstream-sync/sync-cli.py
+++ b/scripts/upstream-sync/sync-cli.py
@@ -88,6 +88,20 @@ REDACT_PATTERNS = ["GH_TOKEN", "GITHUB_TOKEN", "Authorization", "x-access-token"
 # Utility: safe command runner
 # ---------------------------------------------------------------------------
 
+def _configure_stdio() -> None:
+    """Force UTF-8 console output on Windows and other non-UTF-8 locales."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+
+_configure_stdio()
+
+
 def _redact_text(text: str, extra_patterns: Optional[List[str]] = None) -> str:
     """Remove sensitive tokens from text."""
     result = text
@@ -132,6 +146,8 @@ def run_cmd(
         argv,
         cwd=str(resolved_cwd),
         text=True,
+        encoding="utf-8",
+        errors="replace",
         capture_output=capture,
         check=False,
     )
@@ -164,13 +180,13 @@ def resolve_main_worktree_root() -> Path:
     """Resolve the main worktree root via git worktree list --porcelain."""
     result = subprocess.run(
         ["git", "worktree", "list", "--porcelain"],
-        capture_output=True, text=True, check=False,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
     )
     if result.returncode != 0:
         # Fallback: use git-common-dir
         result2 = subprocess.run(
             ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
         )
         if result2.returncode != 0:
             raise RuntimeError("无法解析 git 仓库信息，请在 git 仓库内运行。")
@@ -359,8 +375,11 @@ def cmd_init(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return EXIT_PRECONDITION
-        except Exception:
-            pass  # Corrupted state, allow re-init
+        except Exception as e:
+            print(f"错误: 已存在状态文件但无法读取: {state_path}", file=sys.stderr)
+            print(f"原因: {e}", file=sys.stderr)
+            print("请先备份并修复状态文件，或确认后使用 --force 重新初始化。", file=sys.stderr)
+            return EXIT_STATE_CORRUPT
 
     # Resolve remote and base branch
     remote_name = "origin"
@@ -389,18 +408,20 @@ def cmd_init(args: argparse.Namespace) -> int:
         ],
         cwd=main_root,
     )
+    gen_stdout = gen_result.stdout or ""
+    if "No new upstream commits" in gen_stdout:
+        print("无需同步: upstream 没有新的 commit。")
+        return EXIT_OK
+
     if gen_result.returncode != 0:
         stderr_msg = _truncate(gen_result.stderr or "")
-        stdout_msg = _truncate(gen_result.stdout or "")
-        if "No new upstream commits" in (gen_result.stdout or ""):
-            print("无需同步: upstream 没有新的 commit。")
-            return EXIT_OK
+        stdout_msg = _truncate(gen_stdout)
         print(f"错误: generate-batch.py 失败\nstdout:\n{stdout_msg}\nstderr:\n{stderr_msg}", file=sys.stderr)
         return EXIT_RUNTIME
 
     # Parse generate-batch.py JSON output for batch_dir
     try:
-        gen_info = json.loads(gen_result.stdout.strip())
+        gen_info = json.loads(gen_stdout.strip())
         batch_dir = Path(gen_info["batch_dir"])
     except (json.JSONDecodeError, KeyError):
         print(f"错误: 无法解析 generate-batch.py 输出:\n{gen_result.stdout}", file=sys.stderr)
@@ -604,8 +625,8 @@ def cmd_next(args: argparse.Namespace) -> int:
     batch_date = Path(state.batch_dir).name
     branch_name = make_branch_name(batch_date, commit.sequence, commit.subject)
 
-    worktree_path = Path(state.main_worktree_root).parent / f"GaleHarnessCodingCLI-{branch_name}"
     adapted_patch = Path(commit.adapted_patch)
+    worktree_path = Path(state.main_worktree_root).parent / f"GaleHarnessCodingCLI-{branch_name}"
 
     if dry_run:
         print("=== next --dry-run ===")
@@ -629,6 +650,7 @@ def cmd_next(args: argparse.Namespace) -> int:
     try:
         # --- Stage: worktree_create ---
         branch_name = _resolve_unique_branch(branch_name, state.remote_name, main_root_path)
+        worktree_path = Path(state.main_worktree_root).parent / f"GaleHarnessCodingCLI-{branch_name}"
         commit.branch = branch_name
         commit.base_branch = state.base_branch
         commit.worktree_path = str(worktree_path)
@@ -1072,29 +1094,99 @@ def _resume_from_review(state: SyncState, state_path: Path, dry_run: bool) -> in
         return EXIT_RUNTIME
 
 
+def _git_commit_exists(repo: Path, sha: str) -> bool:
+    r = run_cmd(["git", "rev-parse", "--verify", f"{sha}^{{commit}}"], repo)
+    return r.returncode == 0
+
+
+def _git_is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    r = run_cmd(["git", "merge-base", "--is-ancestor", ancestor, descendant], repo)
+    return r.returncode == 0
+
+
+def _should_write_upstream_ref(state: SyncState, commit: CommitEntry, main_root_path: Path) -> Optional[bool]:
+    """Validate upstream ancestry before mutating .upstream-ref."""
+    upstream_ref_path = main_root_path / ".upstream-ref"
+    upstream_repo_path = main_root_path / ".upstream-repo"
+
+    if not upstream_ref_path.is_file():
+        print(f"错误: 缺少 .upstream-ref 文件: {upstream_ref_path}", file=sys.stderr)
+        return None
+    if not upstream_repo_path.is_file():
+        print(f"错误: 缺少 .upstream-repo 文件: {upstream_repo_path}", file=sys.stderr)
+        return None
+
+    current_ref = upstream_ref_path.read_text(encoding="utf-8").strip()
+    if not current_ref:
+        print("错误: .upstream-ref 文件为空，拒绝推进 baseline。", file=sys.stderr)
+        return None
+
+    upstream_repo = Path(upstream_repo_path.read_text(encoding="utf-8").strip()).expanduser().resolve()
+    if not upstream_repo.is_dir():
+        print(f"错误: upstream 仓库路径无效: {upstream_repo}", file=sys.stderr)
+        return None
+
+    missing = [
+        label
+        for label, sha in [
+            ("state.baseline_sha", state.baseline_sha),
+            ("commit.sha", commit.sha),
+            (".upstream-ref", current_ref),
+        ]
+        if not _git_commit_exists(upstream_repo, sha)
+    ]
+    if missing:
+        print(f"错误: upstream 对账失败，以下引用不是有效 commit: {', '.join(missing)}", file=sys.stderr)
+        return None
+
+    if not _git_is_ancestor(upstream_repo, state.baseline_sha, commit.sha):
+        print(
+            f"错误: upstream ancestry 对账未通过 (baseline {state.baseline_sha[:7]} -> {commit.sha[:7]})",
+            file=sys.stderr,
+        )
+        print("拒绝更新 .upstream-ref，请人工检查 upstream 历史和 state.json。", file=sys.stderr)
+        return None
+
+    if current_ref == commit.sha:
+        print(f"提示: .upstream-ref 已经是 {commit.sha[:7]}，只推进本地状态。", file=sys.stderr)
+        return False
+
+    if current_ref == state.baseline_sha:
+        return True
+
+    if _git_is_ancestor(upstream_repo, commit.sha, current_ref):
+        print(
+            f"警告: .upstream-ref ({current_ref[:7]}) 已经位于当前 commit ({commit.sha[:7]}) 之后，只推进本地状态。",
+            file=sys.stderr,
+        )
+        return False
+
+    if _git_is_ancestor(upstream_repo, current_ref, commit.sha):
+        print(
+            f"警告: .upstream-ref ({current_ref[:7]}) 与 state baseline ({state.baseline_sha[:7]}) 不同，但仍是当前 commit 的祖先；将推进到 {commit.sha[:7]}。",
+            file=sys.stderr,
+        )
+        return True
+
+    print(
+        f"错误: .upstream-ref ({current_ref[:7]}) 与当前 commit ({commit.sha[:7]}) 分叉，拒绝推进 baseline。",
+        file=sys.stderr,
+    )
+    return None
+
+
 def _handle_pr_merged(
     state: SyncState, commit: CommitEntry, state_path: Path, main_root_path: Path,
 ) -> int:
     """Handle PR merged: reconcile .upstream-ref, cleanup, advance."""
     upstream_ref_path = main_root_path / ".upstream-ref"
 
-    # Ancestry reconciliation via upstream repo
-    upstream_repo_path = main_root_path / ".upstream-repo"
-    if upstream_repo_path.is_file():
-        upstream_repo = Path(upstream_repo_path.read_text(encoding="utf-8").strip()).expanduser().resolve()
-        if upstream_repo.is_dir():
-            # Check ancestry: baseline_sha should be ancestor of commit.sha
-            r = run_cmd(
-                ["git", "merge-base", "--is-ancestor", state.baseline_sha, commit.sha],
-                upstream_repo,
-            )
-            if r.returncode != 0:
-                print(f"警告: upstream ancestry 对账未通过 (baseline {state.baseline_sha[:7]} -> {commit.sha[:7]})", file=sys.stderr)
-                print("仍将推进 .upstream-ref，请人工确认 upstream 历史。", file=sys.stderr)
-
-    # Write .upstream-ref
-    upstream_ref_path.write_text(commit.sha + "\n", encoding="utf-8")
-    add_operation(state, "upstream_ref_update", f".upstream-ref 更新为 {commit.sha[:7]}")
+    should_write_ref = _should_write_upstream_ref(state, commit, main_root_path)
+    if should_write_ref is None:
+        return EXIT_STATE_CORRUPT
+    if should_write_ref:
+        upstream_ref_path.write_text(commit.sha + "\n", encoding="utf-8")
+        add_operation(state, "upstream_ref_update", f".upstream-ref 更新为 {commit.sha[:7]}")
 
     # Cleanup worktree
     if commit.worktree_path:
@@ -1124,7 +1216,7 @@ def _handle_pr_merged(
         save_state(state, state_path)
         print(f"=== 同步完成 ===")
         print(f"所有 {len(state.commits)} 个 commit 已处理完成。")
-        print(f".upstream-ref 已更新为 {commit.sha[:7]}")
+        print(f".upstream-ref {'已更新为' if should_write_ref else '保持为'} {commit.sha[:7]}")
         return EXIT_OK
     else:
         state.workflow_state = "idle"
@@ -1133,7 +1225,7 @@ def _handle_pr_merged(
         save_state(state, state_path)
         print(f"=== PR 已合并 ===")
         print(f"Commit #{commit.sequence} 已标记为 merged。")
-        print(f".upstream-ref 已更新为 {commit.sha[:7]}")
+        print(f".upstream-ref {'已更新为' if should_write_ref else '保持为'} {commit.sha[:7]}")
         print(f"\n下一个: #{next_commit.sequence} {next_commit.sha[:7]} {next_commit.subject}")
         print(f"请执行 next 继续。")
         return EXIT_OK
@@ -1217,6 +1309,76 @@ def cmd_skip(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _head_repository_name(pr_data: Dict[str, Any]) -> str:
+    head_repo = pr_data.get("headRepository") or {}
+    if not isinstance(head_repo, dict):
+        return ""
+    name_with_owner = head_repo.get("nameWithOwner")
+    if isinstance(name_with_owner, str):
+        return name_with_owner
+    owner = head_repo.get("owner") or {}
+    owner_login = owner.get("login") if isinstance(owner, dict) else ""
+    repo_name = head_repo.get("name")
+    if owner_login and repo_name:
+        return f"{owner_login}/{repo_name}"
+    return ""
+
+
+def _verify_cleanup_pr_target(state: SyncState, commit: CommitEntry, main_root_path: Path) -> bool:
+    if not commit.pr_number:
+        print("警告: 缺少 PR 编号，无法验真远程分支归属，跳过远程删除。", file=sys.stderr)
+        return False
+
+    result = run_cmd(
+        [
+            "gh", "pr", "view", str(commit.pr_number),
+            "--repo", state.github_repo,
+            "--json", "state,number,headRefName,baseRefName,headRepository",
+        ],
+        main_root_path,
+    )
+    if result.returncode != 0:
+        stderr_safe = _redact_text(_truncate(result.stderr or ""))
+        print(f"警告: 无法查询 PR #{commit.pr_number}，跳过远程删除。\n{stderr_safe}", file=sys.stderr)
+        return False
+
+    try:
+        pr_data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"警告: 无法解析 PR #{commit.pr_number} JSON，跳过远程删除:\n{result.stdout}", file=sys.stderr)
+        return False
+
+    problems: List[str] = []
+    if pr_data.get("number") not in (None, commit.pr_number):
+        problems.append(f"number 不一致 (PR: {pr_data.get('number')}, state: {commit.pr_number})")
+
+    pr_state = str(pr_data.get("state") or "").upper()
+    if pr_state == "OPEN":
+        problems.append("PR 仍为 OPEN")
+
+    expected_head = commit.pr_head_ref or commit.branch
+    head_ref = pr_data.get("headRefName") or ""
+    if expected_head and head_ref != expected_head:
+        problems.append(f"headRefName 不一致 (PR: {head_ref}, state: {expected_head})")
+
+    expected_base = commit.pr_base_ref or state.base_branch
+    base_ref = pr_data.get("baseRefName") or ""
+    if expected_base and base_ref != expected_base:
+        problems.append(f"baseRefName 不一致 (PR: {base_ref}, state: {expected_base})")
+
+    head_repo_name = _head_repository_name(pr_data)
+    if head_repo_name and head_repo_name != state.github_repo:
+        problems.append(f"headRepository 不一致 (PR: {head_repo_name}, expected: {state.github_repo})")
+
+    if problems:
+        print("警告: PR 验真未通过，跳过远程分支删除:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return False
+
+    return True
+
+
 def _do_force_cleanup(state: SyncState, commit: CommitEntry, main_root_path: Path) -> None:
     """Cleanup worktree and remote branch with validation."""
     # Validate and cleanup worktree
@@ -1246,16 +1408,17 @@ def _do_force_cleanup(state: SyncState, commit: CommitEntry, main_root_path: Pat
             print(f"警告: 分支 {branch} 是默认分支，跳过删除。", file=sys.stderr)
             return
 
-        # Delete remote branch
-        r = run_cmd(
-            ["git", "push", state.remote_name, "--delete", branch],
-            main_root_path,
-        )
-        if r.returncode != 0:
-            print(f"警告: 删除远程分支失败: {branch}", file=sys.stderr)
-            print(f"手动删除: git push {state.remote_name} --delete {branch}", file=sys.stderr)
-        else:
-            add_operation(state, "cleanup_remote_branch", f"已删除远程分支: {branch}")
+        # Delete remote branch only after PR metadata proves the branch target.
+        if _verify_cleanup_pr_target(state, commit, main_root_path):
+            r = run_cmd(
+                ["git", "push", state.remote_name, "--delete", branch],
+                main_root_path,
+            )
+            if r.returncode != 0:
+                print(f"警告: 删除远程分支失败: {branch}", file=sys.stderr)
+                print(f"手动删除: git push {state.remote_name} --delete {branch}", file=sys.stderr)
+            else:
+                add_operation(state, "cleanup_remote_branch", f"已删除远程分支: {branch}")
 
         # Delete local branch
         r = run_cmd(["git", "branch", "-D", branch], main_root_path)
@@ -1342,4 +1505,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/upstream-sync-cli.test.ts
+++ b/tests/upstream-sync-cli.test.ts
@@ -119,6 +119,16 @@ async function writeMockGh(mockBin: string, json: string): Promise<void> {
   await fs.writeFile(path.join(mockBin, "gh.cmd"), `@echo off\r\necho ${json}\r\n`, "utf8")
 }
 
+function envWithMockBin(mockBin: string): NodeJS.ProcessEnv {
+  const originalPath = process.env.PATH ?? process.env.Path ?? ""
+  const mockPath = `${mockBin}${path.delimiter}${originalPath}`
+  return {
+    ...gitEnv,
+    PATH: mockPath,
+    Path: mockPath,
+  }
+}
+
 function createMinimalState(
   repoRoot: string,
   overrides: Record<string, any> = {},
@@ -638,10 +648,7 @@ describe("sync-cli.py", () => {
       })
       await writeState(repoRoot, state)
 
-      const envWithMockGh = {
-        ...gitEnv,
-        PATH: `${mockBin}:${process.env.PATH}`,
-      }
+      const envWithMockGh = envWithMockBin(mockBin)
       const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
       expect(r.exitCode).toBe(0)
       expect(r.stdout).toContain("审查中")
@@ -684,10 +691,7 @@ describe("sync-cli.py", () => {
       })
       await writeState(repoRoot, state)
 
-      const envWithMockGh = {
-        ...gitEnv,
-        PATH: `${mockBin}:${process.env.PATH}`,
-      }
+      const envWithMockGh = envWithMockBin(mockBin)
       const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
       expect(r.exitCode).toBe(0)
 
@@ -729,10 +733,7 @@ describe("sync-cli.py", () => {
       })
       await writeState(repoRoot, state)
 
-      const envWithMockGh = {
-        ...gitEnv,
-        PATH: `${mockBin}:${process.env.PATH}`,
-      }
+      const envWithMockGh = envWithMockBin(mockBin)
       const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
       expect(r.exitCode).toBe(0)
 
@@ -773,7 +774,7 @@ describe("sync-cli.py", () => {
 
       const r = await runSyncCli(["resume"], repoRoot, {
         ...gitEnv,
-        PATH: `${mockBin}:${process.env.PATH}`,
+        PATH: envWithMockBin(mockBin).PATH,
       })
       expect(r.exitCode).toBe(3)
       expect(r.stderr).toContain("upstream 对账失败")
@@ -964,7 +965,7 @@ describe("sync-cli.py", () => {
 
       const r = await runSyncCli(["skip", "--force-cleanup"], repoRoot, {
         ...gitEnv,
-        PATH: `${mockBin}:${process.env.PATH}`,
+        PATH: envWithMockBin(mockBin).PATH,
       })
       expect(r.exitCode).toBe(0)
       expect(r.stderr).toContain("PR 验真未通过")
@@ -1031,10 +1032,7 @@ describe("sync-cli.py", () => {
       })
       await writeState(repoRoot, state)
 
-      const envWithMockGh = {
-        ...gitEnv,
-        PATH: `${mockBin}:${process.env.PATH}`,
-      }
+      const envWithMockGh = envWithMockBin(mockBin)
       const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
       expect(r.exitCode).toBe(0)
 

--- a/tests/upstream-sync-cli.test.ts
+++ b/tests/upstream-sync-cli.test.ts
@@ -1,0 +1,949 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { promises as fs } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const projectRoot = path.join(import.meta.dir, "..")
+const scriptPath = path.join(
+  projectRoot,
+  "scripts",
+  "upstream-sync",
+  "sync-cli.py",
+)
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function runSyncCli(
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv,
+) {
+  const proc = Bun.spawn(
+    ["python3", scriptPath, ...args],
+    {
+      cwd,
+      env: env ?? gitEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  )
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+async function runGit(
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv,
+): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    env: env ?? gitEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  if (exitCode !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`,
+    )
+  }
+  return stdout.trim()
+}
+
+/** Create a minimal git repo that satisfies resolve_main_worktree_root(). */
+async function initGitRepo(prefix: string): Promise<string> {
+  const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
+  await runGit(["init", "-b", "main"], repoRoot)
+  // Need at least one commit for git worktree list to work
+  const readmePath = path.join(repoRoot, "README.md")
+  await fs.writeFile(readmePath, "test\n", "utf8")
+  await runGit(["add", "."], repoRoot)
+  await runGit(["commit", "-m", "init"], repoRoot)
+  return repoRoot
+}
+
+function statePath(repoRoot: string): string {
+  return path.join(
+    repoRoot,
+    ".context",
+    "galeharness-cli",
+    "upstream-sync",
+    "state.json",
+  )
+}
+
+async function writeState(
+  repoRoot: string,
+  stateObj: Record<string, any>,
+): Promise<void> {
+  const sp = statePath(repoRoot)
+  await fs.mkdir(path.dirname(sp), { recursive: true })
+  await fs.writeFile(sp, JSON.stringify(stateObj, null, 2) + "\n", "utf8")
+}
+
+async function readState(repoRoot: string): Promise<Record<string, any>> {
+  const sp = statePath(repoRoot)
+  return JSON.parse(await fs.readFile(sp, "utf8"))
+}
+
+function createMinimalState(
+  repoRoot: string,
+  overrides: Record<string, any> = {},
+): Record<string, any> {
+  return {
+    schema_version: 1,
+    main_worktree_root: repoRoot,
+    target_repo_root: repoRoot,
+    batch_dir: path.join(repoRoot, "batch-2026-04-24"),
+    baseline_sha: "abc1234567890abcdef1234567890abcdef123456",
+    target_sha: "def4567890abcdef1234567890abcdef12345678",
+    base_branch: "main",
+    remote_name: "origin",
+    github_repo: "test-owner/test-repo",
+    current_index: 0,
+    workflow_state: "idle",
+    commits: [
+      {
+        sequence: 1,
+        sha: "aaa1111111111111111111111111111111111111",
+        subject: "feat: first change",
+        raw_patch: "/tmp/raw-1.patch",
+        adapted_patch: "/tmp/adapted-1.patch",
+        status: "pending",
+        worktree_path: null,
+        branch: null,
+        base_branch: "main",
+        pr_url: null,
+        pr_number: null,
+        pr_head_ref: null,
+        pr_base_ref: null,
+        failed_at: null,
+        failure_summary: null,
+      },
+    ],
+    operations: [],
+    ...overrides,
+  }
+}
+
+function makeCommitEntry(
+  seq: number,
+  overrides: Record<string, any> = {},
+): Record<string, any> {
+  return {
+    sequence: seq,
+    sha: `${seq}aa1111111111111111111111111111111111111`.slice(0, 40),
+    subject: `feat: change ${seq}`,
+    raw_patch: `/tmp/raw-${seq}.patch`,
+    adapted_patch: `/tmp/adapted-${seq}.patch`,
+    status: "pending",
+    worktree_path: null,
+    branch: null,
+    base_branch: "main",
+    pr_url: null,
+    pr_number: null,
+    pr_head_ref: null,
+    pr_base_ref: null,
+    failed_at: null,
+    failure_summary: null,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sync-cli.py", () => {
+  let repoRoot: string
+
+  beforeEach(async () => {
+    repoRoot = await initGitRepo("sync-cli-test-")
+  })
+
+  // =========================================================================
+  // State schema read/write
+  // =========================================================================
+  describe("state schema", () => {
+    test("status reports error and suggests init when no state.json exists", async () => {
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).not.toBe(0)
+      expect(r.stderr).toContain("init")
+    })
+
+    test("valid state.json is read correctly by status", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("Upstream Sync")
+      expect(r.stdout).toContain("idle")
+    })
+
+    test("invalid JSON in state.json causes exit code 3", async () => {
+      const sp = statePath(repoRoot)
+      await fs.mkdir(path.dirname(sp), { recursive: true })
+      await fs.writeFile(sp, "{not valid json!!!", "utf8")
+
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).toBe(3)
+      expect(r.stderr).toContain("JSON")
+    })
+
+    test("wrong schema_version causes error", async () => {
+      await writeState(
+        repoRoot,
+        createMinimalState(repoRoot, { schema_version: 99 }),
+      )
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).toBe(3)
+      expect(r.stderr).toContain("schema_version")
+    })
+  })
+
+  // =========================================================================
+  // init subcommand
+  // =========================================================================
+  describe("init", () => {
+    test("fails when .upstream-ref is missing", async () => {
+      const r = await runSyncCli(["init"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain(".upstream-ref")
+    })
+
+    test("fails when .upstream-repo is missing", async () => {
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-ref"),
+        "abc123\n",
+        "utf8",
+      )
+      const r = await runSyncCli(["init"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain(".upstream-repo")
+    })
+
+    test("refuses to overwrite incomplete state without --force", async () => {
+      // Write state with workflow_state != complete
+      await writeState(
+        repoRoot,
+        createMinimalState(repoRoot, { workflow_state: "idle" }),
+      )
+      // Also write .upstream-ref and .upstream-repo so we get past those checks
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-ref"),
+        "abc123\n",
+        "utf8",
+      )
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-repo"),
+        repoRoot + "\n",
+        "utf8",
+      )
+
+      const r = await runSyncCli(["init"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("未完成")
+    })
+
+    test("--dry-run does not write state.json", async () => {
+      // Need a valid baseline SHA from the repo
+      const headSha = await runGit(["rev-parse", "HEAD"], repoRoot)
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-ref"),
+        headSha + "\n",
+        "utf8",
+      )
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-repo"),
+        repoRoot + "\n",
+        "utf8",
+      )
+      // Add a remote so resolve_github_repo succeeds
+      await runGit(
+        ["remote", "add", "origin", "https://github.com/test-owner/test-repo.git"],
+        repoRoot,
+      )
+
+      const r = await runSyncCli(["init", "--dry-run"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("dry-run")
+      // state.json should not exist
+      const sp = statePath(repoRoot)
+      await expect(fs.access(sp)).rejects.toThrow()
+    })
+  })
+
+  // =========================================================================
+  // status subcommand
+  // =========================================================================
+  describe("status", () => {
+    test("displays progress percentage and commit queue", async () => {
+      const state = createMinimalState(repoRoot, {
+        commits: [
+          makeCommitEntry(1, { status: "merged" }),
+          makeCommitEntry(2, { status: "pending" }),
+          makeCommitEntry(3, { status: "pending" }),
+        ],
+        current_index: 1,
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("1/3")
+      expect(r.stdout).toContain("33%")
+      expect(r.stdout).toContain("feat: change 1")
+      expect(r.stdout).toContain("feat: change 2")
+    })
+
+    test("--json returns valid JSON with next_commit", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+
+      const r = await runSyncCli(["status", "--json"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      const data = JSON.parse(r.stdout)
+      expect(data.workflow_state).toBe("idle")
+      expect(data.next_commit).toBeDefined()
+      expect(data.next_commit.sequence).toBe(1)
+    })
+
+    test("--json returns null next_commit when all processed", async () => {
+      const state = createMinimalState(repoRoot, {
+        current_index: 1,
+        workflow_state: "complete",
+        commits: [makeCommitEntry(1, { status: "merged" })],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["status", "--json"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      const data = JSON.parse(r.stdout)
+      expect(data.next_commit).toBeNull()
+    })
+
+    test("no state.json returns non-zero exit code", async () => {
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).not.toBe(0)
+    })
+
+    test("shows suggestion for awaiting_human_review state", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["status"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("resume")
+    })
+  })
+
+  // =========================================================================
+  // next subcommand
+  // =========================================================================
+  describe("next", () => {
+    test("rejects when workflow_state is not idle", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "in_progress",
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["next"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("idle")
+    })
+
+    test("rejects when workflow_state is awaiting_human_review", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["next"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("resume")
+    })
+
+    test("rejects when workflow_state is failed", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "failed",
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["next"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("resume")
+    })
+
+    test("rejects when current commit is not pending (exit code 3)", async () => {
+      const state = createMinimalState(repoRoot, {
+        commits: [makeCommitEntry(1, { status: "merged" })],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["next"], repoRoot)
+      expect(r.exitCode).toBe(3)
+      expect(r.stderr).toContain("pending")
+    })
+
+    test("marks complete when current_index >= commits.length", async () => {
+      const state = createMinimalState(repoRoot, {
+        current_index: 1,
+        commits: [makeCommitEntry(1, { status: "merged" })],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["next"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("完成")
+
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("complete")
+    })
+
+    test("--dry-run outputs preview without modifying state", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+
+      const r = await runSyncCli(["next", "--dry-run"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("dry-run")
+      expect(r.stdout).toContain("feat: first change")
+
+      // State should remain unchanged
+      const state = await readState(repoRoot)
+      expect(state.workflow_state).toBe("idle")
+      expect(state.commits[0].status).toBe("pending")
+    })
+  })
+
+  // =========================================================================
+  // resume subcommand
+  // =========================================================================
+  describe("resume", () => {
+    test("rejects when workflow_state is idle", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+
+      const r = await runSyncCli(["resume"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("failed")
+      expect(r.stderr).toContain("awaiting_human_review")
+    })
+
+    test("rejects when workflow_state is complete", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "complete",
+        current_index: 1,
+        commits: [makeCommitEntry(1, { status: "merged" })],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("complete")
+    })
+
+    test("rejects when workflow_state is in_progress", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "in_progress",
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume"], repoRoot)
+      expect(r.exitCode).toBe(1)
+    })
+
+    test("--dry-run from failed state shows recovery plan", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "failed",
+        commits: [
+          makeCommitEntry(1, {
+            status: "failed",
+            failed_at: "test",
+            failure_summary: "bun test failed",
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume", "--dry-run"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("dry-run")
+      expect(r.stdout).toContain("test")
+
+      // State should not be modified
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("failed")
+    })
+
+    test("--dry-run from awaiting_human_review shows PR check plan", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-2026-04-24-0001-feat-change-1",
+            pr_base_ref: "main",
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume", "--dry-run"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("dry-run")
+      expect(r.stdout).toContain("42")
+    })
+
+    test("resume from failed: missing failed_at returns exit code 3", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "failed",
+        commits: [
+          makeCommitEntry(1, {
+            status: "failed",
+            failed_at: null,
+            failure_summary: null,
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume"], repoRoot)
+      expect(r.exitCode).toBe(3)
+      expect(r.stderr).toContain("failed_at")
+    })
+
+    test("resume from awaiting_human_review: missing pr_number returns exit code 3", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_number: null,
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume"], repoRoot)
+      expect(r.exitCode).toBe(3)
+    })
+
+    test("resume from awaiting_human_review with PR open keeps state", async () => {
+      // Create a mock gh script that returns OPEN status
+      const mockBin = await fs.mkdtemp(
+        path.join(os.tmpdir(), "sync-cli-mock-gh-"),
+      )
+      const ghScript = path.join(mockBin, "gh")
+      await fs.writeFile(
+        ghScript,
+        `#!/bin/sh
+echo '{"state":"OPEN","mergedAt":null,"url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}'
+`,
+        { mode: 0o755 },
+      )
+
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-2026-04-24-0001-feat-change-1",
+            pr_base_ref: "main",
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const envWithMockGh = {
+        ...gitEnv,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      }
+      const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("审查中")
+
+      // State should remain awaiting_human_review
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("awaiting_human_review")
+    })
+
+    test("KEY: resume after PR merged sets workflow_state to idle, not in_progress", async () => {
+      // Create a mock gh that returns MERGED
+      const mockBin = await fs.mkdtemp(
+        path.join(os.tmpdir(), "sync-cli-mock-gh-merged-"),
+      )
+      const ghScript = path.join(mockBin, "gh")
+      await fs.writeFile(
+        ghScript,
+        `#!/bin/sh
+echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}'
+`,
+        { mode: 0o755 },
+      )
+
+      // Two commits: first awaiting review, second pending
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-2026-04-24-0001-feat-change-1",
+            pr_base_ref: "main",
+            branch: "upstream-sync-2026-04-24-0001-feat-change-1",
+            worktree_path: path.join(repoRoot, "nonexistent-wt"),
+          }),
+          makeCommitEntry(2),
+        ],
+      })
+      // Write .upstream-repo pointing to repoRoot for ancestry check
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-repo"),
+        repoRoot + "\n",
+        "utf8",
+      )
+      await writeState(repoRoot, state)
+
+      const envWithMockGh = {
+        ...gitEnv,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      }
+      const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      // KEY ASSERTION: resume does NOT auto-trigger next; state goes to idle
+      expect(updated.workflow_state).toBe("idle")
+      expect(updated.current_index).toBe(1)
+      expect(updated.commits[0].status).toBe("merged")
+    })
+
+    test("resume after last PR merged sets workflow_state to complete", async () => {
+      const mockBin = await fs.mkdtemp(
+        path.join(os.tmpdir(), "sync-cli-mock-gh-complete-"),
+      )
+      const ghScript = path.join(mockBin, "gh")
+      await fs.writeFile(
+        ghScript,
+        `#!/bin/sh
+echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}'
+`,
+        { mode: 0o755 },
+      )
+
+      // Only one commit
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-2026-04-24-0001-feat-change-1",
+            pr_base_ref: "main",
+            branch: "upstream-sync-2026-04-24-0001-feat-change-1",
+            worktree_path: path.join(repoRoot, "nonexistent-wt"),
+          }),
+        ],
+      })
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-repo"),
+        repoRoot + "\n",
+        "utf8",
+      )
+      await writeState(repoRoot, state)
+
+      const envWithMockGh = {
+        ...gitEnv,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      }
+      const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("complete")
+      expect(updated.current_index).toBe(1)
+    })
+  })
+
+  // =========================================================================
+  // skip subcommand
+  // =========================================================================
+  describe("skip", () => {
+    test("skips pending commit and advances current_index", async () => {
+      const state = createMinimalState(repoRoot, {
+        commits: [makeCommitEntry(1), makeCommitEntry(2)],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("跳过")
+
+      const updated = await readState(repoRoot)
+      expect(updated.current_index).toBe(1)
+      expect(updated.commits[0].status).toBe("skipped")
+      expect(updated.workflow_state).toBe("idle")
+    })
+
+    test("skip records --reason in state", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+
+      const r = await runSyncCli(
+        ["skip", "--reason", "patch conflicts"],
+        repoRoot,
+      )
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.commits[0].failure_summary).toContain("patch conflicts")
+    })
+
+    test("skip last commit sets workflow_state to complete", async () => {
+      const state = createMinimalState(repoRoot, {
+        commits: [makeCommitEntry(1)],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("complete")
+      expect(updated.current_index).toBe(1)
+    })
+
+    test("KEY: skip does NOT auto-trigger next", async () => {
+      const state = createMinimalState(repoRoot, {
+        commits: [makeCommitEntry(1), makeCommitEntry(2)],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      // After skip, state is idle — not in_progress
+      expect(updated.workflow_state).toBe("idle")
+      expect(updated.commits[1].status).toBe("pending")
+    })
+
+    test("skip of failed commit is allowed", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "failed",
+        commits: [
+          makeCommitEntry(1, {
+            status: "failed",
+            failed_at: "test",
+            failure_summary: "test failure",
+          }),
+          makeCommitEntry(2),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.commits[0].status).toBe("skipped")
+      expect(updated.current_index).toBe(1)
+      expect(updated.workflow_state).toBe("idle")
+    })
+
+    test("skip of awaiting_human_review requires --force-cleanup", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(1)
+      expect(r.stderr).toContain("--force-cleanup")
+    })
+
+    test("skip --dry-run previews without modifying state", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+
+      const r = await runSyncCli(["skip", "--dry-run"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("dry-run")
+
+      const updated = await readState(repoRoot)
+      expect(updated.commits[0].status).toBe("pending")
+      expect(updated.current_index).toBe(0)
+    })
+
+    test("skip in_progress commit is rejected", async () => {
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "in_progress",
+        commits: [makeCommitEntry(1, { status: "in_progress" })],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(1)
+    })
+
+    test("skip with --force-cleanup on awaiting_human_review succeeds", async () => {
+      // Mock gh for the push --delete (will fail, but skip still succeeds with warning)
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            branch: "upstream-sync-2026-04-24-0001-feat-change-1",
+            worktree_path: null,
+          }),
+          makeCommitEntry(2),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip", "--force-cleanup"], repoRoot)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.commits[0].status).toBe("skipped")
+      expect(updated.current_index).toBe(1)
+      expect(updated.workflow_state).toBe("idle")
+    })
+  })
+
+  // =========================================================================
+  // Behavioral boundaries / edge cases
+  // =========================================================================
+  describe("behavioral boundaries", () => {
+    test("complete is terminal: next on complete state with all processed returns complete", async () => {
+      // current_index already past all commits
+      const state = createMinimalState(repoRoot, {
+        current_index: 2,
+        workflow_state: "idle",
+        commits: [
+          makeCommitEntry(1, { status: "merged" }),
+          makeCommitEntry(2, { status: "skipped" }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["next"], repoRoot)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("complete")
+    })
+
+    test("resume does not auto-next: merged state transitions to idle", async () => {
+      // This is a duplicate of the KEY test in resume, but placed here for emphasis
+      const mockBin = await fs.mkdtemp(
+        path.join(os.tmpdir(), "sync-cli-boundary-"),
+      )
+      const ghScript = path.join(mockBin, "gh")
+      await fs.writeFile(
+        ghScript,
+        `#!/bin/sh
+echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-test","baseRefName":"main"}'
+`,
+        { mode: 0o755 },
+      )
+
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-test",
+            pr_base_ref: "main",
+            branch: "upstream-sync-test",
+            worktree_path: null,
+          }),
+          makeCommitEntry(2),
+          makeCommitEntry(3),
+        ],
+      })
+      await fs.writeFile(
+        path.join(repoRoot, ".upstream-repo"),
+        repoRoot + "\n",
+        "utf8",
+      )
+      await writeState(repoRoot, state)
+
+      const envWithMockGh = {
+        ...gitEnv,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      }
+      const r = await runSyncCli(["resume"], repoRoot, envWithMockGh)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("idle")
+      // Commits 2 and 3 are still pending — next was NOT auto-triggered
+      expect(updated.commits[1].status).toBe("pending")
+      expect(updated.commits[2].status).toBe("pending")
+    })
+
+    test("no subcommand prints help and returns non-zero", async () => {
+      const r = await runSyncCli([], repoRoot)
+      expect(r.exitCode).not.toBe(0)
+    })
+
+    test("operations log is capped at MAX_OPERATIONS (50)", async () => {
+      const ops = Array.from({ length: 55 }, (_, i) => ({
+        timestamp: "2026-04-24T00:00:00+00:00",
+        operation: `op-${i}`,
+        summary: `summary ${i}`,
+      }))
+      const state = createMinimalState(repoRoot, {
+        operations: ops,
+        commits: [makeCommitEntry(1)],
+      })
+      await writeState(repoRoot, state)
+
+      // skip triggers add_operation which enforces the cap
+      const r = await runSyncCli(["skip"], repoRoot)
+      expect(r.exitCode).toBe(0)
+
+      const updated = await readState(repoRoot)
+      // MAX_OPERATIONS = 50, plus skip adds up to 2 new entries (skip + possibly complete)
+      expect(updated.operations.length).toBeLessThanOrEqual(50)
+    })
+  })
+})

--- a/tests/upstream-sync-cli.test.ts
+++ b/tests/upstream-sync-cli.test.ts
@@ -105,6 +105,20 @@ async function readState(repoRoot: string): Promise<Record<string, any>> {
   return JSON.parse(await fs.readFile(sp, "utf8"))
 }
 
+async function configureUpstreamAtHead(repoRoot: string): Promise<string> {
+  const headSha = await runGit(["rev-parse", "HEAD"], repoRoot)
+  await fs.writeFile(path.join(repoRoot, ".upstream-ref"), headSha + "\n", "utf8")
+  await fs.writeFile(path.join(repoRoot, ".upstream-repo"), repoRoot + "\n", "utf8")
+  return headSha
+}
+
+async function writeMockGh(mockBin: string, json: string): Promise<void> {
+  await fs.writeFile(path.join(mockBin, "gh"), `#!/bin/sh\necho '${json}'\n`, {
+    mode: 0o755,
+  })
+  await fs.writeFile(path.join(mockBin, "gh.cmd"), `@echo off\r\necho ${json}\r\n`, "utf8")
+}
+
 function createMinimalState(
   repoRoot: string,
   overrides: Record<string, any> = {},
@@ -198,6 +212,19 @@ describe("sync-cli.py", () => {
       expect(r.stdout).toContain("idle")
     })
 
+    test("plain status output is UTF-8 safe under ascii Python IO settings", async () => {
+      await writeState(repoRoot, createMinimalState(repoRoot))
+      const r = await runSyncCli(["status"], repoRoot, {
+        ...gitEnv,
+        PYTHONIOENCODING: "ascii",
+        LC_ALL: "C",
+        LANG: "C",
+      })
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("Upstream Sync")
+      expect(r.stderr).not.toContain("UnicodeEncodeError")
+    })
+
     test("invalid JSON in state.json causes exit code 3", async () => {
       const sp = statePath(repoRoot)
       await fs.mkdir(path.dirname(sp), { recursive: true })
@@ -261,6 +288,31 @@ describe("sync-cli.py", () => {
       const r = await runSyncCli(["init"], repoRoot)
       expect(r.exitCode).toBe(1)
       expect(r.stderr).toContain("未完成")
+    })
+
+    test("refuses corrupt existing state without --force", async () => {
+      await configureUpstreamAtHead(repoRoot)
+      const sp = statePath(repoRoot)
+      await fs.mkdir(path.dirname(sp), { recursive: true })
+      await fs.writeFile(sp, "{not valid json!!!", "utf8")
+
+      const r = await runSyncCli(["init"], repoRoot)
+      expect(r.exitCode).toBe(3)
+      expect(r.stderr).toContain("无法读取")
+      expect(r.stderr).toContain("--force")
+    })
+
+    test("no new upstream commits returns success without parsing JSON", async () => {
+      await configureUpstreamAtHead(repoRoot)
+      await runGit(
+        ["remote", "add", "origin", "https://github.com/test-owner/test-repo.git"],
+        repoRoot,
+      )
+
+      const r = await runSyncCli(["init"], repoRoot)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain("无需同步")
+      await expect(fs.access(statePath(repoRoot))).rejects.toThrow()
     })
 
     test("--dry-run does not write state.json", async () => {
@@ -500,10 +552,14 @@ describe("sync-cli.py", () => {
     })
 
     test("--dry-run from awaiting_human_review shows PR check plan", async () => {
+      const upstreamSha = await configureUpstreamAtHead(repoRoot)
       const state = createMinimalState(repoRoot, {
+        baseline_sha: upstreamSha,
+        target_sha: upstreamSha,
         workflow_state: "awaiting_human_review",
         commits: [
           makeCommitEntry(1, {
+            sha: upstreamSha,
             status: "awaiting_human_review",
             pr_url: "https://github.com/test/repo/pull/42",
             pr_number: 42,
@@ -559,19 +615,19 @@ describe("sync-cli.py", () => {
       const mockBin = await fs.mkdtemp(
         path.join(os.tmpdir(), "sync-cli-mock-gh-"),
       )
-      const ghScript = path.join(mockBin, "gh")
-      await fs.writeFile(
-        ghScript,
-        `#!/bin/sh
-echo '{"state":"OPEN","mergedAt":null,"url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}'
-`,
-        { mode: 0o755 },
+      await writeMockGh(
+        mockBin,
+        '{"state":"OPEN","mergedAt":null,"url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}',
       )
 
+      const upstreamSha = await configureUpstreamAtHead(repoRoot)
       const state = createMinimalState(repoRoot, {
+        baseline_sha: upstreamSha,
+        target_sha: upstreamSha,
         workflow_state: "awaiting_human_review",
         commits: [
           makeCommitEntry(1, {
+            sha: upstreamSha,
             status: "awaiting_human_review",
             pr_url: "https://github.com/test/repo/pull/42",
             pr_number: 42,
@@ -600,20 +656,21 @@ echo '{"state":"OPEN","mergedAt":null,"url":"https://github.com/test/repo/pull/4
       const mockBin = await fs.mkdtemp(
         path.join(os.tmpdir(), "sync-cli-mock-gh-merged-"),
       )
-      const ghScript = path.join(mockBin, "gh")
-      await fs.writeFile(
-        ghScript,
-        `#!/bin/sh
-echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}'
-`,
-        { mode: 0o755 },
+      await writeMockGh(
+        mockBin,
+        '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}',
       )
+
+      const upstreamSha = await configureUpstreamAtHead(repoRoot)
 
       // Two commits: first awaiting review, second pending
       const state = createMinimalState(repoRoot, {
+        baseline_sha: upstreamSha,
+        target_sha: upstreamSha,
         workflow_state: "awaiting_human_review",
         commits: [
           makeCommitEntry(1, {
+            sha: upstreamSha,
             status: "awaiting_human_review",
             pr_url: "https://github.com/test/repo/pull/42",
             pr_number: 42,
@@ -625,12 +682,6 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
           makeCommitEntry(2),
         ],
       })
-      // Write .upstream-repo pointing to repoRoot for ancestry check
-      await fs.writeFile(
-        path.join(repoRoot, ".upstream-repo"),
-        repoRoot + "\n",
-        "utf8",
-      )
       await writeState(repoRoot, state)
 
       const envWithMockGh = {
@@ -651,20 +702,21 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
       const mockBin = await fs.mkdtemp(
         path.join(os.tmpdir(), "sync-cli-mock-gh-complete-"),
       )
-      const ghScript = path.join(mockBin, "gh")
-      await fs.writeFile(
-        ghScript,
-        `#!/bin/sh
-echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}'
-`,
-        { mode: 0o755 },
+      await writeMockGh(
+        mockBin,
+        '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}',
       )
+
+      const upstreamSha = await configureUpstreamAtHead(repoRoot)
 
       // Only one commit
       const state = createMinimalState(repoRoot, {
+        baseline_sha: upstreamSha,
+        target_sha: upstreamSha,
         workflow_state: "awaiting_human_review",
         commits: [
           makeCommitEntry(1, {
+            sha: upstreamSha,
             status: "awaiting_human_review",
             pr_url: "https://github.com/test/repo/pull/42",
             pr_number: 42,
@@ -675,11 +727,6 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
           }),
         ],
       })
-      await fs.writeFile(
-        path.join(repoRoot, ".upstream-repo"),
-        repoRoot + "\n",
-        "utf8",
-      )
       await writeState(repoRoot, state)
 
       const envWithMockGh = {
@@ -692,6 +739,50 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
       const updated = await readState(repoRoot)
       expect(updated.workflow_state).toBe("complete")
       expect(updated.current_index).toBe(1)
+    })
+
+    test("resume after merged refuses to update upstream ref when ancestry check fails", async () => {
+      const mockBin = await fs.mkdtemp(
+        path.join(os.tmpdir(), "sync-cli-mock-gh-diverged-"),
+      )
+      await writeMockGh(
+        mockBin,
+        '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-2026-04-24-0001-feat-change-1","baseRefName":"main"}',
+      )
+
+      const upstreamSha = await configureUpstreamAtHead(repoRoot)
+      const invalidBaseline = "abc1234567890abcdef1234567890abcdef123456"
+      const state = createMinimalState(repoRoot, {
+        baseline_sha: invalidBaseline,
+        target_sha: upstreamSha,
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            sha: upstreamSha,
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-2026-04-24-0001-feat-change-1",
+            pr_base_ref: "main",
+            branch: "upstream-sync-2026-04-24-0001-feat-change-1",
+            worktree_path: path.join(repoRoot, "nonexistent-wt"),
+          }),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["resume"], repoRoot, {
+        ...gitEnv,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      })
+      expect(r.exitCode).toBe(3)
+      expect(r.stderr).toContain("upstream 对账失败")
+      expect(await fs.readFile(path.join(repoRoot, ".upstream-ref"), "utf8")).toBe(
+        upstreamSha + "\n",
+      )
+
+      const updated = await readState(repoRoot)
+      expect(updated.workflow_state).toBe("awaiting_human_review")
     })
   })
 
@@ -844,6 +935,45 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
       expect(updated.current_index).toBe(1)
       expect(updated.workflow_state).toBe("idle")
     })
+
+    test("skip --force-cleanup skips remote deletion when PR metadata mismatches state", async () => {
+      const mockBin = await fs.mkdtemp(
+        path.join(os.tmpdir(), "sync-cli-mock-gh-cleanup-"),
+      )
+      await writeMockGh(
+        mockBin,
+        '{"state":"CLOSED","number":42,"headRefName":"upstream-sync-other","baseRefName":"main","headRepository":{"nameWithOwner":"test-owner/test-repo"}}',
+      )
+
+      const state = createMinimalState(repoRoot, {
+        workflow_state: "awaiting_human_review",
+        commits: [
+          makeCommitEntry(1, {
+            status: "awaiting_human_review",
+            pr_url: "https://github.com/test/repo/pull/42",
+            pr_number: 42,
+            pr_head_ref: "upstream-sync-2026-04-24-0001-feat-change-1",
+            pr_base_ref: "main",
+            branch: "upstream-sync-2026-04-24-0001-feat-change-1",
+            worktree_path: null,
+          }),
+          makeCommitEntry(2),
+        ],
+      })
+      await writeState(repoRoot, state)
+
+      const r = await runSyncCli(["skip", "--force-cleanup"], repoRoot, {
+        ...gitEnv,
+        PATH: `${mockBin}:${process.env.PATH}`,
+      })
+      expect(r.exitCode).toBe(0)
+      expect(r.stderr).toContain("PR 验真未通过")
+      expect(r.stderr).toContain("headRefName")
+
+      const updated = await readState(repoRoot)
+      expect(updated.commits[0].status).toBe("skipped")
+      expect(updated.current_index).toBe(1)
+    })
   })
 
   // =========================================================================
@@ -874,19 +1004,19 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
       const mockBin = await fs.mkdtemp(
         path.join(os.tmpdir(), "sync-cli-boundary-"),
       )
-      const ghScript = path.join(mockBin, "gh")
-      await fs.writeFile(
-        ghScript,
-        `#!/bin/sh
-echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-test","baseRefName":"main"}'
-`,
-        { mode: 0o755 },
+      await writeMockGh(
+        mockBin,
+        '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.com/test/repo/pull/42","number":42,"headRefName":"upstream-sync-test","baseRefName":"main"}',
       )
 
+      const upstreamSha = await configureUpstreamAtHead(repoRoot)
       const state = createMinimalState(repoRoot, {
+        baseline_sha: upstreamSha,
+        target_sha: upstreamSha,
         workflow_state: "awaiting_human_review",
         commits: [
           makeCommitEntry(1, {
+            sha: upstreamSha,
             status: "awaiting_human_review",
             pr_url: "https://github.com/test/repo/pull/42",
             pr_number: 42,
@@ -899,11 +1029,6 @@ echo '{"state":"MERGED","mergedAt":"2026-04-24T12:00:00Z","url":"https://github.
           makeCommitEntry(3),
         ],
       })
-      await fs.writeFile(
-        path.join(repoRoot, ".upstream-repo"),
-        repoRoot + "\n",
-        "utf8",
-      )
       await writeState(repoRoot, state)
 
       const envWithMockGh = {


### PR DESCRIPTION
## 实现概述

将现有 `scripts/upstream-sync/` 的逐 commit patch 批次能力升级为半自动化 CLI，通过 `sync-cli.py` 提供 5 个子命令：

| 子命令 | 功能 |
|--------|------|
| `init` | 一次性生成 raw/adapted patch batch 并初始化 state.json |
| `status` | 显示同步概览、队列、当前状态和操作日志 |
| `next` | 消费 adapted patch，完成 worktree->patch->test->commit->push->PR 全流程 |
| `resume` | 处理 PR merged/open/closed 与 failed 恢复 |
| `skip` | 标记当前 commit 跳过，可选 --force-cleanup |

### 新增文件

- `scripts/upstream-sync/sync-cli.py` — 完整 CLI 实现（~1300 行）
- `tests/upstream-sync-cli.test.ts` — 42 个测试用例
- `docs/plans/2026-04-24-001-feat-upstream-sync-cli-automation-plan.md` — 计划文档

## 关键行为边界

### resume 不自动触发 next
`resume` 在检测到 PR merged 后，只执行：
1. upstream ancestry 对账
2. 写入 `.upstream-ref`
3. 清理 worktree
4. 推进 `current_index`
5. 设置 `workflow_state = "idle"`（或 `"complete"`）

用户必须显式执行 `next` 才会进入下一个 commit 的副作用流程。

### complete 是唯一批次完成终态
当 `current_index >= commits.length` 时，`workflow_state` 必须为 `"complete"`。`"idle"` 只表示还有 pending commit。

### 外部命令安全执行
- argv 数组传递，`shell=False`
- 显式 verified cwd（resolve + 存在性检查）
- stdout/stderr 脱敏（GH_TOKEN、Authorization、basic-auth URL）
- 日志截断（最多 500 字进入 state）

### GitHub 目标验真
- 所有 `gh` 调用显式传 `--repo owner/repo`
- `resume` 和 cleanup 前重新校验 PR repo、headRefName、baseRefName 与 state 一致
- `skip --force-cleanup` 通过 `git worktree list` 重新验证 worktree 目标

## 测试结果

51 pass, 0 fail (4 个测试文件, 162 expect() 调用)

- 42 个新增 sync-cli 测试覆盖 state/init/status/next/resume/skip 及关键 edge cases
- 9 个已有 upstream-sync 测试无回归

## 风险与待确认事项

1. **init 依赖 generate-batch.py 的输出格式** — 如果 generate-batch.py 输出结构变化，init 的 patch 队列解析需要同步更新
2. **预生成 adapted patch 可能失效** — 当连续 commit 修改相邻代码区域时，后续 patch 可能冲突。计划中已标注若失败可改为每轮重生成
3. **gh CLI 输出格式依赖** — resume 和 skip 依赖 `gh pr view --json` 的字段名，gh 版本升级可能影响
4. **Python 3.9 兼容** — 未使用 3.10+ 语法，但未在 3.9 以外版本测试
