### PR TITLE
feat(morph): 新增 iOS Morph-X 工作流

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,23 @@ Brainstorm -> Plan -> Work -> Review -> Compound -> Repeat
 | `/gh:brainstorm` | 在规划前探索需求和方案，通过交互式问答细化想法 | 检索相关需求，存储需求文档 |
 | `/gh:plan` | 将功能想法转化为详细实施计划，带自动置信度检查 | 检索相似方案，存储技术规划 |
 | `/gh:work` | 系统化执行工作项，使用 worktree 和任务追踪 | 检索实现模式，存储实现总结 |
+| `/gh:work-x` | iOS Morph-X 实施模式：在保留工作流能力的同时降低模板化代码重复风险 | 检索历史模式标签，存储蓝图/策略指纹 |
 | `/gh:review` | 多代理代码审查，分层角色和置信度门控 | 检索审查模式，存储审查发现 |
 | `/gh:compound` | 记录已解决问题，沉淀团队知识 | 检索相关解决方案，存储完整知识 |
 | `/gh:debug` | 系统性查找根本原因并修复缺陷 | 检索类似问题，存储调试经验 |
+| `/gh:debug-x` | iOS Morph-X 调试模式：保持根因定位纪律，并在修复产出后执行变换和相似度审计 | 检索历史模式标签，存储蓝图/策略指纹 |
 | `/gh:optimize` | 迭代优化循环，并行实验和 LLM 评分 | 检索优化策略，存储优化结果 |
 | `/document-review` | 多角色并行评审需求/方案文档 | 无 |
 | `/gh:sessions` | 搜索历史 Claude Code/Codex/Cursor 会话 | 无 |
 | `/gh:slack-research` | 搜索 Slack 获取组织上下文 | 无 |
 
 > **入口说明**：`/gh:brainstorm` 是主要入口 —— 它通过交互式问答将想法细化为需求文档，在不需要时自动跳过。`/gh:ideate` 效果显著但使用较少 —— 基于代码库主动发现改进建议。
+
+### iOS Morph-X 降低代码重复风险
+
+`/gh:work-x` 和 `/gh:debug-x` 是面向 iOS Swift/ObjC 代码产出的特殊工作流。它们先根据项目 seed、历史模式标签和 `.morph-config.yaml` 选择实现蓝图，再在代码产出后运行 `gale-harness morph --apply` 与 `gale-harness audit --similarity`，输出相似度风险报告。
+
+Morph-X 的定位是降低模板化代码重复风险并提供自检证据，不保证 Apple App Review 通过，也不能替代真实的产品、UI、内容和功能差异。
 
 ---
 

--- a/plugins/galeharness-cli/README.md
+++ b/plugins/galeharness-cli/README.md
@@ -32,7 +32,7 @@ language: zh-CN  # zh-CN (Chinese, default) or en (English)
 | Component | Count |
 |-----------|-------|
 | Agents | 50+ |
-| Skills | 42+ |
+| Skills | 39 |
 
 ## Skills
 
@@ -48,6 +48,8 @@ The primary entry points for engineering work, invoked as slash commands:
 | `/gh:review` | Structured code review with tiered persona agents, confidence gating, and dedup pipeline |
 | `/gh:work` | Execute work items systematically |
 | `/gh:debug` | Systematically find root causes and fix bugs -- traces causal chains, forms testable hypotheses, and implements test-first fixes |
+| `/gh:work-x` | Morph-X work execution for iOS code-output projects; reduces template-code repetition risk with blueprint constraints, safe transforms, and similarity audit |
+| `/gh:debug-x` | Morph-X debugging workflow for iOS fixes; keeps root-cause discipline while applying blueprint constraints, transforms, and similarity audit |
 | `/gh:compound` | Document solved problems to compound team knowledge |
 | `/gh:compound-refresh` | Refresh stale or drifting learnings and decide whether to keep, update, replace, or archive them |
 | `/gh:optimize` | Run iterative optimization loops with parallel experiments, measurement gates, and LLM-as-judge quality scoring |
@@ -138,6 +140,10 @@ Recommended operating model:
 |-------|-------------|
 | `/gh:polish-beta` | Human-in-the-loop polish phase after /gh:review — verifies review + CI, starts a dev server from `.claude/launch.json`, generates a testable checklist, and dispatches polish sub-agents for fixes. Emits stacked-PR seeds for oversized work |
 | `/lfg` | Full autonomous engineering workflow |
+
+### Morph-X CLI Utilities
+
+`gale-harness audit --similarity <project>` scans Swift/ObjC source against configured baselines and reports statement, token, structural, and control-flow similarity risk. `gale-harness morph --apply <project>` selects a deterministic Morph-X blueprint/strategy and calls an optional SwiftSyntax adapter when configured. These tools are for reducing template-code repetition risk; they do not guarantee Apple App Review outcomes.
 
 ## Agents
 

--- a/plugins/galeharness-cli/skills/gh-debug-x/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug-x/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: gh:debug-x
+description: Debug and fix iOS Swift/ObjC bugs with Morph-X blueprint, transform, audit, and memory fingerprinting to reduce template-code repetition risk.
+argument-hint: "[issue reference, error message, test path, or iOS broken behavior]"
+---
+
+# Debug-X and Fix
+
+Find the root cause first, then fix it with normal debug discipline plus Morph-X safeguards for iOS Swift/ObjC changes. This reduces template-code repetition risk; it does not guarantee App Review success and does not replace genuine product, UI, content, metadata, or feature differentiation.
+
+<bug_description> #$ARGUMENTS </bug_description>
+
+## Core Principles
+
+1. **Investigate before fixing.** Do not propose a fix until the causal chain from trigger to symptom has no gaps.
+2. **Predictions for uncertain links.** If a causal link is uncertain, state a prediction and test it.
+3. **One change at a time.** Avoid shotgun debugging.
+4. **When stuck, diagnose why.** Do not keep trying unrelated fixes.
+
+## Execution Flow
+
+<!-- HKT-PATCH:gale-task-start -->
+### Phase -1: Task Lifecycle Start
+
+Run:
+
+```bash
+gale-task log skill_started --skill gh:debug-x --title "<bug-description>" 2>/dev/null || true
+```
+
+If `gale-task` is unavailable, skip silently. This must never block debugging.
+<!-- /HKT-PATCH:gale-task-start -->
+
+| Phase | Name | Purpose |
+|-------|------|---------|
+| 0 | Triage | Parse input, fetch issue if referenced, retrieve memory |
+| 1 | Investigate | Reproduce the bug and trace the code path |
+| 2 | Root Cause | Test hypotheses, enforce causal chain gate |
+| 3 | Fix | Test-first fix with Morph-X blueprint constraints |
+| 4 | Morph-X | Apply transform, audit similarity, store fingerprints |
+| 5 | Close | Structured summary and handoff |
+
+### Phase 0: Triage
+
+Parse the input and create a clear problem statement.
+
+If the input references an issue tracker, fetch the issue when possible and extract symptoms, expected behavior, reproduction steps, and environment details. If the tracker cannot be fetched, ask the user for the relevant issue content.
+
+<!-- HKT-PATCH:phase-0.4 -->
+### Phase 0.4: HKTMemory Retrieve
+
+Retrieve related bugs, root causes, implementation constraints, and prior Morph-X blueprint/strategy fingerprints:
+
+```bash
+hkt-memory retrieve \
+  --query "<error, symptom, iOS component, Swift/ObjC file, blueprint or strategy tags>" \
+  --layer all --limit 10 --min-similarity 0.35 \
+  --vector-weight 0.7 --bm25-weight 0.3
+```
+
+Use results as context only. They may inform hypotheses and blueprint constraints, but do not copy historical code structure. If retrieval fails or returns nothing, proceed silently without blocking investigation.
+<!-- /HKT-PATCH:phase-0.4 -->
+
+<!-- HKT-PATCH:phase-0.4b -->
+### Phase 0.4b: HKTMemory Session Search
+
+Search related historical debug sessions:
+
+```bash
+hkt-memory session-search \
+  --query "gh:debug-x <error message or bug summary>" \
+  --limit 5
+```
+
+Use returned sessions as supplementary context. If unavailable, continue silently; session search is non-blocking.
+<!-- /HKT-PATCH:phase-0.4b -->
+
+Ask questions only when ambiguity blocks investigation. If the user mentions prior failed attempts, ask what was tried before reproducing.
+
+### Phase 1: Investigate
+
+1. Reproduce the bug with the smallest reliable command, test, UI path, or issue steps.
+2. If it cannot be reproduced after 2-3 attempts, document attempts and identify missing conditions.
+3. Trace the code path from symptom backward to the first invalid state.
+4. Check recent changes in relevant files and available logs, error trackers, browser console, database state, or Xcode output.
+5. Do not stop at the first suspicious function; root cause is where bad state originates.
+
+### Phase 2: Root Cause
+
+Form ranked hypotheses. For each:
+
+- State what is wrong and where.
+- Explain the causal chain from trigger to symptom.
+- For uncertain links, state a prediction and test it.
+
+**Causal chain gate:** Do not proceed to Phase 3 until the full causal chain has no gaps, unless the user explicitly authorizes proceeding with the best available hypothesis.
+
+Present findings before fixing: root cause, proposed fix, files likely to change, tests to add or update, and whether existing tests should have caught the bug.
+
+### Phase 3: Fix with Morph-X Blueprint Constraints
+
+If the user chose diagnosis-only handoff, skip the fix and move to close.
+
+Before writing Swift/ObjC fix code:
+
+1. Check `git status` and protect uncommitted user work.
+2. Load `.morph-config.yaml` from the target iOS project root if present; otherwise use in-memory defaults.
+3. Build a blueprint prompt block from the root cause, project seed, local architecture, retrieved historical fingerprints, blacklisted pattern tags, and test/build constraints.
+4. Choose constraints that avoid recently used strategy fingerprints across state management, module boundaries, file splitting, protocol boundaries, error handling, and data flow.
+5. If config, CLI, or memory is unavailable, continue with a manual blueprint summary and mark Morph-X as degraded.
+
+Then fix test-first:
+
+1. Write or identify a failing test for the root cause.
+2. Verify it fails for the right reason.
+3. Implement the minimal fix using the blueprint constraints.
+4. Verify the focused test passes.
+5. Run the relevant broader test target when the changed surface warrants it.
+
+### Phase 4: Morph-X Apply and Similarity Audit
+
+After the fix is implemented:
+
+1. Apply safe transformation when available:
+   ```bash
+   gale-harness morph --apply --config .morph-config.yaml --report .morph-report.json
+   ```
+   The transform must preserve semantics. If the command, SwiftSyntax, or ObjC support is unavailable, skip it, record the degraded reason, and continue.
+
+2. Run similarity audit:
+   ```bash
+   gale-harness audit --similarity --config .morph-config.yaml --report .morph-audit.json
+   ```
+   Capture AST/structure fingerprint, token n-gram, statement Jaccard, and control-flow approximation metrics when available. Missing baselines or tools are non-blocking degraded signals.
+
+3. Handle thresholds:
+   - Default behavior is warning-only.
+   - If `.morph-config.yaml` sets a blocking threshold and the audit exceeds it, pause and ask the user how to proceed.
+   - Do not claim the audit proves App Review compliance.
+
+<!-- HKT-PATCH:phase-4.5 -->
+### Phase 4.5: HKTMemory Store
+
+After diagnosis, or after the fix and Morph-X audit when a fix was applied, store a concise memory record:
+
+```bash
+hkt-memory store \
+  --content "<bug, root cause, fix or diagnosis-only result, repo-relative files, blueprint constraints, strategy fingerprint, audit status, degraded fallback notes>" \
+  --title "<debug-x bug title>" \
+  --topic "debug-x morph blueprint strategy fingerprint" \
+  --layer all
+```
+
+Store only summaries, tags, and fingerprints; do not store full source code. On error, note it as non-blocking and do not fail the debug workflow.
+<!-- /HKT-PATCH:phase-4.5 -->
+
+### Phase 5: Close
+
+Return:
+
+```text
+## Debug-X Summary
+**Problem**: [what was broken]
+**Root Cause**: [full causal chain with file references]
+**Fix**: [what changed or diagnosis only]
+**Blueprint**: [constraints and strategy fingerprint]
+**Morph Apply**: [report path or degraded reason]
+**Similarity Audit**: [report path, threshold result, blocking/warning decision]
+**Tests**: [commands run and results]
+**Compliance Boundary**: Reduces template-code repetition risk; does not guarantee App Review success.
+```
+
+Handoff options: commit the fix, document as a learning, post findings to the issue, view in Proof, or done.
+
+<!-- HKT-PATCH:gale-task-end -->
+Run `gale-task log skill_completed 2>/dev/null || true`. If unavailable, skip silently.
+<!-- /HKT-PATCH:gale-task-end -->

--- a/plugins/galeharness-cli/skills/gh-work-x/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work-x/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: gh:work-x
+description: Execute iOS Swift/ObjC work with Morph-X blueprint, transform, audit, and memory fingerprinting to reduce template-code repetition risk.
+argument-hint: "[Plan doc path or description of iOS work. Blank to auto use latest plan doc]"
+---
+
+# Work-X Execution Command
+
+Execute work with the normal shipping discipline, plus Morph-X safeguards for iOS Swift/ObjC output. This reduces template-code repetition risk; it does not guarantee App Review success and does not replace real product, UI, content, metadata, or feature differentiation.
+
+## Input Document
+
+<input_document> #$ARGUMENTS </input_document>
+
+## Execution Workflow
+
+### Phase 0: Input Triage
+
+Determine how to proceed from `<input_document>`.
+
+**Plan document:** read it completely in Phase 1 and treat it as a decision artifact.
+
+**Bare prompt:** scan likely files, nearby tests, and local conventions; classify scope:
+
+| Complexity | Signals | Action |
+|-----------|---------|--------|
+| Trivial | 1-2 files, no behavioral change | Setup, apply directly, and run relevant tests if behavior changed |
+| Small / Medium | Clear scope, under ~10 files | Build a task list, then execute |
+| Large | Cross-cutting, architecture, auth/payments/migrations, 10+ files | Recommend planning/brainstorming; if proceeding, build tasks carefully |
+
+<!-- HKT-PATCH:gale-task-start -->
+### Phase 0.1: Task Lifecycle Start
+
+Run:
+
+```bash
+gale-task log skill_started --skill gh:work-x --title "${ARGUMENTS:-work-x}" 2>/dev/null || true
+```
+
+If `gale-task` is unavailable, skip silently. This must never block execution.
+<!-- /HKT-PATCH:gale-task-start -->
+
+<!-- HKT-PATCH:phase-0.6 -->
+### Phase 0.6: HKTMemory Retrieve
+
+Before choosing a blueprint, retrieve related implementation context and historical Morph-X fingerprints:
+
+```bash
+hkt-memory retrieve \
+  --query "<task summary, iOS components, Swift/ObjC files, prior blueprint or strategy tags>" \
+  --layer all --limit 10 --min-similarity 0.35 \
+  --vector-weight 0.7 --bm25-weight 0.3
+```
+
+Use results only as context: extract constraints, avoided patterns, and prior blueprint/strategy fingerprints. Do not copy historical code shape. If no results or any command error occurs, proceed silently without blocking.
+<!-- /HKT-PATCH:phase-0.6 -->
+
+<!-- HKT-PATCH:phase-0.6b -->
+### Phase 0.6b: HKTMemory Session Search
+
+Query related work sessions:
+
+```bash
+hkt-memory session-search \
+  --query "gh:work-x <task title or iOS feature summary>" \
+  --limit 5
+```
+
+Use returned sessions as supplementary context for blueprint selection. If unavailable, continue silently; session search is non-blocking.
+<!-- /HKT-PATCH:phase-0.6b -->
+
+### Phase 1: Quick Start
+
+1. **Read Plan and Clarify** when a plan/spec path was provided.
+   - Read the full document, including requirements, scope boundaries, implementation units, files, test scenarios, verification, and deferred unknowns.
+   - Ask only when ambiguity blocks correct execution.
+   - Get user approval to proceed when the source workflow requires it.
+
+2. **Setup Environment**
+   - Check the current branch and default branch.
+   - If already on a meaningful feature branch, continue unless the user asks otherwise.
+   - If on the default branch, create a feature branch or worktree unless the user explicitly confirms working on the default branch.
+   - Respect workspace safety: do not overwrite uncommitted user work.
+
+3. **Create Task List**
+   - Derive tasks from implementation units, dependencies, file ownership, tests, and verification.
+   - Preserve plan U-IDs in task names.
+   - Include quality checks and relevant tests.
+
+4. **Choose Execution Strategy**
+   - Use inline execution for small work or interactive tasks.
+   - Use serial subagents for dependent multi-unit work.
+   - Use parallel subagents only after checking file ownership overlap; do not stage, commit, or run the full suite inside parallel workers.
+
+### Phase 1.5: Morph-X Blueprint Constraints
+
+Before writing or changing Swift/ObjC code:
+
+1. Load `.morph-config.yaml` from the target iOS project root if present. If missing, use in-memory defaults and record `config_source: default`.
+2. Build a blueprint prompt block from: project seed, feature intent, retrieved historical fingerprints, blacklisted pattern tags, existing architecture, and local test/build constraints.
+3. Select a blueprint that differs from recently used strategy fingerprints across:
+   - state management
+   - module boundaries
+   - file splitting
+   - protocol or abstraction boundaries
+   - error handling
+   - data-flow organization
+4. Write the constraints into the task notes before implementation. The constraints should guide original structure; they must not request cosmetic churn or semantic changes.
+5. If config, CLI, or memory retrieval is unavailable, continue with a manual blueprint summary and mark Morph-X as degraded, not failed.
+
+### Phase 2: Execute
+
+For each task:
+
+1. Mark it in progress.
+2. Read relevant files and local patterns.
+3. Find adjacent tests before editing.
+4. Implement with existing conventions and the Phase 1.5 blueprint constraints.
+5. Run a System-Wide Test Check: if shared contracts or user-facing behavior changed, choose a relevant broader test target; otherwise run focused tests.
+6. Assess quality before moving on: behavior covered, edge cases considered, no unrelated refactors, no user work overwritten.
+
+### Phase 3: Morph-X Apply and Similarity Audit
+
+After Swift/ObjC code is produced and before final summary:
+
+1. Apply safe transformation when the CLI is available:
+   ```bash
+   gale-harness morph --apply --config .morph-config.yaml --report .morph-report.json
+   ```
+   The transform must be semantics-preserving. If the command, SwiftSyntax, or ObjC adapter is unavailable, skip the transform, record the reason, and continue to audit fallback.
+
+2. Audit similarity:
+   ```bash
+   gale-harness audit --similarity --config .morph-config.yaml --report .morph-audit.json
+   ```
+   Include AST/structure fingerprint, token n-gram, statement Jaccard, and control-flow approximation results when available. Missing baselines or tools are non-blocking and should be reported as degraded signals.
+
+3. Handle thresholds:
+   - Default behavior is warn, not block.
+   - If `.morph-config.yaml` configures a blocking threshold and the audit exceeds it, stop before finalizing code and ask the user how to proceed.
+   - Never claim the audit proves App Review compliance.
+
+4. Run focused compile/test verification appropriate to the changed iOS project when available. If no Xcode or Swift test target is runnable, state the gap.
+
+<!-- HKT-PATCH:phase-4.5 -->
+### Phase 4.5: HKTMemory Store
+
+After implementation and Morph-X audit, store a concise memory record:
+
+```bash
+hkt-memory store \
+  --content "<summary with repo-relative files, blueprint constraints, strategy fingerprint, audit status, degraded fallback notes>" \
+  --title "<work-x title>" \
+  --topic "work-x morph blueprint strategy fingerprint" \
+  --layer all
+```
+
+Store only summaries, tags, and fingerprints; do not store full source code. On error, note it as non-blocking and do not fail the workflow.
+<!-- /HKT-PATCH:phase-4.5 -->
+
+### Phase 5: Close
+
+Return:
+
+```text
+## Work-X Summary
+**Completed**: [what changed]
+**Blueprint**: [constraints and strategy fingerprint]
+**Morph Apply**: [report path or degraded reason]
+**Similarity Audit**: [report path, threshold result, blocking/warning decision]
+**Tests**: [commands run and results]
+**Compliance Boundary**: Reduces template-code repetition risk; does not guarantee App Review success.
+```
+
+<!-- HKT-PATCH:gale-task-end -->
+Run `gale-task log skill_completed 2>/dev/null || true`. If unavailable, skip silently.
+<!-- /HKT-PATCH:gale-task-end -->

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,136 @@
+import { defineCommand } from "citty"
+import { promises as fs } from "fs"
+import path from "path"
+import { loadMorphConfig } from "../morph/config"
+import { collectMorphSourceFiles, matchBaselineFiles } from "../morph/files"
+import { buildMorphSimilarityReport } from "../morph/report"
+import type { MorphConfigThresholds, MorphSimilarityReport } from "../morph/types"
+
+export default defineCommand({
+  meta: {
+    name: "audit",
+    description: "Audit generated code for Morph-X similarity risk",
+  },
+  args: {
+    target: {
+      type: "positional",
+      required: false,
+      default: ".",
+      description: "Project directory or source file to scan",
+    },
+    similarity: {
+      type: "boolean",
+      default: false,
+      description: "Run similarity audit",
+    },
+    baseline: {
+      type: "string",
+      description: "Baseline directory or source file. Overrides .morph-config.yaml baselines.",
+    },
+    threshold: {
+      type: "string",
+      description: "Override all similarity thresholds with a number between 0 and 1",
+    },
+    json: {
+      type: "boolean",
+      default: false,
+      description: "Print machine-readable JSON",
+    },
+    failOnThreshold: {
+      type: "boolean",
+      default: false,
+      alias: "fail-on-threshold",
+      description: "Exit non-zero when any file meets or exceeds a threshold",
+    },
+  },
+  async run({ args }) {
+    if (!args.similarity) {
+      throw new Error("audit currently requires --similarity")
+    }
+
+    const target = String(args.target ?? ".")
+    const thresholdOverride = parseThresholdOverride(args.threshold)
+    const baselinePaths = args.baseline ? splitList(String(args.baseline)) : undefined
+    const configRoot = await resolveConfigRoot(target)
+    const config = await loadMorphConfig(configRoot, {
+      baselinePaths,
+      thresholds: thresholdOverride ? allThresholds(thresholdOverride) : undefined,
+    })
+    const sources = await collectMorphSourceFiles(target, { excludePaths: config.baselines.paths })
+    const matches = await matchBaselineFiles(sources, config.baselines.paths)
+    const report = buildMorphSimilarityReport(matches.map((match) => ({
+      path: match.source.path,
+      source: match.source.content,
+      baselinePath: match.baselinePath,
+      baselineSource: match.baselineSource,
+    })), config.thresholds)
+    report.warnings.push(...config.warnings.map((warning) => warning.code))
+
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2))
+    } else {
+      printSimilarityReport(report)
+    }
+
+    if (args.failOnThreshold && report.status === "blocked") {
+      process.exitCode = 2
+    }
+  },
+})
+
+function parseThresholdOverride(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error("Invalid --threshold: expected number between 0 and 1")
+  }
+  return parsed
+}
+
+async function resolveConfigRoot(target: string): Promise<string> {
+  const resolved = path.resolve(target)
+  const stat = await fs.stat(resolved)
+  return stat.isDirectory() ? resolved : path.dirname(resolved)
+}
+
+function allThresholds(value: number): Partial<MorphConfigThresholds> {
+  return {
+    statementJaccard: value,
+    tokenNgram: value,
+    structuralHash: value,
+    controlFlow: value,
+  }
+}
+
+function splitList(value: string): string[] {
+  return value.split(",").map((item) => item.trim()).filter(Boolean)
+}
+
+function printSimilarityReport(report: MorphSimilarityReport): void {
+  console.log(`Morph-X similarity audit: ${report.status}`)
+  if (report.files.length === 0) {
+    console.log("No Swift/ObjC source files found.")
+  }
+
+  for (const file of report.files) {
+    const marker = file.highRisk ? "risk" : "ok"
+    const metrics = Object.entries(file.metrics)
+      .map(([name, score]) => `${name}=${formatScore(score)}`)
+      .join(", ")
+    console.log(`- ${marker} ${file.path}${metrics ? ` (${metrics})` : ""}`)
+    for (const reason of file.riskReasons) {
+      console.log(`  ${reason.reason}`)
+    }
+    for (const warning of file.warnings) {
+      console.log(`  warning: ${warning}`)
+    }
+  }
+
+  for (const warning of report.warnings) {
+    console.log(`warning: ${warning}`)
+  }
+}
+
+function formatScore(value: unknown): string {
+  return typeof value === "number" && Number.isFinite(value) ? value.toFixed(3) : "n/a"
+}

--- a/src/commands/morph.ts
+++ b/src/commands/morph.ts
@@ -1,0 +1,123 @@
+import { defineCommand } from "citty"
+import { promises as fs } from "fs"
+import path from "path"
+import { loadMorphConfig } from "../morph/config"
+import { collectMorphSourceFiles, matchBaselineFiles } from "../morph/files"
+import { buildMorphSimilarityReport } from "../morph/report"
+import { runSwiftAdapter, applySwiftAdapterResult } from "../morph/swift-adapter"
+import { selectMorphStrategy } from "../morph/strategies"
+
+export default defineCommand({
+  meta: {
+    name: "morph",
+    description: "Apply Morph-X code-structure transforms and produce an audit report",
+  },
+  args: {
+    target: {
+      type: "positional",
+      required: false,
+      default: ".",
+      description: "Project directory or source file to process",
+    },
+    apply: {
+      type: "boolean",
+      default: false,
+      description: "Apply transformations when an adapter is available",
+    },
+    baseline: {
+      type: "string",
+      description: "Baseline directory or source file. Overrides .morph-config.yaml baselines.",
+    },
+    seed: {
+      type: "string",
+      description: "Override Morph-X project seed",
+    },
+    json: {
+      type: "boolean",
+      default: false,
+      description: "Print machine-readable JSON",
+    },
+    report: {
+      type: "string",
+      description: "Write JSON report to this file",
+    },
+  },
+  async run({ args }) {
+    const target = String(args.target ?? ".")
+    const baselinePaths = args.baseline ? splitList(String(args.baseline)) : undefined
+    const configRoot = await resolveConfigRoot(target)
+    const config = await loadMorphConfig(configRoot, {
+      seed: args.seed ? String(args.seed) : undefined,
+      baselinePaths,
+    })
+    const sources = await collectMorphSourceFiles(target, { excludePaths: config.baselines.paths })
+    const selection = selectMorphStrategy({
+      seed: config.seed,
+      usedFingerprints: config.usedFingerprints,
+      blacklistedTags: config.blacklistedPatternTags,
+      languages: Array.from(new Set(sources.map((source) => source.language))),
+    })
+
+    const swiftSources = sources.filter((source) => source.language === "swift")
+    const adapterResult = await runSwiftAdapter({
+      files: swiftSources.map((source) => ({ path: source.path, content: source.content })),
+      strategyFingerprint: selection.strategy.fingerprint,
+      strategyTags: selection.strategy.tags,
+      apply: Boolean(args.apply),
+    })
+    const written = args.apply ? await applySwiftAdapterResult(adapterResult) : []
+    const refreshedSources = written.length > 0
+      ? await collectMorphSourceFiles(target, { excludePaths: config.baselines.paths })
+      : sources
+    const matches = await matchBaselineFiles(refreshedSources, config.baselines.paths)
+    const similarity = buildMorphSimilarityReport(matches.map((match) => ({
+      path: match.source.path,
+      source: match.source.content,
+      baselinePath: match.baselinePath,
+      baselineSource: match.baselineSource,
+    })), config.thresholds)
+    similarity.warnings.push(...config.warnings.map((warning) => warning.code), ...adapterResult.warnings)
+
+    const report = {
+      status: similarity.status,
+      seed: config.seed,
+      blueprint: selection.blueprint,
+      strategy: selection.strategy,
+      fingerprint: selection.fingerprint,
+      applied: Boolean(args.apply),
+      filesChanged: written,
+      adapter: {
+        ok: adapterResult.ok,
+        unavailable: adapterResult.unavailable === true,
+        warnings: adapterResult.warnings,
+      },
+      similarity,
+      warnings: [...selection.warnings, ...similarity.warnings],
+    }
+
+    if (args.report) {
+      await fs.writeFile(String(args.report), JSON.stringify(report, null, 2) + "\n", "utf8")
+    }
+
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2))
+    } else {
+      console.log(`Morph-X strategy: ${selection.strategy.fingerprint}`)
+      console.log(`Morph-X blueprint: ${selection.blueprint.fingerprint}`)
+      console.log(`Files changed: ${written.length}`)
+      for (const warning of report.warnings) {
+        console.log(`warning: ${warning}`)
+      }
+    }
+  },
+})
+
+function splitList(value: string): string[] {
+  return value.split(",").map((item) => item.trim()).filter(Boolean)
+}
+
+async function resolveConfigRoot(target: string): Promise<string> {
+  const resolved = path.resolve(target)
+  const stat = await fs.stat(resolved)
+  return stat.isDirectory() ? resolved : path.dirname(resolved)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import pluginPath from "./commands/plugin-path"
 import sync from "./commands/sync"
 import board from "./commands/board"
 import update from "./commands/update"
+import audit from "./commands/audit"
+import morph from "./commands/morph"
 
 const main = defineCommand({
   meta: {
@@ -23,6 +25,8 @@ const main = defineCommand({
     sync: () => sync,
     board: () => board,
     update: () => update,
+    audit: () => audit,
+    morph: () => morph,
   },
   run: async (ctx) => {
     const hasSubCommand = ctx.rawArgs.some((arg) => !arg.startsWith("-"));

--- a/src/morph/adapters/README.md
+++ b/src/morph/adapters/README.md
@@ -1,0 +1,42 @@
+# Morph-X Swift Adapter
+
+Morph-X keeps the TypeScript CLI as the orchestrator and delegates semantic Swift
+rewrites to an optional SwiftSyntax executable.
+
+Set `MORPH_SWIFT_ADAPTER` to an executable that:
+
+1. Reads one JSON request from stdin.
+2. Writes one JSON response to stdout.
+3. Leaves files untouched. The TypeScript CLI owns writes after validating the response.
+
+Request shape:
+
+```json
+{
+  "files": [{ "path": "/project/ViewModel.swift", "content": "..." }],
+  "strategyFingerprint": "strategy:...",
+  "strategyTags": ["control.guard-first"],
+  "apply": true
+}
+```
+
+Response shape:
+
+```json
+{
+  "ok": true,
+  "files": [
+    {
+      "path": "/project/ViewModel.swift",
+      "changed": true,
+      "content": "...",
+      "warnings": []
+    }
+  ],
+  "warnings": []
+}
+```
+
+When the adapter is unavailable, Morph-X falls back to detection/reporting and
+emits an `adapter_unavailable` warning instead of requiring Xcode for ordinary
+GaleHarnessCLI usage.

--- a/src/morph/blueprints.ts
+++ b/src/morph/blueprints.ts
@@ -1,0 +1,146 @@
+import type {
+  MorphBlueprintDimension,
+  MorphBlueprintSelection,
+  MorphDimensionOption,
+  MorphLanguage,
+  MorphUsedFingerprint,
+} from "./types"
+
+export const BLUEPRINT_DIMENSIONS: MorphBlueprintDimension[] = [
+  "state",
+  "moduleBoundary",
+  "fileSplit",
+  "abstraction",
+  "dependencyInjection",
+  "errorPropagation",
+  "asyncFlow",
+]
+
+export const BLUEPRINT_REGISTRY: MorphDimensionOption<MorphBlueprintDimension>[] = [
+  option("state.mvvm-service", "state", ["state.mvvm-service", "state.observable-view-model", "risk.mvvm-like"], "View-model owned state", "Keep mutable UI state inside view models; views bind to derived read-only values."),
+  option("state.reducer-local", "state", ["state.reducer-local", "state.value-state", "shape.reducer"], "Reducer-local value state", "Represent screen state as value snapshots updated through small reducer-style transitions."),
+  option("state.coordinator-store", "state", ["state.coordinator-store", "state.flow-owned", "shape.coordinator"], "Coordinator flow store", "Let flow coordinators own cross-screen state and pass focused value slices into views/controllers."),
+
+  option("boundary.service-protocol", "moduleBoundary", ["boundary.service-protocol", "boundary.mvvm-service", "risk.service-like"], "Service protocol boundary", "Place IO behind service protocols and inject protocol-typed dependencies at feature boundaries."),
+  option("boundary.usecase-pipeline", "moduleBoundary", ["boundary.usecase-pipeline", "boundary.command-query", "shape.usecase"], "Use-case pipeline boundary", "Expose feature behavior through use-case objects that separate command and query paths."),
+  option("boundary.feature-facade", "moduleBoundary", ["boundary.feature-facade", "boundary.facade-events", "shape.facade"], "Feature facade boundary", "Wrap feature internals behind a facade that emits domain events and accepts explicit intents."),
+
+  option("files.by-layer", "fileSplit", ["files.by-layer", "files.layered", "risk.template-layer"], "Layered files", "Split files by layer: view/controller, state, service, model, and tests."),
+  option("files.by-flow", "fileSplit", ["files.by-flow", "files.vertical-slice", "shape.flow-slice"], "Flow-sliced files", "Group files by user flow and keep supporting state, IO, and view code near that flow."),
+  option("files.by-capability", "fileSplit", ["files.by-capability", "files.capability-first", "shape.capability"], "Capability files", "Split files by capability such as loading, validation, presentation mapping, and persistence."),
+
+  option("abstraction.protocol-minimal", "abstraction", ["abstraction.protocol-minimal", "abstraction.protocols", "shape.protocol"], "Minimal protocols", "Extract protocols only at external seams and keep local collaborators concrete."),
+  option("abstraction.generic-policy", "abstraction", ["abstraction.generic-policy", "abstraction.generics", "shape.policy"], "Generic policies", "Model variable behavior as small generic policy types rather than service inheritance."),
+  option("abstraction.closure-ports", "abstraction", ["abstraction.closure-ports", "abstraction.functional-ports", "shape.closure"], "Closure ports", "Pass narrow closure ports for one-off effects instead of broad protocols."),
+
+  option("di.initializer", "dependencyInjection", ["di.initializer", "di.explicit", "shape.constructor"], "Initializer injection", "Require dependencies through initializers and avoid hidden global lookup."),
+  option("di.environment", "dependencyInjection", ["di.environment", "di.context", "shape.environment"], "Environment context", "Collect shared collaborators in an explicit environment object passed through feature setup."),
+  option("di.factory", "dependencyInjection", ["di.factory", "di.builder", "shape.factory"], "Factory injection", "Use factories/builders to create child components and keep construction logic outside feature behavior."),
+
+  option("errors.typed-result", "errorPropagation", ["errors.typed-result", "errors.result", "shape.result"], "Typed results", "Return typed Result values from recoverable operations and map errors at the feature edge."),
+  option("errors.domain-enum", "errorPropagation", ["errors.domain-enum", "errors.exhaustive", "shape.domain-error"], "Domain error enum", "Convert external failures into feature-owned error enums before UI presentation."),
+  option("errors.recovery-route", "errorPropagation", ["errors.recovery-route", "errors.route", "shape.recovery"], "Recovery routes", "Represent failures as recovery routes/actions that the coordinator or facade handles."),
+
+  option("async.structured-task", "asyncFlow", ["async.structured-task", "async.await", "shape.structured-concurrency"], "Structured tasks", "Use structured async functions and keep task lifetime tied to the owning screen or flow."),
+  option("async.event-stream", "asyncFlow", ["async.event-stream", "async.sequence", "shape.stream"], "Event streams", "Model long-lived updates as event streams consumed by state transitions."),
+  option("async.callback-adapter", "asyncFlow", ["async.callback-adapter", "async.bridge", "shape.adapter"], "Callback adapters", "Isolate callback-based APIs in adapters and expose simple async or Result-returning calls upstream."),
+]
+
+export function selectBlueprint(input: {
+  seed: string
+  usedFingerprints?: MorphUsedFingerprint[]
+  blacklistedTags?: string[]
+  languages?: MorphLanguage[]
+}): MorphBlueprintSelection {
+  const usedTags = new Set((input.usedFingerprints ?? []).flatMap((fingerprint) => fingerprint.tags))
+  const blacklistedTags = new Set(input.blacklistedTags ?? [])
+  const dimensions = {} as Record<MorphBlueprintDimension, MorphDimensionOption<MorphBlueprintDimension>>
+
+  for (const dimension of BLUEPRINT_DIMENSIONS) {
+    const selected = selectDimensionOption({
+      dimension,
+      options: BLUEPRINT_REGISTRY.filter((item) => item.dimension === dimension),
+      seed: input.seed,
+      usedTags,
+      blacklistedTags,
+      languages: input.languages,
+    })
+    if (!selected) {
+      throw new Error(`No Morph-X blueprint option remains for dimension ${dimension}; remove blacklisted tags or add more registry options.`)
+    }
+    dimensions[dimension] = selected
+  }
+
+  const tags = BLUEPRINT_DIMENSIONS.flatMap((dimension) => dimensions[dimension].tags)
+  const constraints = BLUEPRINT_DIMENSIONS.map((dimension) => dimensions[dimension].constraint)
+  return {
+    fingerprint: `blueprint:${stableHash(["blueprint", input.seed, ...tags].join("|"))}`,
+    tags,
+    constraints,
+    dimensions,
+  }
+}
+
+export function stableHash(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+export function hasBlacklistedTag(tags: string[], blacklistedTags: Set<string>): boolean {
+  return tags.some((tag) => blacklistedTags.has(tag))
+}
+
+export function supportsLanguages(option: MorphDimensionOption<string>, languages: MorphLanguage[] | undefined): boolean {
+  if (!option.supportedLanguages || option.supportedLanguages.length === 0) return true
+  if (!languages || languages.length === 0) return true
+  const concreteLanguages = languages.filter((language) => language !== "unknown")
+  if (concreteLanguages.length === 0) return true
+  return concreteLanguages.some((language) => option.supportedLanguages?.includes(language))
+}
+
+export function selectDimensionOption<TDimension extends string>(input: {
+  dimension: TDimension
+  options: MorphDimensionOption<TDimension>[]
+  seed: string
+  usedTags: Set<string>
+  blacklistedTags: Set<string>
+  languages?: MorphLanguage[]
+}): MorphDimensionOption<TDimension> | undefined {
+  const candidates = input.options.filter(
+    (option) => !hasBlacklistedTag(option.tags, input.blacklistedTags) && supportsLanguages(option, input.languages),
+  )
+  if (candidates.length === 0) return undefined
+
+  return candidates
+    .map((option) => ({
+      option,
+      score: scoreOption(option, input.seed, input.dimension, input.usedTags),
+    }))
+    .sort((left, right) => right.score - left.score || left.option.id.localeCompare(right.option.id))[0]?.option
+}
+
+function scoreOption<TDimension extends string>(
+  option: MorphDimensionOption<TDimension>,
+  seed: string,
+  dimension: TDimension,
+  usedTags: Set<string>,
+): number {
+  const usedOverlap = option.tags.filter((tag) => usedTags.has(tag)).length
+  const seedScore = Number.parseInt(stableHash([seed, dimension, option.id].join("|")), 36) / 0xffffffff
+  return seedScore - usedOverlap * 10
+}
+
+function option(
+  id: string,
+  dimension: MorphBlueprintDimension,
+  tags: string[],
+  summary: string,
+  constraint: string,
+  supportedLanguages?: MorphLanguage[],
+): MorphDimensionOption<MorphBlueprintDimension> {
+  return { id, dimension, tags, summary, constraint, supportedLanguages }
+}

--- a/src/morph/config.ts
+++ b/src/morph/config.ts
@@ -1,0 +1,200 @@
+import { load } from "js-yaml"
+import path from "path"
+import { pathExists, readText } from "../utils/files"
+import type {
+  MorphBaselineConfig,
+  MorphConfig,
+  MorphConfigLoadOptions,
+  MorphConfigThresholds,
+  MorphConfigWarning,
+  MorphUsedFingerprint,
+} from "./types"
+
+export const MORPH_CONFIG_FILE = ".morph-config.yaml"
+
+export const DEFAULT_MORPH_THRESHOLDS: MorphConfigThresholds = {
+  statementJaccard: 0.15,
+  tokenNgram: 0.2,
+  structuralHash: 0.25,
+  controlFlow: 0.3,
+}
+
+type RawMorphConfig = {
+  seed?: unknown
+  thresholds?: unknown
+  baselines?: unknown
+  baselinePaths?: unknown
+  blacklistedPatternTags?: unknown
+  blacklisted_pattern_tags?: unknown
+  usedFingerprints?: unknown
+  used_fingerprints?: unknown
+}
+
+export async function loadMorphConfig(
+  projectRoot: string,
+  options: MorphConfigLoadOptions = {},
+): Promise<MorphConfig> {
+  const resolvedRoot = path.resolve(projectRoot)
+  const configPath = path.join(resolvedRoot, MORPH_CONFIG_FILE)
+  const hasConfig = await pathExists(configPath)
+  const rawConfig = hasConfig ? await parseConfigFile(configPath) : {}
+  const source = hasConfig ? "file" : "default"
+
+  const seed = normalizeSeed(options.seed ?? rawConfig.seed) ?? deriveDefaultSeed(resolvedRoot)
+  const thresholds = mergeThresholds(DEFAULT_MORPH_THRESHOLDS, readThresholds(rawConfig.thresholds), options.thresholds)
+  validateThresholds(thresholds)
+
+  const baselinePaths = options.baselinePaths ?? readBaselinePaths(rawConfig)
+  const baselines: MorphBaselineConfig = {
+    paths: baselinePaths.map((baselinePath) => path.resolve(resolvedRoot, baselinePath)),
+  }
+
+  const warnings = buildWarnings(source, baselines.paths, options.seed ?? rawConfig.seed)
+
+  return {
+    projectRoot: resolvedRoot,
+    configPath,
+    source,
+    seed,
+    thresholds,
+    baselines,
+    blacklistedPatternTags: readStringArray(
+      rawConfig.blacklistedPatternTags ?? rawConfig.blacklisted_pattern_tags,
+      "blacklistedPatternTags",
+    ),
+    usedFingerprints: readUsedFingerprints(rawConfig.usedFingerprints ?? rawConfig.used_fingerprints),
+    warnings,
+  }
+}
+
+async function parseConfigFile(configPath: string): Promise<RawMorphConfig> {
+  const raw = await readText(configPath)
+  if (raw.trim().length === 0) return {}
+
+  try {
+    const parsed = load(raw)
+    if (parsed === undefined || parsed === null) return {}
+    if (!isRecord(parsed)) {
+      throw new Error("top-level value must be a mapping")
+    }
+    return parsed as RawMorphConfig
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid ${MORPH_CONFIG_FILE}: ${message}`)
+  }
+}
+
+function normalizeSeed(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  if (typeof value === "string" || typeof value === "number") return String(value)
+  throw new Error("Invalid .morph-config.yaml field seed: expected string or number")
+}
+
+function deriveDefaultSeed(projectRoot: string): string {
+  return `default:${path.basename(projectRoot) || "project"}`
+}
+
+function readThresholds(value: unknown): Partial<MorphConfigThresholds> {
+  if (value === undefined || value === null) return {}
+  if (!isRecord(value)) {
+    throw new Error("Invalid .morph-config.yaml field thresholds: expected mapping")
+  }
+
+  const result: Partial<MorphConfigThresholds> = {}
+  for (const key of Object.keys(DEFAULT_MORPH_THRESHOLDS) as Array<keyof MorphConfigThresholds>) {
+    if (value[key] !== undefined) {
+      result[key] = readNumber(value[key], `thresholds.${key}`)
+    }
+  }
+  return result
+}
+
+function mergeThresholds(
+  defaults: MorphConfigThresholds,
+  fileThresholds: Partial<MorphConfigThresholds>,
+  optionThresholds?: Partial<MorphConfigThresholds>,
+): MorphConfigThresholds {
+  return {
+    ...defaults,
+    ...fileThresholds,
+    ...optionThresholds,
+  }
+}
+
+export function validateThresholds(thresholds: MorphConfigThresholds): void {
+  for (const [key, value] of Object.entries(thresholds)) {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new Error(`Invalid .morph-config.yaml field thresholds.${key}: expected number between 0 and 1`)
+    }
+  }
+}
+
+function readBaselinePaths(config: RawMorphConfig): string[] {
+  const baselines = config.baselines
+  if (isRecord(baselines) && baselines.paths !== undefined) {
+    return readStringArray(baselines.paths, "baselines.paths")
+  }
+  return readStringArray(config.baselinePaths, "baselinePaths")
+}
+
+function readUsedFingerprints(value: unknown): MorphUsedFingerprint[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid .morph-config.yaml field usedFingerprints: expected array")
+  }
+
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`Invalid .morph-config.yaml field usedFingerprints[${index}]: expected mapping`)
+    }
+    const seed = readRequiredString(entry.seed, `usedFingerprints[${index}].seed`)
+    const blueprint = readRequiredString(entry.blueprint, `usedFingerprints[${index}].blueprint`)
+    const strategy = readRequiredString(entry.strategy, `usedFingerprints[${index}].strategy`)
+    const tags = readStringArray(entry.tags, `usedFingerprints[${index}].tags`)
+    const createdAt = entry.createdAt === undefined ? undefined : readRequiredString(entry.createdAt, `usedFingerprints[${index}].createdAt`)
+    return { seed, blueprint, strategy, tags, createdAt }
+  })
+}
+
+function readStringArray(value: unknown, fieldName: string): string[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid .morph-config.yaml field ${fieldName}: expected array`)
+  }
+  return value.map((item, index) => readRequiredString(item, `${fieldName}[${index}]`))
+}
+
+function readRequiredString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid .morph-config.yaml field ${fieldName}: expected non-empty string`)
+  }
+  return value
+}
+
+function readNumber(value: unknown, fieldName: string): number {
+  if (typeof value !== "number") {
+    throw new Error(`Invalid .morph-config.yaml field ${fieldName}: expected number`)
+  }
+  return value
+}
+
+function buildWarnings(source: "file" | "default", baselinePaths: string[], seedInput: unknown): MorphConfigWarning[] {
+  const warnings: MorphConfigWarning[] = []
+  if (source === "default" || seedInput === undefined || seedInput === null || seedInput === "") {
+    warnings.push({
+      code: "default_seed",
+      message: "No Morph-X seed configured; using deterministic default derived from the project path.",
+    })
+  }
+  if (baselinePaths.length === 0) {
+    warnings.push({
+      code: "baseline_missing",
+      message: "No similarity baseline paths configured; reports can include fingerprints but cannot compare against a baseline.",
+    })
+  }
+  return warnings
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/src/morph/files.ts
+++ b/src/morph/files.ts
@@ -1,0 +1,93 @@
+import { promises as fs } from "fs"
+import path from "path"
+import { pathExists, walkFiles } from "../utils/files"
+import { detectMorphLanguage } from "./fingerprints"
+import type { MorphLanguage } from "./types"
+
+export type MorphSourceFile = {
+  path: string
+  relativePath: string
+  language: MorphLanguage
+  content: string
+}
+
+export type MorphBaselineMatch = {
+  source: MorphSourceFile
+  baselinePath?: string
+  baselineSource?: string
+}
+
+export type CollectMorphSourceOptions = {
+  excludePaths?: string[]
+}
+
+const SOURCE_EXTENSIONS = new Set([".swift", ".m", ".mm", ".h"])
+
+export async function collectMorphSourceFiles(
+  targetPath: string,
+  options: CollectMorphSourceOptions = {},
+): Promise<MorphSourceFile[]> {
+  const resolvedTarget = path.resolve(targetPath)
+  if (!(await pathExists(resolvedTarget))) {
+    throw new Error(`Target path does not exist: ${resolvedTarget}`)
+  }
+
+  const stat = await fs.stat(resolvedTarget)
+  const root = stat.isDirectory() ? resolvedTarget : path.dirname(resolvedTarget)
+  const candidates = stat.isDirectory() ? await walkFiles(resolvedTarget) : [resolvedTarget]
+  const excludes = options.excludePaths?.map((excludePath) => path.resolve(excludePath)) ?? []
+  const files: MorphSourceFile[] = []
+
+  for (const candidate of candidates) {
+    if (isExcluded(candidate, excludes)) continue
+    if (!SOURCE_EXTENSIONS.has(path.extname(candidate).toLowerCase())) continue
+    files.push({
+      path: candidate,
+      relativePath: path.relative(root, candidate),
+      language: detectMorphLanguage(candidate),
+      content: await fs.readFile(candidate, "utf8"),
+    })
+  }
+
+  return files.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+export async function matchBaselineFiles(
+  sources: MorphSourceFile[],
+  baselinePaths: string[],
+): Promise<MorphBaselineMatch[]> {
+  if (baselinePaths.length === 0) {
+    return sources.map((source) => ({ source }))
+  }
+
+  const baselineFiles = await collectBaselineFiles(baselinePaths)
+  return sources.map((source) => {
+    const exact = baselineFiles.find((baseline) => baseline.relativePath === source.relativePath)
+    const basename = exact ?? baselineFiles.find((baseline) => path.basename(baseline.path) === path.basename(source.path))
+    const language = basename ?? baselineFiles.find((baseline) => baseline.language === source.language)
+    const fallback = language ?? baselineFiles[0]
+    if (!fallback) return { source }
+    return {
+      source,
+      baselinePath: fallback.path,
+      baselineSource: fallback.content,
+    }
+  })
+}
+
+async function collectBaselineFiles(baselinePaths: string[]): Promise<MorphSourceFile[]> {
+  const allFiles: MorphSourceFile[] = []
+  for (const baselinePath of baselinePaths) {
+    if (!(await pathExists(baselinePath))) continue
+    allFiles.push(...await collectMorphSourceFiles(baselinePath))
+  }
+  return allFiles
+}
+
+function isExcluded(candidate: string, excludePaths: string[]): boolean {
+  const resolvedCandidate = path.resolve(candidate)
+  return excludePaths.some((excludePath) => {
+    const relative = path.relative(excludePath, resolvedCandidate)
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+  })
+}

--- a/src/morph/fingerprints.ts
+++ b/src/morph/fingerprints.ts
@@ -1,0 +1,323 @@
+import path from "path"
+import type { MorphAstAdapterOutput, MorphLanguage, MorphSourceFingerprint } from "./types"
+
+const IMPORT_RE = /^(?:@testable\s+)?import\s+/i
+const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const CONTROL_FLOW_KEYWORDS = new Set([
+  "if",
+  "else",
+  "guard",
+  "for",
+  "while",
+  "repeat",
+  "switch",
+  "case",
+  "default",
+  "return",
+  "throw",
+  "break",
+  "continue",
+  "defer",
+  "do",
+  "catch",
+])
+
+const STRUCTURAL_KEYWORDS = new Set([
+  "class",
+  "struct",
+  "enum",
+  "protocol",
+  "extension",
+  "func",
+  "init",
+  "var",
+  "let",
+  ...CONTROL_FLOW_KEYWORDS,
+])
+
+export type FingerprintOptions = {
+  tokenNgramSize?: number
+  adapterOutput?: MorphAstAdapterOutput | unknown
+}
+
+export function createSourceFingerprint(
+  filePath: string,
+  source: string,
+  options: FingerprintOptions = {},
+): MorphSourceFingerprint {
+  const language = detectMorphLanguage(filePath)
+  const warnings: string[] = []
+  const ngramSize = options.tokenNgramSize ?? 3
+  const normalized = normalizeMorphSource(source)
+  const statements = extractNormalizedStatements(normalized)
+  const tokens = tokenizeMorphSource(normalized)
+  const tokenNgrams = createTokenNgrams(tokens, ngramSize)
+  const structural = createStructuralFingerprint(tokens, options.adapterOutput, warnings)
+
+  return {
+    path: filePath,
+    language,
+    statements,
+    tokens,
+    tokenNgrams,
+    structuralHash: structural.hash,
+    structuralParts: structural.parts,
+    controlFlow: summarizeControlFlow(tokens),
+    warnings,
+  }
+}
+
+export function detectMorphLanguage(filePath: string): MorphLanguage {
+  const ext = path.extname(filePath).toLowerCase()
+  if (ext === ".swift") return "swift"
+  if (ext === ".m" || ext === ".mm" || ext === ".h") return "objc"
+  return "unknown"
+}
+
+export function normalizeMorphSource(source: string): string {
+  return replaceLiterals(stripComments(source))
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .toLowerCase()
+    .trim()
+}
+
+export function extractNormalizedStatements(normalizedSource: string): string[] {
+  if (normalizedSource.length === 0) return []
+
+  const statements: string[] = []
+  let current = ""
+  let parenDepth = 0
+  let bracketDepth = 0
+
+  for (const char of normalizedSource) {
+    if (char === "(") parenDepth += 1
+    if (char === ")" && parenDepth > 0) parenDepth -= 1
+    if (char === "[") bracketDepth += 1
+    if (char === "]" && bracketDepth > 0) bracketDepth -= 1
+
+    if ((char === "\n" || char === ";" || char === "{" || char === "}") && parenDepth === 0 && bracketDepth === 0) {
+      pushStatement(statements, current)
+      current = ""
+      continue
+    }
+    current += char
+  }
+  pushStatement(statements, current)
+  return statements
+}
+
+export function tokenizeMorphSource(normalizedSource: string): string[] {
+  if (normalizedSource.length === 0) return []
+  return normalizedSource.match(/[A-Za-z_][A-Za-z0-9_]*|\d+(?:\.\d+)?|==|!=|<=|>=|&&|\|\||->|[{}()[\].,:;+\-*/%<>=!?@#]/g) ?? []
+}
+
+export function createTokenNgrams(tokens: string[], n = 3): string[] {
+  const size = Math.max(1, Math.floor(n))
+  if (tokens.length === 0) return []
+  if (tokens.length < size) return [tokens.join(" ")]
+
+  const grams: string[] = []
+  for (let index = 0; index <= tokens.length - size; index += 1) {
+    grams.push(tokens.slice(index, index + size).join(" "))
+  }
+  return grams
+}
+
+export function createStructuralFingerprint(
+  tokens: string[],
+  adapterOutput?: MorphAstAdapterOutput | unknown,
+  warnings: string[] = [],
+): { hash: string; parts: string[] } {
+  const adapterParts = readAdapterStructuralParts(adapterOutput, warnings)
+  const parts = adapterParts.length > 0 ? adapterParts : fallbackStructuralParts(tokens)
+  return {
+    hash: stableHash(parts.join("|")),
+    parts,
+  }
+}
+
+export function summarizeControlFlow(tokens: string[]): string[] {
+  const summary: string[] = []
+  const blockStack: string[] = []
+  let pendingBlock: string | undefined
+  let inlineConditional = false
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (token === "{") {
+      blockStack.push(pendingBlock ?? "block")
+      pendingBlock = undefined
+      continue
+    }
+    if (token === "}") {
+      blockStack.pop()
+      pendingBlock = undefined
+      inlineConditional = false
+      continue
+    }
+
+    if (!CONTROL_FLOW_KEYWORDS.has(token)) continue
+    if (token === "case" || token === "default") inlineConditional = true
+    if (token === "if" || token === "guard" || token === "case") pendingBlock = token
+    if (token === "else" && tokens[index + 1] !== "if") pendingBlock = "else"
+    if (token === "return" || token === "throw") {
+      summary.push(`${token}:${isInsideConditionalBlock(blockStack) || inlineConditional ? "conditional" : "direct"}`)
+      continue
+    }
+    summary.push(token)
+  }
+  return summary
+}
+
+function stripComments(source: string): string {
+  let result = ""
+  let index = 0
+  let blockDepth = 0
+  let lineComment = false
+  let stringQuote: string | undefined
+
+  while (index < source.length) {
+    const char = source[index]
+    const next = source[index + 1]
+
+    if (lineComment) {
+      if (char === "\n") {
+        lineComment = false
+        result += char
+      }
+      index += 1
+      continue
+    }
+
+    if (blockDepth > 0) {
+      if (char === "/" && next === "*") {
+        blockDepth += 1
+        index += 2
+        continue
+      }
+      if (char === "*" && next === "/") {
+        blockDepth -= 1
+        index += 2
+        continue
+      }
+      if (char === "\n") result += "\n"
+      index += 1
+      continue
+    }
+
+    if (stringQuote !== undefined) {
+      result += char
+      if (char === "\\") {
+        if (index + 1 < source.length) result += source[index + 1]
+        index += 2
+        continue
+      }
+      if (char === stringQuote) stringQuote = undefined
+      index += 1
+      continue
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true
+      index += 2
+      continue
+    }
+    if (char === "/" && next === "*") {
+      blockDepth = 1
+      index += 2
+      continue
+    }
+    if (char === "\"" || char === "'") {
+      stringQuote = char
+      result += char
+      index += 1
+      continue
+    }
+
+    result += char
+    index += 1
+  }
+
+  return result
+}
+
+function replaceLiterals(source: string): string {
+  return source
+    .replace(/"""[\s\S]*?"""/g, " str ")
+    .replace(/"(?:\\.|[^"\\])*"/g, " str ")
+    .replace(/'(?:\\.|[^'\\])*'/g, " str ")
+    .replace(/\b\d+(?:\.\d+)?\b/g, " num ")
+}
+
+function pushStatement(statements: string[], statement: string): void {
+  const normalized = statement
+    .replace(/\s+/g, " ")
+    .replace(/\s*([{}()[\].,:;+\-*/%<>=!?@#])\s*/g, "$1")
+    .trim()
+  if (normalized.length === 0 || IMPORT_RE.test(normalized)) return
+  statements.push(normalized)
+}
+
+function readAdapterStructuralParts(adapterOutput: MorphAstAdapterOutput | unknown, warnings: string[]): string[] {
+  if (adapterOutput === undefined || adapterOutput === null) return []
+  if (!isRecord(adapterOutput) || typeof adapterOutput.ok !== "boolean") {
+    warnings.push("AST adapter output was invalid; using token-structure fallback.")
+    return []
+  }
+  if (!adapterOutput.ok) {
+    const suffix = typeof adapterOutput.error === "string" && adapterOutput.error.trim().length > 0
+      ? ` ${adapterOutput.error.trim()}`
+      : ""
+    warnings.push(`AST adapter unavailable; using token-structure fallback.${suffix}`)
+    for (const warning of readAdapterWarnings(adapterOutput)) warnings.push(warning)
+    return []
+  }
+
+  for (const warning of readAdapterWarnings(adapterOutput)) warnings.push(warning)
+  const nodes = Array.isArray(adapterOutput.nodes) ? adapterOutput.nodes : []
+  const parts = nodes.flatMap((node) => flattenAdapterNode(node))
+  if (parts.length === 0) warnings.push("AST adapter returned no structural nodes; using token-structure fallback.")
+  return parts
+}
+
+function readAdapterWarnings(adapterOutput: Record<string, unknown>): string[] {
+  if (!Array.isArray(adapterOutput.warnings)) return []
+  return adapterOutput.warnings.filter((warning): warning is string => typeof warning === "string" && warning.trim().length > 0)
+}
+
+function flattenAdapterNode(node: unknown): string[] {
+  if (!isRecord(node) || typeof node.kind !== "string" || node.kind.trim().length === 0) return []
+  const kind = node.kind.trim().toLowerCase()
+  const children = Array.isArray(node.children) ? node.children.flatMap((child) => flattenAdapterNode(child)) : []
+  return [kind, ...children]
+}
+
+function fallbackStructuralParts(tokens: string[]): string[] {
+  const parts: string[] = []
+  for (const token of tokens) {
+    if (STRUCTURAL_KEYWORDS.has(token) || "{}()[]".includes(token)) {
+      parts.push(token)
+    } else if (IDENTIFIER_RE.test(token)) {
+      parts.push("id")
+    }
+  }
+  return parts
+}
+
+function isInsideConditionalBlock(blockStack: string[]): boolean {
+  return blockStack.some((block) => block === "if" || block === "guard" || block === "case" || block === "else")
+}
+
+function stableHash(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0")
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/src/morph/metrics.ts
+++ b/src/morph/metrics.ts
@@ -1,0 +1,102 @@
+import { createSourceFingerprint, type FingerprintOptions } from "./fingerprints"
+import type { MorphSourceFingerprint, MorphSimilarityMetric } from "./types"
+
+export type MorphMetricOptions = {
+  tokenNgramSize?: number
+  sourceAdapterOutput?: FingerprintOptions["adapterOutput"]
+  baselineAdapterOutput?: FingerprintOptions["adapterOutput"]
+}
+
+export type MorphMetricResult = {
+  source: MorphSourceFingerprint
+  baseline: MorphSourceFingerprint
+  metrics: Record<MorphSimilarityMetric, number>
+  warnings: string[]
+}
+
+export function compareMorphSources(
+  sourcePath: string,
+  sourceText: string,
+  baselinePath: string,
+  baselineText: string,
+  options: MorphMetricOptions = {},
+): MorphMetricResult {
+  const source = createSourceFingerprint(sourcePath, sourceText, {
+    tokenNgramSize: options.tokenNgramSize,
+    adapterOutput: options.sourceAdapterOutput,
+  })
+  const baseline = createSourceFingerprint(baselinePath, baselineText, {
+    tokenNgramSize: options.tokenNgramSize,
+    adapterOutput: options.baselineAdapterOutput,
+  })
+
+  return {
+    source,
+    baseline,
+    metrics: calculateSimilarityMetrics(source, baseline),
+    warnings: [...source.warnings, ...baseline.warnings],
+  }
+}
+
+export function calculateSimilarityMetrics(
+  source: MorphSourceFingerprint,
+  baseline: MorphSourceFingerprint,
+): Record<MorphSimilarityMetric, number> {
+  return {
+    statement_jaccard: jaccardSimilarity(source.statements, baseline.statements),
+    token_ngram: jaccardSimilarity(source.tokenNgrams, baseline.tokenNgrams),
+    structural_hash: structuralSimilarity(source, baseline),
+    control_flow: controlFlowSimilarity(source.controlFlow, baseline.controlFlow),
+  }
+}
+
+export function jaccardSimilarity(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 1
+  if (left.length === 0 || right.length === 0) return 0
+
+  const leftSet = new Set(left)
+  const rightSet = new Set(right)
+  let intersection = 0
+  for (const item of leftSet) {
+    if (rightSet.has(item)) intersection += 1
+  }
+  const union = new Set([...leftSet, ...rightSet]).size
+  return safeRatio(intersection, union)
+}
+
+export function multisetJaccardSimilarity(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 1
+  if (left.length === 0 || right.length === 0) return 0
+
+  const leftCounts = countValues(left)
+  const rightCounts = countValues(right)
+  const keys = new Set([...leftCounts.keys(), ...rightCounts.keys()])
+  let intersection = 0
+  let union = 0
+  for (const key of keys) {
+    intersection += Math.min(leftCounts.get(key) ?? 0, rightCounts.get(key) ?? 0)
+    union += Math.max(leftCounts.get(key) ?? 0, rightCounts.get(key) ?? 0)
+  }
+  return safeRatio(intersection, union)
+}
+
+export function structuralSimilarity(source: MorphSourceFingerprint, baseline: MorphSourceFingerprint): number {
+  if (source.structuralHash === baseline.structuralHash) return 1
+  return multisetJaccardSimilarity(source.structuralParts, baseline.structuralParts)
+}
+
+export function controlFlowSimilarity(left: string[], right: string[]): number {
+  return multisetJaccardSimilarity(left, right)
+}
+
+function countValues(values: string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1)
+  return counts
+}
+
+function safeRatio(numerator: number, denominator: number): number {
+  if (denominator === 0) return 1
+  const result = numerator / denominator
+  return Number.isFinite(result) ? result : 0
+}

--- a/src/morph/report.ts
+++ b/src/morph/report.ts
@@ -1,0 +1,132 @@
+import type {
+  MorphAstAdapterOutput,
+  MorphConfigThresholds,
+  MorphFileSimilarityReport,
+  MorphReportStatus,
+  MorphRiskReason,
+  MorphSimilarityMetric,
+  MorphSimilarityReport,
+} from "./types"
+import { compareMorphSources, type MorphMetricOptions } from "./metrics"
+
+const METRICS: MorphSimilarityMetric[] = ["statement_jaccard", "token_ngram", "structural_hash", "control_flow"]
+
+export type MorphReportFileInput = {
+  path: string
+  source: string
+  baselinePath?: string
+  baselineSource?: string
+  sourceAdapterOutput?: MorphAstAdapterOutput | unknown
+  baselineAdapterOutput?: MorphAstAdapterOutput | unknown
+}
+
+export type MorphReportOptions = {
+  tokenNgramSize?: number
+}
+
+export function buildMorphFileSimilarityReport(
+  input: MorphReportFileInput,
+  thresholds: MorphConfigThresholds,
+  options: MorphReportOptions = {},
+): MorphFileSimilarityReport {
+  if (input.baselineSource === undefined) {
+    return {
+      path: input.path,
+      language: languageFromPath(input.path),
+      metrics: {},
+      highRisk: false,
+      riskReasons: [],
+      warnings: [`No baseline source available for ${input.path}; similarity metrics were skipped.`],
+    }
+  }
+
+  const metricOptions: MorphMetricOptions = {
+    tokenNgramSize: options.tokenNgramSize,
+    sourceAdapterOutput: input.sourceAdapterOutput,
+    baselineAdapterOutput: input.baselineAdapterOutput,
+  }
+  const comparison = compareMorphSources(input.path, input.source, input.baselinePath ?? input.path, input.baselineSource, metricOptions)
+  const riskReasons = buildRiskReasons(comparison.metrics, thresholds)
+
+  return {
+    path: input.path,
+    language: comparison.source.language,
+    metrics: comparison.metrics,
+    highRisk: riskReasons.length > 0,
+    riskReasons,
+    warnings: comparison.warnings,
+  }
+}
+
+export function buildMorphSimilarityReport(
+  files: MorphReportFileInput[],
+  thresholds: MorphConfigThresholds,
+  options: MorphReportOptions = {},
+): MorphSimilarityReport {
+  const fileReports = files.map((file) => buildMorphFileSimilarityReport(file, thresholds, options))
+  const warnings = fileReports.flatMap((file) => file.warnings.map((warning) => `${file.path}: ${warning}`))
+  const overall = averageMetrics(fileReports)
+  const status = determineStatus(fileReports, warnings)
+
+  return {
+    status,
+    threshold: thresholds,
+    files: fileReports,
+    overall,
+    warnings,
+  }
+}
+
+export function averageMetrics(files: MorphFileSimilarityReport[]): Partial<Record<MorphSimilarityMetric, number>> {
+  const overall: Partial<Record<MorphSimilarityMetric, number>> = {}
+  for (const metric of METRICS) {
+    const values = files
+      .map((file) => file.metrics[metric])
+      .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+    if (values.length > 0) {
+      overall[metric] = values.reduce((sum, value) => sum + value, 0) / values.length
+    }
+  }
+  return overall
+}
+
+function buildRiskReasons(
+  metrics: Record<MorphSimilarityMetric, number>,
+  thresholds: MorphConfigThresholds,
+): MorphRiskReason[] {
+  const thresholdByMetric: Record<MorphSimilarityMetric, number> = {
+    statement_jaccard: thresholds.statementJaccard,
+    token_ngram: thresholds.tokenNgram,
+    structural_hash: thresholds.structuralHash,
+    control_flow: thresholds.controlFlow,
+  }
+
+  return METRICS.flatMap((metric) => {
+    const score = metrics[metric]
+    const threshold = thresholdByMetric[metric]
+    if (!Number.isFinite(score) || score < threshold) return []
+    return [{
+      metric,
+      score,
+      threshold,
+      reason: `${metric} similarity ${formatScore(score)} meets or exceeds threshold ${formatScore(threshold)}`,
+    }]
+  })
+}
+
+function determineStatus(files: MorphFileSimilarityReport[], warnings: string[]): MorphReportStatus {
+  if (files.some((file) => file.highRisk)) return "blocked"
+  if (warnings.length > 0) return "warning"
+  return "passed"
+}
+
+function languageFromPath(filePath: string): "swift" | "objc" | "unknown" {
+  const lower = filePath.toLowerCase()
+  if (lower.endsWith(".swift")) return "swift"
+  if (lower.endsWith(".m") || lower.endsWith(".mm") || lower.endsWith(".h")) return "objc"
+  return "unknown"
+}
+
+function formatScore(score: number): string {
+  return score.toFixed(3).replace(/0+$/, "").replace(/\.$/, "")
+}

--- a/src/morph/strategies.ts
+++ b/src/morph/strategies.ts
@@ -1,0 +1,149 @@
+import {
+  selectBlueprint,
+  selectDimensionOption,
+  stableHash,
+} from "./blueprints"
+import type {
+  MorphDimensionOption,
+  MorphLanguage,
+  MorphSelectionResult,
+  MorphStrategyDimension,
+  MorphStrategySelectorInput,
+  MorphStrategySelection,
+  MorphUsedFingerprint,
+} from "./types"
+
+export const STRATEGY_DIMENSIONS: MorphStrategyDimension[] = [
+  "naming",
+  "controlFlow",
+  "layout",
+  "importOrder",
+  "extensionSplit",
+]
+
+export const STRATEGY_REGISTRY: MorphDimensionOption<MorphStrategyDimension>[] = [
+  option("naming.role-suffix", "naming", ["naming.role-suffix", "naming.semantic", "hook.rename-private"], "Role suffix naming", "Prefer role suffixes for private collaborators and local helpers.", ["swift", "objc"]),
+  option("naming.domain-phrase", "naming", ["naming.domain-phrase", "naming.intent", "hook.rename-private"], "Domain phrase naming", "Prefer domain-intent phrases for private helpers rather than generic service/manager names.", ["swift", "objc"]),
+  option("naming.short-local", "naming", ["naming.short-local", "naming.local-context", "hook.rename-local"], "Short local naming", "Prefer concise local names where scope already carries context.", ["swift", "objc"]),
+
+  option("controlFlow.guard-first", "controlFlow", ["control.guard-first", "control.early-return", "hook.rewrite-guards"], "Guard-first flow", "Use guard/early-return shape for validation and failure exits.", ["swift"]),
+  option("controlFlow.result-switch", "controlFlow", ["control.result-switch", "control.exhaustive-switch", "hook.rewrite-switch"], "Result switch flow", "Use exhaustive switch handling around Result-like outcomes.", ["swift"]),
+  option("controlFlow.predicate-branch", "controlFlow", ["control.predicate-branch", "control.named-conditions", "hook.rewrite-conditions"], "Named predicate flow", "Extract complex branch predicates into named local booleans before branching.", ["swift", "objc"]),
+
+  option("layout.extensions-by-role", "layout", ["layout.extensions-by-role", "layout.role-grouping", "hook.reorder-decls"], "Role extensions", "Group declarations into extensions by role or protocol conformance.", ["swift"]),
+  option("layout.lifecycle-first", "layout", ["layout.lifecycle-first", "layout.entrypoints-first", "hook.reorder-decls"], "Lifecycle first", "Order lifecycle/entrypoint methods before private helpers.", ["swift", "objc"]),
+  option("layout.helpers-near-use", "layout", ["layout.helpers-near-use", "layout.locality", "hook.reorder-decls"], "Helpers near use", "Place private helpers near their primary call sites when safe.", ["swift", "objc"]),
+
+  option("imports.system-first", "importOrder", ["imports.system-first", "imports.sorted-groups", "hook.reorder-imports"], "System imports first", "Group system imports before third-party and local imports.", ["swift", "objc"]),
+  option("imports.local-first", "importOrder", ["imports.local-first", "imports.boundary-first", "hook.reorder-imports"], "Local imports first", "Group local module imports before framework imports when the language permits.", ["objc"]),
+  option("imports.minimal-visible", "importOrder", ["imports.minimal-visible", "imports.lazy", "hook.trim-imports"], "Minimal visible imports", "Keep only directly used imports visible in each file and move optional imports downward when safe.", ["swift", "objc"]),
+
+  option("extensionSplit.protocol-conformance", "extensionSplit", ["extension.protocol-conformance", "extension.protocols", "hook.split-extensions"], "Protocol conformance split", "Move protocol conformances into dedicated extensions.", ["swift"]),
+  option("extensionSplit.private-behavior", "extensionSplit", ["extension.private-behavior", "extension.private-api", "hook.split-extensions"], "Private behavior split", "Group private behavior in a separate private extension.", ["swift"]),
+  option("extensionSplit.none-compact", "extensionSplit", ["extension.none-compact", "extension.compact", "hook.keep-compact"], "Compact declarations", "Keep small declarations compact when extension splitting would add noise.", ["swift", "objc"]),
+]
+
+export function selectMorphStrategy(input: MorphStrategySelectorInput): MorphSelectionResult {
+  const languages = normalizeLanguages(input.languages)
+  const usedFingerprints = input.usedFingerprints ?? []
+  const blacklistedTags = input.blacklistedTags ?? []
+  const blueprint = selectBlueprint({
+    seed: input.seed,
+    usedFingerprints,
+    blacklistedTags,
+    languages,
+  })
+  const strategy = selectStrategy({
+    seed: input.seed,
+    usedFingerprints,
+    blacklistedTags,
+    languages,
+  })
+  const warnings = buildWarnings(blueprint.tags, strategy.tags, usedFingerprints, blacklistedTags)
+  const tags = [...blueprint.tags, ...strategy.tags]
+
+  return {
+    seed: input.seed,
+    blueprint,
+    strategy,
+    fingerprint: {
+      seed: input.seed,
+      blueprint: blueprint.fingerprint,
+      strategy: strategy.fingerprint,
+      tags,
+      warnings,
+    },
+    warnings,
+  }
+}
+
+export function selectStrategy(input: {
+  seed: string
+  usedFingerprints?: MorphUsedFingerprint[]
+  blacklistedTags?: string[]
+  languages?: MorphLanguage[]
+}): MorphStrategySelection {
+  const usedTags = new Set((input.usedFingerprints ?? []).flatMap((fingerprint) => fingerprint.tags))
+  const blacklistedTags = new Set(input.blacklistedTags ?? [])
+  const dimensions = {} as Record<MorphStrategyDimension, MorphDimensionOption<MorphStrategyDimension>>
+
+  for (const dimension of STRATEGY_DIMENSIONS) {
+    const selected = selectDimensionOption({
+      dimension,
+      options: STRATEGY_REGISTRY.filter((item) => item.dimension === dimension),
+      seed: input.seed,
+      usedTags,
+      blacklistedTags,
+      languages: input.languages,
+    })
+    if (!selected) {
+      throw new Error(`No Morph-X strategy option remains for dimension ${dimension}; remove blacklisted tags or add more registry options.`)
+    }
+    dimensions[dimension] = selected
+  }
+
+  const tags = STRATEGY_DIMENSIONS.flatMap((dimension) => dimensions[dimension].tags)
+  const hooks = Array.from(new Set(tags.filter((tag) => tag.startsWith("hook.")))).sort()
+
+  return {
+    fingerprint: `strategy:${stableHash(["strategy", input.seed, ...tags].join("|"))}`,
+    tags,
+    hooks,
+    dimensions,
+  }
+}
+
+function buildWarnings(
+  selectedBlueprintTags: string[],
+  selectedStrategyTags: string[],
+  usedFingerprints: MorphUsedFingerprint[],
+  blacklistedTags: string[],
+): string[] {
+  const warnings: string[] = []
+  const usedTags = new Set(usedFingerprints.flatMap((fingerprint) => fingerprint.tags))
+  const selectedTags = [...selectedBlueprintTags, ...selectedStrategyTags]
+  const overlap = selectedTags.filter((tag) => usedTags.has(tag))
+  if (overlap.length > 0) {
+    warnings.push(`low_differentiation_space: selected ${overlap.length} tags already present in history after filtering unavailable options.`)
+  }
+  if (blacklistedTags.length > 0) {
+    warnings.push(`blacklist_applied: excluded ${blacklistedTags.length} blacklisted Morph-X tags.`)
+  }
+  return warnings
+}
+
+function normalizeLanguages(languages: MorphLanguage[] | undefined): MorphLanguage[] {
+  if (!languages || languages.length === 0) return ["swift"]
+  return Array.from(new Set(languages))
+}
+
+function option(
+  id: string,
+  dimension: MorphStrategyDimension,
+  tags: string[],
+  summary: string,
+  constraint: string,
+  supportedLanguages?: MorphLanguage[],
+): MorphDimensionOption<MorphStrategyDimension> {
+  return { id, dimension, tags, summary, constraint, supportedLanguages }
+}

--- a/src/morph/swift-adapter.ts
+++ b/src/morph/swift-adapter.ts
@@ -1,0 +1,166 @@
+import { promises as fs } from "fs"
+import path from "path"
+
+export type SwiftAdapterInputFile = {
+  path: string
+  content: string
+}
+
+export type SwiftAdapterRequest = {
+  files: SwiftAdapterInputFile[]
+  strategyFingerprint: string
+  strategyTags: string[]
+  apply: boolean
+}
+
+export type SwiftAdapterFileResult = {
+  path: string
+  changed: boolean
+  content?: string
+  warnings: string[]
+}
+
+export type SwiftAdapterResult = {
+  ok: boolean
+  unavailable?: boolean
+  files: SwiftAdapterFileResult[]
+  warnings: string[]
+  stderr?: string
+}
+
+export type SwiftAdapterOptions = {
+  executable?: string
+  cwd?: string
+}
+
+export async function runSwiftAdapter(
+  request: SwiftAdapterRequest,
+  options: SwiftAdapterOptions = {},
+): Promise<SwiftAdapterResult> {
+  const executable = options.executable ?? process.env.MORPH_SWIFT_ADAPTER
+  if (!executable) {
+    return adapterUnavailable("Set MORPH_SWIFT_ADAPTER to enable SwiftSyntax-backed transformations.")
+  }
+
+  if (!(await executableExists(executable))) {
+    return adapterUnavailable(`Swift adapter executable not found: ${executable}`)
+  }
+
+  const proc = Bun.spawn([executable], {
+    cwd: options.cwd,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  proc.stdin.write(JSON.stringify(request))
+  proc.stdin.end()
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+
+  if (exitCode !== 0) {
+    return {
+      ok: false,
+      files: request.files.map((file) => ({ path: file.path, changed: false, warnings: [] })),
+      warnings: ["swift_adapter_failed"],
+      stderr: summarize(stderr),
+    }
+  }
+
+  try {
+    return parseAdapterOutput(stdout, request)
+  } catch (err) {
+    return {
+      ok: false,
+      files: request.files.map((file) => ({ path: file.path, changed: false, warnings: [] })),
+      warnings: [`swift_adapter_invalid_json: ${err instanceof Error ? err.message : String(err)}`],
+      stderr: summarize(stderr),
+    }
+  }
+}
+
+export async function applySwiftAdapterResult(result: SwiftAdapterResult): Promise<string[]> {
+  if (!result.ok) return []
+
+  const written: string[] = []
+  for (const file of result.files) {
+    if (!file.changed || file.content === undefined) continue
+    await fs.writeFile(file.path, file.content, "utf8")
+    written.push(file.path)
+  }
+  return written
+}
+
+function parseAdapterOutput(raw: string, request: SwiftAdapterRequest): SwiftAdapterResult {
+  const parsed = JSON.parse(raw) as unknown
+  if (!isRecord(parsed)) {
+    throw new Error("top-level adapter output must be an object")
+  }
+  const files = Array.isArray(parsed.files) ? parsed.files.map(readFileResult) : request.files.map((file) => ({
+    path: file.path,
+    changed: false,
+    warnings: ["adapter_output_missing_file_result"],
+  }))
+
+  return {
+    ok: parsed.ok === undefined ? true : parsed.ok === true,
+    files,
+    warnings: readStringArray(parsed.warnings),
+    stderr: typeof parsed.stderr === "string" ? summarize(parsed.stderr) : undefined,
+  }
+}
+
+function readFileResult(value: unknown): SwiftAdapterFileResult {
+  if (!isRecord(value)) {
+    throw new Error("adapter file result must be an object")
+  }
+  if (typeof value.path !== "string" || value.path.trim().length === 0) {
+    throw new Error("adapter file result path must be a non-empty string")
+  }
+  return {
+    path: value.path,
+    changed: value.changed === true,
+    content: typeof value.content === "string" ? value.content : undefined,
+    warnings: readStringArray(value.warnings),
+  }
+}
+
+function readStringArray(value: unknown): string[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+async function executableExists(executable: string): Promise<boolean> {
+  if (executable.includes(path.sep)) {
+    try {
+      await fs.access(executable, fs.constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const proc = Bun.spawn(["which", executable], { stdout: "pipe", stderr: "pipe" })
+  return (await proc.exited) === 0
+}
+
+function adapterUnavailable(message: string): SwiftAdapterResult {
+  return {
+    ok: true,
+    unavailable: true,
+    files: [],
+    warnings: [`adapter_unavailable: ${message}`],
+  }
+}
+
+function summarize(value: string): string {
+  return value.trim().slice(0, 1000)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/src/morph/types.ts
+++ b/src/morph/types.ts
@@ -1,0 +1,166 @@
+export type MorphConfigSource = "file" | "default"
+
+export type MorphConfigThresholds = {
+  statementJaccard: number
+  tokenNgram: number
+  structuralHash: number
+  controlFlow: number
+}
+
+export type MorphBaselineConfig = {
+  paths: string[]
+}
+
+export type MorphUsedFingerprint = {
+  seed: string
+  blueprint: string
+  strategy: string
+  tags: string[]
+  createdAt?: string
+}
+
+export type MorphConfig = {
+  projectRoot: string
+  configPath: string
+  source: MorphConfigSource
+  seed: string
+  thresholds: MorphConfigThresholds
+  baselines: MorphBaselineConfig
+  blacklistedPatternTags: string[]
+  usedFingerprints: MorphUsedFingerprint[]
+  warnings: MorphConfigWarning[]
+}
+
+export type MorphConfigWarningCode = "baseline_missing" | "default_seed"
+
+export type MorphConfigWarning = {
+  code: MorphConfigWarningCode
+  message: string
+}
+
+export type MorphConfigLoadOptions = {
+  seed?: string
+  thresholds?: Partial<MorphConfigThresholds>
+  baselinePaths?: string[]
+}
+
+export type MorphReportStatus = "passed" | "warning" | "blocked"
+
+export type MorphSimilarityMetric = "statement_jaccard" | "token_ngram" | "structural_hash" | "control_flow"
+
+export type MorphAstAdapterOutput =
+  | {
+      ok: true
+      nodes: MorphAstAdapterNode[]
+      warnings?: string[]
+    }
+  | {
+      ok: false
+      error?: string
+      warnings?: string[]
+    }
+
+export type MorphAstAdapterNode = {
+  kind: string
+  children?: MorphAstAdapterNode[]
+}
+
+export type MorphSourceFingerprint = {
+  path: string
+  language: MorphLanguage
+  statements: string[]
+  tokens: string[]
+  tokenNgrams: string[]
+  structuralHash: string
+  structuralParts: string[]
+  controlFlow: string[]
+  warnings: string[]
+}
+
+export type MorphRiskReason = {
+  metric: MorphSimilarityMetric
+  score: number
+  threshold: number
+  reason: string
+}
+
+export type MorphFileSimilarityReport = {
+  path: string
+  language: MorphLanguage
+  metrics: Partial<Record<MorphSimilarityMetric, number>>
+  highRisk: boolean
+  riskReasons: MorphRiskReason[]
+  warnings: string[]
+}
+
+export type MorphSimilarityReport = {
+  status: MorphReportStatus
+  threshold: MorphConfigThresholds
+  files: MorphFileSimilarityReport[]
+  overall: Partial<Record<MorphSimilarityMetric, number>>
+  warnings: string[]
+}
+
+export type MorphStrategyFingerprint = {
+  seed: string
+  blueprint: string
+  strategy: string
+  tags: string[]
+  warnings: string[]
+}
+
+export type MorphLanguage = "swift" | "objc" | "unknown"
+
+export type MorphBlueprintDimension =
+  | "state"
+  | "moduleBoundary"
+  | "fileSplit"
+  | "abstraction"
+  | "dependencyInjection"
+  | "errorPropagation"
+  | "asyncFlow"
+
+export type MorphStrategyDimension =
+  | "naming"
+  | "controlFlow"
+  | "layout"
+  | "importOrder"
+  | "extensionSplit"
+
+export type MorphDimensionOption<TDimension extends string> = {
+  id: string
+  dimension: TDimension
+  tags: string[]
+  summary: string
+  constraint: string
+  supportedLanguages?: MorphLanguage[]
+}
+
+export type MorphBlueprintSelection = {
+  fingerprint: string
+  tags: string[]
+  constraints: string[]
+  dimensions: Record<MorphBlueprintDimension, MorphDimensionOption<MorphBlueprintDimension>>
+}
+
+export type MorphStrategySelection = {
+  fingerprint: string
+  tags: string[]
+  hooks: string[]
+  dimensions: Record<MorphStrategyDimension, MorphDimensionOption<MorphStrategyDimension>>
+}
+
+export type MorphStrategySelectorInput = {
+  seed: string
+  usedFingerprints?: MorphUsedFingerprint[]
+  blacklistedTags?: string[]
+  languages?: MorphLanguage[]
+}
+
+export type MorphSelectionResult = {
+  seed: string
+  blueprint: MorphBlueprintSelection
+  strategy: MorphStrategySelection
+  fingerprint: MorphStrategyFingerprint
+  warnings: string[]
+}

--- a/tests/audit-command.test.ts
+++ b/tests/audit-command.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+
+const tempRoots: string[] = []
+const repoRoot = path.join(import.meta.dir, "..")
+
+async function makeTempProject(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "morph-audit-"))
+  tempRoots.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+async function runCli(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", "src/index.ts", ...args], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+describe("audit --similarity", () => {
+  test("reports high similarity against a configured baseline", async () => {
+    const project = await makeTempProject()
+    const baseline = path.join(project, "baseline")
+    await fs.mkdir(path.join(project, "Sources"), { recursive: true })
+    await fs.mkdir(path.join(baseline, "Sources"), { recursive: true })
+    const source = "import Foundation\nstruct Loader { func run() { if true { print(\"ok\") } } }\n"
+    await fs.writeFile(path.join(project, "Sources", "Loader.swift"), source)
+    await fs.writeFile(path.join(baseline, "Sources", "Loader.swift"), source)
+    await fs.writeFile(
+      path.join(project, ".morph-config.yaml"),
+      ["seed: test", "baselines:", "  paths:", "    - baseline", "thresholds:", "  statementJaccard: 0.9", ""].join("\n"),
+    )
+
+    const result = await runCli(["audit", "--similarity", project])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("Morph-X similarity audit: blocked")
+    expect(result.stdout).toContain("Loader.swift")
+    expect(result.stdout.match(/Loader\.swift/g)).toHaveLength(1)
+  })
+
+  test("prints parseable JSON output", async () => {
+    const project = await makeTempProject()
+    await fs.mkdir(path.join(project, "Sources"), { recursive: true })
+    await fs.writeFile(path.join(project, "Sources", "Only.swift"), "import Foundation\nlet value = 1\n")
+
+    const result = await runCli(["audit", "--similarity", "--json", project])
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout)
+    expect(parsed.status).toBe("warning")
+    expect(parsed.warnings).toContain("baseline_missing")
+  })
+
+  test("fails when fail-on-threshold is set and thresholds are exceeded", async () => {
+    const project = await makeTempProject()
+    const baseline = path.join(project, "baseline")
+    await fs.mkdir(baseline, { recursive: true })
+    const source = "struct Demo { func run() { return } }\n"
+    await fs.writeFile(path.join(project, "Demo.swift"), source)
+    await fs.writeFile(path.join(baseline, "Demo.swift"), source)
+
+    const result = await runCli(["audit", "--similarity", "--baseline", baseline, "--fail-on-threshold", project])
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stdout).toContain("blocked")
+  })
+
+  test("rejects invalid threshold values", async () => {
+    const project = await makeTempProject()
+    await fs.writeFile(path.join(project, "Demo.swift"), "struct Demo {}\n")
+
+    const result = await runCli(["audit", "--similarity", "--threshold", "2", project])
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain("Invalid --threshold")
+  })
+})

--- a/tests/codex-converter.test.ts
+++ b/tests/codex-converter.test.ts
@@ -129,6 +129,13 @@ describe("convertClaudeToCodex", () => {
           sourceDir: "/tmp/plugin/skills/workflows-plan",
           skillPath: "/tmp/plugin/skills/workflows-plan/SKILL.md",
         },
+        {
+          name: "gh:work-x",
+          description: "Morph-X work workflow",
+          argumentHint: "[plan]",
+          sourceDir: "/tmp/plugin/skills/gh-work-x",
+          skillPath: "/tmp/plugin/skills/gh-work-x/SKILL.md",
+        },
       ],
     }
 
@@ -138,15 +145,20 @@ describe("convertClaudeToCodex", () => {
       permissions: "none",
     })
 
-    expect(bundle.prompts).toHaveLength(1)
+    expect(bundle.prompts).toHaveLength(2)
     expect(bundle.prompts[0]?.name).toBe("gh-plan")
+    expect(bundle.prompts[1]?.name).toBe("gh-work-x")
 
     const parsedPrompt = parseFrontmatter(bundle.prompts[0]!.content)
     expect(parsedPrompt.data.description).toBe("Planning workflow")
     expect(parsedPrompt.data["argument-hint"]).toBe("[feature]")
     expect(parsedPrompt.body).toContain("Use the gh:plan skill")
+    const parsedXPrompt = parseFrontmatter(bundle.prompts[1]!.content)
+    expect(parsedXPrompt.data.description).toBe("Morph-X work workflow")
+    expect(parsedXPrompt.data["argument-hint"]).toBe("[plan]")
+    expect(parsedXPrompt.body).toContain("Use the gh:work-x skill")
 
-    expect(bundle.skillDirs.map((skill) => skill.name)).toEqual(["gh:plan"])
+    expect(bundle.skillDirs.map((skill) => skill.name)).toEqual(["gh:plan", "gh:work-x"])
   })
 
   test("does not apply compound workflow canonicalization to other plugins", () => {

--- a/tests/morph-command.test.ts
+++ b/tests/morph-command.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+
+const tempRoots: string[] = []
+const repoRoot = path.join(import.meta.dir, "..")
+
+async function makeTempProject(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "morph-command-"))
+  tempRoots.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+async function runCli(args: string[], env: NodeJS.ProcessEnv = process.env): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", "run", "src/index.ts", ...args], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+describe("morph command", () => {
+  test("runs detection-only when the Swift adapter is unavailable", async () => {
+    const project = await makeTempProject()
+    await fs.writeFile(path.join(project, "Demo.swift"), "import Foundation\nstruct Demo {}\n")
+
+    const result = await runCli(["morph", "--json", project], {
+      ...process.env,
+      MORPH_SWIFT_ADAPTER: "",
+    })
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout)
+    expect(parsed.fingerprint.strategy).toStartWith("strategy:")
+    expect(parsed.adapter.unavailable).toBe(true)
+    expect(parsed.warnings.join("\n")).toContain("adapter_unavailable")
+  })
+
+  test("applies mock adapter output and writes a report file", async () => {
+    const project = await makeTempProject()
+    const reportPath = path.join(project, "morph-report.json")
+    const adapter = path.join(project, "adapter.js")
+    const swiftFile = path.join(project, "Demo.swift")
+    await fs.writeFile(swiftFile, "import Foundation\nstruct Demo {}\n")
+    await fs.writeFile(
+      adapter,
+      [
+        "#!/usr/bin/env bun",
+        "const request = await new Response(Bun.stdin.stream()).json()",
+        "console.log(JSON.stringify({ ok: true, files: request.files.map((file) => ({ path: file.path, changed: true, content: file.content + \"// morph\\\\n\", warnings: [] })), warnings: [] }))",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    )
+
+    const result = await runCli(["morph", "--apply", "--json", "--report", reportPath, "--seed", "seed-a", project], {
+      ...process.env,
+      MORPH_SWIFT_ADAPTER: adapter,
+    })
+
+    expect(result.exitCode).toBe(0)
+    const parsed = JSON.parse(result.stdout)
+    expect(parsed.applied).toBe(true)
+    expect(parsed.filesChanged).toEqual([swiftFile])
+    expect(await fs.readFile(swiftFile, "utf8")).toContain("// morph")
+    const report = JSON.parse(await fs.readFile(reportPath, "utf8"))
+    expect(report.seed).toBe("seed-a")
+  })
+})

--- a/tests/morph-config.test.ts
+++ b/tests/morph-config.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+import { loadMorphConfig } from "../src/morph/config"
+
+const tempRoots: string[] = []
+
+async function makeTempProject(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "morph-config-"))
+  tempRoots.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+describe("loadMorphConfig", () => {
+  test("loads a complete .morph-config.yaml", async () => {
+    const projectRoot = await makeTempProject()
+    await fs.writeFile(
+      path.join(projectRoot, ".morph-config.yaml"),
+      [
+        "seed: ios-demo-a",
+        "thresholds:",
+        "  statementJaccard: 0.1",
+        "  tokenNgram: 0.12",
+        "  structuralHash: 0.2",
+        "  controlFlow: 0.25",
+        "baselines:",
+        "  paths:",
+        "    - fixtures/baseline-a",
+        "blacklistedPatternTags:",
+        "  - state.mvvm-service",
+        "usedFingerprints:",
+        "  - seed: old-seed",
+        "    blueprint: blueprint-old",
+        "    strategy: strategy-old",
+        "    tags:",
+        "      - layout.extensions-by-role",
+        "    createdAt: '2026-04-24T00:00:00Z'",
+        "",
+      ].join("\n"),
+    )
+
+    const config = await loadMorphConfig(projectRoot)
+
+    expect(config.source).toBe("file")
+    expect(config.seed).toBe("ios-demo-a")
+    expect(config.thresholds.statementJaccard).toBe(0.1)
+    expect(config.thresholds.tokenNgram).toBe(0.12)
+    expect(config.thresholds.structuralHash).toBe(0.2)
+    expect(config.thresholds.controlFlow).toBe(0.25)
+    expect(config.baselines.paths).toEqual([path.join(projectRoot, "fixtures/baseline-a")])
+    expect(config.blacklistedPatternTags).toEqual(["state.mvvm-service"])
+    expect(config.usedFingerprints).toEqual([
+      {
+        seed: "old-seed",
+        blueprint: "blueprint-old",
+        strategy: "strategy-old",
+        tags: ["layout.extensions-by-role"],
+        createdAt: "2026-04-24T00:00:00Z",
+      },
+    ])
+    expect(config.warnings).toHaveLength(0)
+  })
+
+  test("returns defaults when the config file is missing", async () => {
+    const projectRoot = await makeTempProject()
+
+    const config = await loadMorphConfig(projectRoot)
+
+    expect(config.source).toBe("default")
+    expect(config.seed).toBe(`default:${path.basename(projectRoot)}`)
+    expect(config.thresholds.statementJaccard).toBe(0.15)
+    expect(config.baselines.paths).toEqual([])
+    expect(config.warnings.map((warning) => warning.code)).toEqual(["default_seed", "baseline_missing"])
+  })
+
+  test("merges partial config with defaults", async () => {
+    const projectRoot = await makeTempProject()
+    await fs.writeFile(
+      path.join(projectRoot, ".morph-config.yaml"),
+      ["seed: 42", "thresholds:", "  tokenNgram: 0.33", "baselinePaths:", "  - ../shared-baseline", ""].join("\n"),
+    )
+
+    const config = await loadMorphConfig(projectRoot)
+
+    expect(config.seed).toBe("42")
+    expect(config.thresholds.statementJaccard).toBe(0.15)
+    expect(config.thresholds.tokenNgram).toBe(0.33)
+    expect(config.baselines.paths).toEqual([path.resolve(projectRoot, "../shared-baseline")])
+  })
+
+  test("overrides config values with CLI options", async () => {
+    const projectRoot = await makeTempProject()
+    await fs.writeFile(path.join(projectRoot, ".morph-config.yaml"), "seed: file-seed\n")
+
+    const config = await loadMorphConfig(projectRoot, {
+      seed: "cli-seed",
+      thresholds: { controlFlow: 0.09 },
+      baselinePaths: ["cli-baseline"],
+    })
+
+    expect(config.seed).toBe("cli-seed")
+    expect(config.thresholds.controlFlow).toBe(0.09)
+    expect(config.baselines.paths).toEqual([path.join(projectRoot, "cli-baseline")])
+  })
+
+  test("reports invalid YAML with the config file name", async () => {
+    const projectRoot = await makeTempProject()
+    await fs.writeFile(path.join(projectRoot, ".morph-config.yaml"), "seed: [unterminated\n")
+
+    await expect(loadMorphConfig(projectRoot)).rejects.toThrow("Invalid .morph-config.yaml")
+  })
+
+  test("rejects thresholds outside the 0 to 1 range", async () => {
+    const projectRoot = await makeTempProject()
+    await fs.writeFile(
+      path.join(projectRoot, ".morph-config.yaml"),
+      ["thresholds:", "  statementJaccard: -0.1", ""].join("\n"),
+    )
+
+    await expect(loadMorphConfig(projectRoot)).rejects.toThrow("thresholds.statementJaccard")
+  })
+})

--- a/tests/morph-fingerprints.test.ts
+++ b/tests/morph-fingerprints.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createSourceFingerprint,
+  createStructuralFingerprint,
+  extractNormalizedStatements,
+  normalizeMorphSource,
+  summarizeControlFlow,
+  tokenizeMorphSource,
+} from "../src/morph/fingerprints"
+
+describe("morph fingerprints", () => {
+  test("normalizes whitespace, comments, literals, and import-only noise", () => {
+    const first = extractNormalizedStatements(normalizeMorphSource(`
+      import SwiftUI
+      // Comment should not matter
+      let Name = "Gale"
+      print(Name)
+    `))
+    const second = extractNormalizedStatements(normalizeMorphSource(`
+      import SwiftUI
+      let name = "Other" ; print( name )
+    `))
+
+    expect(first).toEqual(["let name=str", "print(name)"])
+    expect(second).toEqual(["let name=str", "print(name)"])
+  })
+
+  test("creates identical fingerprints for identical Swift code", () => {
+    const source = `
+      struct ProfileView {
+        func title(_ name: String) -> String {
+          if name.isEmpty { return "Untitled" }
+          return name
+        }
+      }
+    `
+
+    const left = createSourceFingerprint("ProfileView.swift", source)
+    const right = createSourceFingerprint("ProfileView.swift", source)
+
+    expect(left.language).toBe("swift")
+    expect(left.statements).toEqual(right.statements)
+    expect(left.tokenNgrams).toEqual(right.tokenNgrams)
+    expect(left.structuralHash).toBe(right.structuralHash)
+    expect(left.controlFlow).toEqual(["if", "return:conditional", "return:direct"])
+  })
+
+  test("uses adapter structural nodes when available", () => {
+    const warnings: string[] = []
+    const fromAdapter = createStructuralFingerprint([], {
+      ok: true,
+      nodes: [
+        { kind: "SourceFile", children: [{ kind: "StructDecl" }, { kind: "FunctionDecl" }] },
+      ],
+    }, warnings)
+    const sameShape = createStructuralFingerprint([], {
+      ok: true,
+      nodes: [
+        { kind: "sourcefile", children: [{ kind: "structdecl" }, { kind: "functiondecl" }] },
+      ],
+    })
+
+    expect(fromAdapter.parts).toEqual(["sourcefile", "structdecl", "functiondecl"])
+    expect(fromAdapter.hash).toBe(sameShape.hash)
+    expect(warnings).toEqual([])
+  })
+
+  test("falls back to token structure and warns on invalid adapter output", () => {
+    const warnings: string[] = []
+    const tokens = tokenizeMorphSource(normalizeMorphSource("func run() { if ready { return } }"))
+
+    const fingerprint = createStructuralFingerprint(tokens, { nodes: [] }, warnings)
+
+    expect(fingerprint.parts).toContain("func")
+    expect(fingerprint.parts).toContain("if")
+    expect(fingerprint.hash).toMatch(/^[0-9a-f]{8}$/)
+    expect(warnings).toEqual(["AST adapter output was invalid; using token-structure fallback."])
+  })
+
+  test("summarizes approximate control-flow shape", () => {
+    const tokens = tokenizeMorphSource(normalizeMorphSource(`
+      guard isReady else { return }
+      for item in items {
+        if item.enabled { continue }
+      }
+      switch state {
+      case .done: return
+      default: break
+      }
+    `))
+
+    expect(summarizeControlFlow(tokens)).toEqual([
+      "guard",
+      "else",
+      "return:conditional",
+      "for",
+      "if",
+      "continue",
+      "switch",
+      "case",
+      "return:conditional",
+      "default",
+      "break",
+    ])
+  })
+})

--- a/tests/morph-metrics.test.ts
+++ b/tests/morph-metrics.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import { compareMorphSources } from "../src/morph/metrics"
+import { buildMorphSimilarityReport } from "../src/morph/report"
+import type { MorphConfigThresholds } from "../src/morph/types"
+
+const thresholds: MorphConfigThresholds = {
+  statementJaccard: 0.8,
+  tokenNgram: 0.8,
+  structuralHash: 0.8,
+  controlFlow: 0.8,
+}
+
+describe("morph metrics", () => {
+  test("scores identical Swift code as fully similar", () => {
+    const source = `
+      final class Counter {
+        func next(_ value: Int) -> Int {
+          if value > 0 { return value + 1 }
+          return 0
+        }
+      }
+    `
+
+    const result = compareMorphSources("Counter.swift", source, "Counter.swift", source)
+
+    expect(result.metrics.statement_jaccard).toBe(1)
+    expect(result.metrics.token_ngram).toBe(1)
+    expect(result.metrics.structural_hash).toBe(1)
+    expect(result.metrics.control_flow).toBe(1)
+  })
+
+  test("keeps whitespace and comments from materially changing normalized similarity", () => {
+    const first = `
+      // Old note
+      func label(_ name: String) -> String {
+        return "Hi, \\(name)"
+      }
+    `
+    const second = `
+      func LABEL( _ NAME: String ) -> String
+      {
+        /* changed prose */
+        return "Hello, \\(NAME)"
+      }
+    `
+
+    const result = compareMorphSources("Label.swift", first, "Label.swift", second)
+
+    expect(result.metrics.statement_jaccard).toBeGreaterThanOrEqual(0.5)
+    expect(result.metrics.token_ngram).toBeGreaterThan(0.6)
+  })
+
+  test("recognizes similar control-flow shape even when token n-grams diverge", () => {
+    const earlyReturn = `
+      func access(_ user: User) -> Bool {
+        guard user.isActive else { return false }
+        if user.isAdmin { return true }
+        return user.hasSeat
+      }
+    `
+    const nested = `
+      func allowed(_ account: Account) -> Decision {
+        guard account.enabled else { return .deny }
+        if account.role == .owner { return .allow }
+        return account.subscription.available ? .allow : .deny
+      }
+    `
+
+    const result = compareMorphSources("Access.swift", earlyReturn, "Access.swift", nested)
+
+    expect(result.metrics.token_ngram).toBeLessThan(0.5)
+    expect(result.metrics.control_flow).toBe(1)
+  })
+
+  test("returns finite scores for empty, comment-only, and import-only inputs", () => {
+    const cases = ["", "// comment only\n", "import SwiftUI\n@testable import App\n"]
+
+    for (const source of cases) {
+      const result = compareMorphSources("Empty.swift", source, "Empty.swift", source)
+      for (const score of Object.values(result.metrics)) {
+        expect(Number.isFinite(score)).toBe(true)
+      }
+      expect(result.metrics.statement_jaccard).toBe(1)
+      expect(result.metrics.token_ngram).toBe(1)
+    }
+  })
+
+  test("report keeps adapter fallback warnings and still computes fallback metrics", () => {
+    const report = buildMorphSimilarityReport(
+      [{
+        path: "Adapter.swift",
+        source: "func run() { if ready { return } }",
+        baselineSource: "func run() { if ready { return } }",
+        sourceAdapterOutput: { ok: false, error: "invalid json" },
+      }],
+      thresholds,
+    )
+
+    expect(report.status).toBe("blocked")
+    expect(report.files[0].metrics.structural_hash).toBe(1)
+    expect(report.files[0].warnings.join("\n")).toContain("AST adapter unavailable")
+    expect(report.warnings.join("\n")).toContain("invalid json")
+  })
+
+  test("multi-file report localizes the only high-risk file", () => {
+    const report = buildMorphSimilarityReport(
+      [
+        {
+          path: "Sources/ProfileView.swift",
+          source: "struct ProfileView { func body() -> String { return title } }",
+          baselineSource: "struct ProfileView { func body() -> String { return title } }",
+        },
+        {
+          path: "Sources/SettingsView.swift",
+          source: "struct SettingsView { func render() -> String { return footer } }",
+          baselineSource: "enum Preferences { case enabled }",
+        },
+      ],
+      thresholds,
+    )
+
+    const risky = report.files.filter((file) => file.highRisk)
+
+    expect(report.status).toBe("blocked")
+    expect(risky.map((file) => file.path)).toEqual(["Sources/ProfileView.swift"])
+    expect(report.overall.statement_jaccard).toBeGreaterThan(0)
+    expect(Number.isFinite(report.overall.statement_jaccard ?? Number.NaN)).toBe(true)
+  })
+})

--- a/tests/morph-strategies.test.ts
+++ b/tests/morph-strategies.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test"
+import { BLUEPRINT_DIMENSIONS, BLUEPRINT_REGISTRY } from "../src/morph/blueprints"
+import { selectMorphStrategy, STRATEGY_DIMENSIONS, STRATEGY_REGISTRY } from "../src/morph/strategies"
+import type { MorphUsedFingerprint } from "../src/morph/types"
+
+describe("Morph-X blueprint and strategy registries", () => {
+  test("define at least three tags per planned dimension", () => {
+    for (const dimension of BLUEPRINT_DIMENSIONS) {
+      const options = BLUEPRINT_REGISTRY.filter((entry) => entry.dimension === dimension)
+      expect(options.length).toBeGreaterThanOrEqual(3)
+      expect(new Set(options.flatMap((entry) => entry.tags)).size).toBeGreaterThanOrEqual(3)
+    }
+
+    for (const dimension of STRATEGY_DIMENSIONS) {
+      const options = STRATEGY_REGISTRY.filter((entry) => entry.dimension === dimension)
+      expect(options.length).toBeGreaterThanOrEqual(3)
+      expect(new Set(options.flatMap((entry) => entry.tags)).size).toBeGreaterThanOrEqual(3)
+    }
+  })
+})
+
+describe("selectMorphStrategy", () => {
+  test("returns stable blueprint and strategy fingerprints for the same seed and history", () => {
+    const input = {
+      seed: "ios-demo-seed",
+      usedFingerprints: [],
+      blacklistedTags: [],
+      languages: ["swift" as const],
+    }
+
+    const first = selectMorphStrategy(input)
+    const second = selectMorphStrategy(input)
+
+    expect(second.blueprint.fingerprint).toBe(first.blueprint.fingerprint)
+    expect(second.strategy.fingerprint).toBe(first.strategy.fingerprint)
+    expect(second.fingerprint).toEqual(first.fingerprint)
+    expect(first.blueprint.constraints.length).toBe(BLUEPRINT_DIMENSIONS.length)
+    expect(first.strategy.hooks.length).toBeGreaterThan(0)
+  })
+
+  test("different seeds vary the selected blueprint or strategy combination", () => {
+    const first = selectMorphStrategy({ seed: "ios-demo-a", languages: ["swift"] })
+    const second = selectMorphStrategy({ seed: "ios-demo-b", languages: ["swift"] })
+
+    expect(`${second.blueprint.fingerprint}:${second.strategy.fingerprint}`).not.toBe(
+      `${first.blueprint.fingerprint}:${first.strategy.fingerprint}`,
+    )
+  })
+
+  test("history biases away from MVVM service-like blueprint tags", () => {
+    const baseline = selectMorphStrategy({ seed: "seed-0", languages: ["swift"] })
+    const usedFingerprints: MorphUsedFingerprint[] = [
+      {
+        seed: "prior",
+        blueprint: "blueprint:prior",
+        strategy: "strategy:prior",
+        tags: ["state.mvvm-service", "boundary.service-protocol", "risk.mvvm-like", "risk.service-like"],
+      },
+    ]
+
+    const selected = selectMorphStrategy({
+      seed: "seed-0",
+      usedFingerprints,
+      languages: ["swift"],
+    })
+
+    expect(baseline.blueprint.tags).toContain("state.mvvm-service")
+    expect(selected.blueprint.tags).not.toContain("state.mvvm-service")
+    expect(selected.blueprint.tags).not.toContain("boundary.service-protocol")
+  })
+
+  test("respects blacklisted tags across blueprint and strategy choices", () => {
+    const selected = selectMorphStrategy({
+      seed: "blacklist-seed",
+      blacklistedTags: ["state.mvvm-service", "control.guard-first", "imports.system-first"],
+      languages: ["swift"],
+    })
+
+    expect(selected.fingerprint.tags).not.toContain("state.mvvm-service")
+    expect(selected.fingerprint.tags).not.toContain("control.guard-first")
+    expect(selected.fingerprint.tags).not.toContain("imports.system-first")
+    expect(selected.warnings.some((warning) => warning.startsWith("blacklist_applied"))).toBe(true)
+  })
+
+  test("treats unknown-only language input as unclassified rather than exhausted", () => {
+    const selected = selectMorphStrategy({
+      seed: "unknown-language-seed",
+      languages: ["unknown"],
+    })
+
+    expect(selected.fingerprint.strategy).toMatch(/^strategy:/)
+    expect(selected.strategy.tags.length).toBeGreaterThanOrEqual(STRATEGY_DIMENSIONS.length)
+  })
+
+  test("warns but still returns a selection when history covers most strategy tags", () => {
+    const usedFingerprints: MorphUsedFingerprint[] = [
+      {
+        seed: "prior",
+        blueprint: "blueprint:prior",
+        strategy: "strategy:prior",
+        tags: [...BLUEPRINT_REGISTRY.flatMap((entry) => entry.tags), ...STRATEGY_REGISTRY.flatMap((entry) => entry.tags)],
+      },
+    ]
+
+    const selected = selectMorphStrategy({
+      seed: "crowded-space",
+      usedFingerprints,
+      languages: ["swift"],
+    })
+
+    expect(selected.fingerprint.strategy).toMatch(/^strategy:/)
+    expect(selected.warnings.some((warning) => warning.startsWith("low_differentiation_space"))).toBe(true)
+  })
+
+  test("throws an explicit error only when no valid option remains", () => {
+    const blacklist = BLUEPRINT_REGISTRY.filter((entry) => entry.dimension === "state").flatMap((entry) => entry.tags)
+
+    expect(() =>
+      selectMorphStrategy({
+        seed: "exhausted-blueprint",
+        blacklistedTags: blacklist,
+        languages: ["swift"],
+      }),
+    ).toThrow("No Morph-X blueprint option remains for dimension state")
+  })
+})

--- a/tests/morph-swift-adapter.test.ts
+++ b/tests/morph-swift-adapter.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import os from "os"
+import path from "path"
+import { applySwiftAdapterResult, runSwiftAdapter } from "../src/morph/swift-adapter"
+
+const tempRoots: string[] = []
+
+async function makeTempDir(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "morph-swift-adapter-"))
+  tempRoots.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+describe("runSwiftAdapter", () => {
+  test("reports adapter_unavailable when no executable is configured", async () => {
+    const oldEnv = process.env.MORPH_SWIFT_ADAPTER
+    delete process.env.MORPH_SWIFT_ADAPTER
+    try {
+      const result = await runSwiftAdapter({
+        files: [],
+        strategyFingerprint: "strategy-a",
+        strategyTags: [],
+        apply: true,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.unavailable).toBe(true)
+      expect(result.warnings[0]).toContain("adapter_unavailable")
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env.MORPH_SWIFT_ADAPTER
+      } else {
+        process.env.MORPH_SWIFT_ADAPTER = oldEnv
+      }
+    }
+  })
+
+  test("parses successful adapter output and writes transformed files explicitly", async () => {
+    const root = await makeTempDir()
+    const swiftFile = path.join(root, "Demo.swift")
+    const adapter = path.join(root, "adapter.js")
+    await fs.writeFile(swiftFile, "import Foundation\n")
+    await fs.writeFile(
+      adapter,
+      [
+        "#!/usr/bin/env bun",
+        "const request = await new Response(Bun.stdin.stream()).json()",
+        "console.log(JSON.stringify({ ok: true, files: request.files.map((file) => ({ path: file.path, changed: true, content: file.content + \"// transformed\\\\n\", warnings: [] })), warnings: [] }))",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    )
+
+    const result = await runSwiftAdapter({
+      files: [{ path: swiftFile, content: "import Foundation\n" }],
+      strategyFingerprint: "strategy-a",
+      strategyTags: ["import.alpha"],
+      apply: true,
+    }, { executable: adapter, cwd: root })
+
+    expect(result.ok).toBe(true)
+    expect(result.files[0].changed).toBe(true)
+    const written = await applySwiftAdapterResult(result)
+    expect(written).toEqual([swiftFile])
+    expect(await fs.readFile(swiftFile, "utf8")).toContain("// transformed")
+  })
+
+  test("keeps original files when adapter exits non-zero", async () => {
+    const root = await makeTempDir()
+    const swiftFile = path.join(root, "Demo.swift")
+    const adapter = path.join(root, "adapter.js")
+    await fs.writeFile(swiftFile, "let value = 1\n")
+    await fs.writeFile(
+      adapter,
+      ["#!/usr/bin/env bun", "console.error('boom')", "process.exit(2)", ""].join("\n"),
+      { mode: 0o755 },
+    )
+
+    const result = await runSwiftAdapter({
+      files: [{ path: swiftFile, content: "let value = 1\n" }],
+      strategyFingerprint: "strategy-a",
+      strategyTags: [],
+      apply: true,
+    }, { executable: adapter, cwd: root })
+
+    expect(result.ok).toBe(false)
+    expect(result.warnings).toContain("swift_adapter_failed")
+    expect(await applySwiftAdapterResult(result)).toEqual([])
+    expect(await fs.readFile(swiftFile, "utf8")).toBe("let value = 1\n")
+  })
+
+  test("reports invalid JSON without throwing", async () => {
+    const root = await makeTempDir()
+    const adapter = path.join(root, "adapter.js")
+    await fs.writeFile(adapter, ["#!/usr/bin/env bun", "console.log('not json')", ""].join("\n"), { mode: 0o755 })
+
+    const result = await runSwiftAdapter({
+      files: [],
+      strategyFingerprint: "strategy-a",
+      strategyTags: [],
+      apply: false,
+    }, { executable: adapter, cwd: root })
+
+    expect(result.ok).toBe(false)
+    expect(result.warnings[0]).toContain("swift_adapter_invalid_json")
+  })
+})

--- a/tests/x-skill-contract.test.ts
+++ b/tests/x-skill-contract.test.ts
@@ -1,0 +1,106 @@
+import path from "path"
+import { readFile } from "fs/promises"
+import { describe, expect, test } from "bun:test"
+import { parseFrontmatter } from "../src/utils/frontmatter"
+
+const SKILL_ROOT = path.join(process.cwd(), "plugins", "galeharness-cli", "skills")
+
+const X_SKILLS = [
+  {
+    dir: "gh-work-x",
+    name: "gh:work-x",
+    anchors: [
+      "Phase 0: Input Triage",
+      "Setup Environment",
+      "Create Task List",
+      "quality checks",
+      "HKTMemory Session Search",
+    ],
+  },
+  {
+    dir: "gh-debug-x",
+    name: "gh:debug-x",
+    anchors: [
+      "Phase 0: Triage",
+      "Phase 1: Investigate",
+      "Causal chain gate",
+      "test-first",
+      "Debug-X Summary",
+    ],
+  },
+] as const
+
+async function readSkill(dir: string): Promise<string> {
+  return readFile(path.join(SKILL_ROOT, dir, "SKILL.md"), "utf8")
+}
+
+function hktPatchLine(content: string, patchName: string): number {
+  const lines = content.split("\n")
+  const index = lines.findIndex((line) => line.trim() === `<!-- HKT-PATCH:${patchName} -->`)
+  return index === -1 ? -1 : index + 1
+}
+
+describe("Morph-X skill contract", () => {
+  for (const skill of X_SKILLS) {
+    test(`${skill.dir} has parseable frontmatter`, async () => {
+      const content = await readSkill(skill.dir)
+      const parsed = parseFrontmatter(content, `${skill.dir}/SKILL.md`)
+
+      expect(parsed.data.name).toBe(skill.name)
+      expect(parsed.data.description).toEqual(expect.any(String))
+      expect(String(parsed.data.description)).toContain("Morph-X")
+      expect(parsed.data["argument-hint"]).toEqual(expect.any(String))
+      expect(parsed.body.length).toBeGreaterThan(100)
+    })
+
+    test(`${skill.dir} preserves base workflow anchors`, async () => {
+      const content = await readSkill(skill.dir)
+
+      for (const anchor of skill.anchors) {
+        expect(content).toContain(anchor)
+      }
+    })
+
+    test(`${skill.dir} documents Morph-X phases and compliance boundary`, async () => {
+      const content = await readSkill(skill.dir)
+
+      expect(content).toContain("Morph-X Blueprint Constraints")
+      expect(content).toContain(".morph-config.yaml")
+      expect(content).toContain("gale-harness morph --apply")
+      expect(content).toContain("gale-harness audit --similarity")
+      expect(content).toContain("strategy fingerprint")
+      expect(content).toContain("threshold")
+      expect(content).toContain("template-code repetition risk")
+      expect(content).toContain("does not guarantee App Review success")
+    })
+
+    test(`${skill.dir} has HKTMemory retrieve, session search, store, and non-blocking fallbacks`, async () => {
+      const content = await readSkill(skill.dir)
+
+      expect(content).toContain("hkt-memory retrieve")
+      expect(content).toContain("hkt-memory session-search")
+      expect(content).toContain("hkt-memory store")
+      expect(content).toMatch(/blueprint\/strategy fingerprints|blueprint constraints, strategy fingerprint/)
+      expect(content).toMatch(/non-blocking|proceed silently|continue silently|skip silently/i)
+    })
+
+    test(`${skill.dir} retrieves before storing fingerprints`, async () => {
+      const content = await readSkill(skill.dir)
+      const retrieveLine = skill.dir === "gh-work-x" ? hktPatchLine(content, "phase-0.6") : hktPatchLine(content, "phase-0.4")
+      const storeLine = hktPatchLine(content, "phase-4.5")
+
+      expect(retrieveLine).toBeGreaterThan(0)
+      expect(storeLine).toBeGreaterThan(0)
+      expect(retrieveLine).toBeLessThan(storeLine)
+    })
+
+    test(`${skill.dir} is self-contained and avoids sibling or absolute skill references`, async () => {
+      const content = await readSkill(skill.dir)
+
+      expect(content).not.toMatch(/\.\.\//)
+      expect(content).not.toMatch(/plugins\/galeharness-cli\/skills\/gh-(work|debug)/)
+      expect(content).not.toMatch(/\/Users\/|\/home\/|\/tmp\/plugin\/skills/)
+      expect(content).not.toMatch(/Skill:\s*gh:(work|debug)\b|skill:\s*gh-(work|debug)\b/i)
+    })
+  }
+})


### PR DESCRIPTION
## 概要

这次新增 iOS Morph-X 工作流：`gh:work-x` 和 `gh:debug-x` 作为独立技能入口，保留原有工作流能力，同时把最终代码产出接入确定性的差异化规划。

默认的 `gh:work` 和 `gh:debug` 没有改动。Morph-X 通过新的 CLI、配置和技能封装提供可选路径，让团队可以按项目启用相似度审计、种子驱动的策略选择，以及 Swift adapter 集成。

```mermaid
flowchart TB
  Skill["gh:work-x / gh:debug-x"] --> Blueprint["Morph 蓝图选择"]
  Blueprint --> Strategy["种子驱动策略指纹"]
  Strategy --> Adapter["可选 Swift adapter"]
  Adapter --> Audit["相似度审计报告"]
  Config[".morph-config.yaml"] --> Blueprint
  Config --> Audit
  Baseline["历史基准代码"] --> Audit
```

## 主要改动

- 新增 `gh:work-x` 和 `gh:debug-x` 两个 Morph-X 技能，定义记忆检索、计划、实现、审计和交付契约。
- 新增 `gale-harness audit --similarity`，支持基于配置或命令行传入的基准代码生成相似度报告。
- 新增 `gale-harness morph --apply`，支持按 seed/config 选择差异化策略，运行可选 Swift adapter，并在产出后执行审计。
- 新增 `src/morph/` 模块，覆盖配置加载、源码收集、基准匹配、指纹生成、指标计算、报告生成、蓝图选择、策略选择和 adapter 调用。
- 更新 README、插件 README 和 Codex 转换测试，确保 `-x` 技能可发现、可转换、可验证。

## 验证

- `bun test`
- `bun run release:validate`
- `git diff --check`

补充：之前也跑过 `bunx tsc --noEmit`，仍然命中既有的 `src/utils/update.ts` 中 `Bun.execPath` 类型问题，和本次 Morph-X 改动无关。