### PR TITLE
fix(cli): restore release binary install path

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -3,6 +3,9 @@ name: Release Assets
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Release PR"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -12,8 +15,11 @@ on:
 jobs:
   build-and-upload:
     if: >-
-      startsWith(github.event.release.tag_name, 'galeharness-cli-v') ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'galeharness-cli-v'))
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main')
     runs-on: macos-latest
     permissions:
       contents: write
@@ -31,26 +37,49 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$DISPATCH_TAG"
+          elif [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$(gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 20 \
+              --json tagName,isDraft \
+              --jq '[.[] | select(.isDraft == false and (.tagName | startswith("galeharness-cli-v")))] | first | .tagName')"
           fi
+
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "No galeharness-cli release tag found; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$TAG" != galeharness-cli-v* ]]; then
+            echo "Tag '$TAG' is not a galeharness-cli release; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           VERSION="${TAG#galeharness-cli-v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Build release binaries
+        if: steps.version.outputs.skip != 'true'
         run: bun run build:release --version ${{ steps.version.outputs.version }}
 
       - name: Upload assets to release
+        if: steps.version.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ARCHIVE="galeharness-cli-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            gh release upload "${{ steps.version.outputs.tag }}" "$ARCHIVE" --clobber
-          else
-            gh release upload "${{ github.event.release.tag_name }}" "$ARCHIVE" --clobber
-          fi
+          gh release upload "${{ steps.version.outputs.tag }}" "$ARCHIVE" --clobber

--- a/README.md
+++ b/README.md
@@ -420,6 +420,16 @@ gale-knowledge rebuild-index --full  # 全量
 
 ### 一键安装
 
+#### Release 二进制安装（推荐用于升级旧版 CLI）
+
+旧版 `bun link` / source-mode 安装无法通过 `gale-harness update` 自我替换。先运行一次 release 安装脚本迁移到编译二进制，之后再使用 `gale-harness update`。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/install-release.sh | bash
+```
+
+脚本会优先安装到当前 `gale-harness` 所在目录，并移除旧的 `bun link` symlink 后写入编译二进制。没有已安装命令时，默认安装到 `~/.local/bin`。
+
 #### macOS / Linux
 
 ```bash

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Install GaleHarnessCLI from compiled GitHub Release assets.
+# Usage:
+#   bash scripts/install-release.sh [galeharness-cli-vX.Y.Z]
+#
+# Environment:
+#   INSTALL_DIR=/path/to/bin   Override install directory
+
+set -euo pipefail
+
+REPO="wangrenzhu-ola/GaleHarnessCodingCLI"
+TAG_PREFIX="galeharness-cli-v"
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+}
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "missing required command: $1"
+    exit 1
+  fi
+}
+
+detect_platform() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os:$arch" in
+    Darwin:arm64) echo "darwin-arm64" ;;
+    Darwin:x86_64) echo "darwin-x64" ;;
+    Linux:x86_64) echo "linux-x64" ;;
+    Linux:aarch64 | Linux:arm64) echo "linux-arm64" ;;
+    *)
+      err "unsupported platform: $os $arch"
+      exit 1
+      ;;
+  esac
+}
+
+resolve_tag() {
+  if [ "${1:-}" != "" ]; then
+    printf '%s\n' "$1"
+    return
+  fi
+
+  need python3
+  curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=20" | python3 -c '
+import json
+import sys
+
+for release in json.load(sys.stdin):
+    tag = release.get("tag_name", "")
+    if not release.get("draft") and tag.startswith("galeharness-cli-v"):
+        print(tag)
+        break
+else:
+    sys.exit("no galeharness-cli release found")
+'
+}
+
+resolve_install_dir() {
+  if [ "${INSTALL_DIR:-}" != "" ]; then
+    printf '%s\n' "$INSTALL_DIR"
+    return
+  fi
+
+  if command -v gale-harness >/dev/null 2>&1; then
+    dirname "$(command -v gale-harness)"
+    return
+  fi
+
+  printf '%s\n' "$HOME/.local/bin"
+}
+
+need curl
+need tar
+
+tag="$(resolve_tag "${1:-}")"
+if [[ "$tag" != "$TAG_PREFIX"* ]]; then
+  err "release tag must start with $TAG_PREFIX: $tag"
+  exit 1
+fi
+
+version="${tag#$TAG_PREFIX}"
+platform="$(detect_platform)"
+asset="galeharness-cli-$version-$platform.tar.gz"
+url="https://github.com/$REPO/releases/download/$tag/$asset"
+tmpdir="$(mktemp -d -t galeharness-install-XXXXXX)"
+install_dir="$(resolve_install_dir)"
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+printf 'Installing GaleHarnessCLI %s (%s)\n' "$version" "$platform"
+printf 'Download: %s\n' "$url"
+
+curl -fL "$url" -o "$tmpdir/$asset"
+tar -xzf "$tmpdir/$asset" -C "$tmpdir"
+
+mkdir -p "$install_dir"
+for bin in gale-harness compound-plugin gale-knowledge; do
+  dest="$install_dir/$bin"
+  if [ -L "$dest" ]; then
+    rm "$dest"
+  fi
+  install -m 0755 "$tmpdir/$bin" "$dest"
+done
+install -m 0644 "$tmpdir/VERSION" "$install_dir/VERSION"
+
+cat <<EOF
+
+Installed to $install_dir
+
+This script overwrites existing GaleHarnessCLI binaries in that directory. If a
+previous install used bun link, old symlinks were removed before installing the
+compiled binaries.
+
+Then verify:
+
+  gale-harness --version
+  gale-harness update --check
+EOF

--- a/src/utils/update.ts
+++ b/src/utils/update.ts
@@ -40,6 +40,13 @@ export interface UpdateResult {
   newVersion?: string
 }
 
+interface GitHubRelease {
+  tag_name: string
+  draft?: boolean
+  prerelease?: boolean
+  assets: Array<{ name: string; browser_download_url: string; size: number }>
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
@@ -113,7 +120,7 @@ export function isCompiledBinary(): boolean {
  * Query GitHub Release API for the latest version matching our tag prefix.
  */
 export async function getLatestVersion(repo: string): Promise<{ version: string; assetUrl: string; assetName: string }> {
-  const url = `https://api.github.com/repos/${repo}/releases/latest`
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=20`
   const response = await fetch(url, {
     headers: {
       "User-Agent": "gale-harness-update",
@@ -128,14 +135,14 @@ export async function getLatestVersion(repo: string): Promise<{ version: string;
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`)
   }
 
-  const release = (await response.json()) as {
-    tag_name: string
-    assets: Array<{ name: string; browser_download_url: string; size: number }>
-  }
-
-  // Verify tag prefix
-  if (!release.tag_name.startsWith(TAG_PREFIX)) {
-    throw new Error(`Latest release tag '${release.tag_name}' does not match expected prefix '${TAG_PREFIX}'.`)
+  const releases = (await response.json()) as GitHubRelease[]
+  const release = releases.find((candidate) =>
+    !candidate.draft &&
+    !candidate.prerelease &&
+    candidate.tag_name.startsWith(TAG_PREFIX),
+  )
+  if (!release) {
+    throw new Error(`No releases found for ${repo}. Ensure at least one release exists with tag prefix '${TAG_PREFIX}'.`)
   }
 
   const version = release.tag_name.slice(TAG_PREFIX.length)

--- a/tests/update-command.test.ts
+++ b/tests/update-command.test.ts
@@ -9,6 +9,7 @@ import {
   detectBinDir,
   isCompiledBinary,
   checkForUpdate,
+  getLatestVersion,
   performUpdate,
   performRollback,
 } from "../src/utils/update"
@@ -88,6 +89,56 @@ describe("update utils", () => {
       const dir = detectBinDir()
       expect(dir).toBeTruthy()
       expect(path.isAbsolute(dir)).toBe(true)
+    })
+  })
+
+  describe("getLatestVersion", () => {
+    const originalFetch = globalThis.fetch
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    test("selects the latest galeharness-cli release when another component release is newer", async () => {
+      globalThis.fetch = mock(async () => new Response(JSON.stringify([
+        {
+          tag_name: "cli-v2.2.0",
+          draft: false,
+          prerelease: false,
+          assets: [],
+        },
+        {
+          tag_name: "galeharness-cli-v2.2.0",
+          draft: false,
+          prerelease: false,
+          assets: [
+            {
+              name: `galeharness-cli-2.2.0-${detectPlatform()}.tar.gz`,
+              browser_download_url: "https://example.com/asset.tar.gz",
+              size: 1,
+            },
+          ],
+        },
+      ]), { status: 200 }))
+
+      const latest = await getLatestVersion("owner/repo")
+
+      expect(latest.version).toBe("2.2.0")
+      expect(latest.assetUrl).toBe("https://example.com/asset.tar.gz")
+      expect(latest.assetName).toBe(`galeharness-cli-2.2.0-${detectPlatform()}.tar.gz`)
+    })
+
+    test("reports missing platform asset from the matching release", async () => {
+      globalThis.fetch = mock(async () => new Response(JSON.stringify([
+        {
+          tag_name: "galeharness-cli-v2.2.0",
+          draft: false,
+          prerelease: false,
+          assets: [],
+        },
+      ]), { status: 200 }))
+
+      expect(getLatestVersion("owner/repo")).rejects.toThrow("No release asset found")
     })
   })
 })


### PR DESCRIPTION
## Summary

This fixes the 2.2.0 release recovery path for users who installed GaleHarnessCLI through the old source/bun-link flow. Those installs cannot self-update because `gale-harness update` only supports compiled binaries, so this adds a direct release-binary installer and documents the migration path.

It also fixes the release asset pipeline so future `galeharness-cli-v*` releases get compiled assets even when release-please creates the GitHub Release with `GITHUB_TOKEN`. The asset workflow now also runs after the Release PR workflow completes, resolves the latest non-draft `galeharness-cli-v*` release, and uploads the compiled archive. The existing manual dispatch path remains available for backfills.

Finally, `gale-harness update` now lists releases and selects the latest `galeharness-cli-v*` release instead of depending on `/releases/latest`, which can point at another release component such as `cli-v*`.

## Notes

The `galeharness-cli-v2.2.0` release has already been manually backfilled with `galeharness-cli-2.2.0-darwin-arm64.tar.gz`.

Old installs can migrate with:

```bash
curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/install-release.sh | bash
```

If `~/.bun/bin` shadows the new binary, users should put `~/.local/bin` first in PATH.

## Verification

- `bun test tests/update-command.test.ts`
- `bash -n scripts/install-release.sh`
- `bun run release:validate`
- Parsed `.github/workflows/release-assets.yml` with `js-yaml`
- Ran `scripts/install-release.sh galeharness-cli-v2.2.0` against a temp `INSTALL_DIR`
