### PR TITLE
fix(release): include gale-memory binary

### DIFF
--- a/scripts/dev-link.sh
+++ b/scripts/dev-link.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Link gale-harness, compound-plugin, and gale-knowledge to local source tree for development.
+# Link gale-harness, compound-plugin, gale-knowledge, and gale-memory to local source tree for development.
 # Creates wrapper scripts that invoke `bun run` on the source, so the commands
 # work the same as the release symlinks (which point to .ts with #!/usr/bin/env bun).
 # Run from repo root or pass the repo path as $1.
@@ -14,10 +14,12 @@ if [ ! -f "$DEFAULT_ENTRY" ]; then
   exit 1
 fi
 
-for bin in gale-harness compound-plugin gale-knowledge; do
+for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
   # Select entry file per binary
   if [ "$bin" = "gale-knowledge" ]; then
     ENTRY="$REPO_ROOT/cmd/gale-knowledge/index.ts"
+  elif [ "$bin" = "gale-memory" ]; then
+    ENTRY="$REPO_ROOT/cmd/gale-memory/index.ts"
   else
     ENTRY="$DEFAULT_ENTRY"
   fi

--- a/scripts/dev-unlink.sh
+++ b/scripts/dev-unlink.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Restore gale-harness, compound-plugin, and gale-knowledge to the release version.
+# Restore gale-harness, compound-plugin, gale-knowledge, and gale-memory to the release version.
 # Restores the saved symlinks from before dev-link was run.
 # If no backup exists, falls back to reinstalling from the bun global cache.
 set -euo pipefail
@@ -7,7 +7,7 @@ set -euo pipefail
 BIN_DIR="$HOME/.bun/bin"
 GLOBAL_PKG="$HOME/.bun/install/global/node_modules/@gale/harness-cli/src/index.ts"
 
-for bin in gale-harness compound-plugin gale-knowledge; do
+for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
   LINK="$BIN_DIR/$bin"
   BACKUP="$BIN_DIR/${bin}.release-target"
 

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -102,7 +102,7 @@ curl -fL "$url" -o "$tmpdir/$asset"
 tar -xzf "$tmpdir/$asset" -C "$tmpdir"
 
 mkdir -p "$install_dir"
-for bin in gale-harness compound-plugin gale-knowledge; do
+for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
   dest="$install_dir/$bin"
   if [ -L "$dest" ]; then
     rm "$dest"

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -70,6 +70,8 @@ if (fs.existsSync(archivePath)) {
   fs.unlinkSync(archivePath)
 }
 
+const releaseFiles = ["gale-harness", "compound-plugin", "gale-knowledge", "gale-memory", "VERSION"]
+
 console.error(`[build] Compiling binaries (v${version}, ${platform})...`)
 
 // 1. Compile gale-harness (src/index.ts)
@@ -93,18 +95,27 @@ execSync(
   },
 )
 
-// 4. Write VERSION file
+// 4. Compile gale-memory (cmd/gale-memory/index.ts)
+execSync(
+  `bun build --compile cmd/gale-memory/index.ts --outfile ${path.join(buildDir, "gale-memory")} --target bun`,
+  {
+    cwd: repoRoot,
+    stdio: "inherit",
+  },
+)
+
+// 5. Write VERSION file
 fs.writeFileSync(path.join(buildDir, "VERSION"), `${version}\n`, "utf-8")
 
-// 5. Package into tar.gz
+// 6. Package into tar.gz
 console.error(`[build] Packaging ${archiveName}...`)
-execSync(`tar -czf ${archivePath} -C ${buildDir} gale-harness compound-plugin gale-knowledge VERSION`, {
+execSync(`tar -czf ${archivePath} -C ${buildDir} ${releaseFiles.join(" ")}`, {
   cwd: repoRoot,
   stdio: "inherit",
 })
 
-// 6. Clean up build directory
+// 7. Clean up build directory
 fs.rmSync(buildDir, { recursive: true, force: true })
 
-// 7. Print archive path to stdout (for CI)
+// 8. Print archive path to stdout (for CI)
 console.log(archivePath)

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -394,6 +394,20 @@ if ($CI_MODE) {
         $cliOk = $false
     }
 
+    # 验证 gale-memory
+    try {
+        $gmResult = & gale-memory --help 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            ok "gale-memory CLI 启动正常"
+        } else {
+            err "gale-memory CLI 启动失败 (exit code: $LASTEXITCODE)"
+            $cliOk = $false
+        }
+    } catch {
+        err "gale-memory CLI 启动异常: $_"
+        $cliOk = $false
+    }
+
     if (-not $cliOk) {
         err "CI 验证失败：CLI 无法正常启动"
         exit 1
@@ -427,6 +441,9 @@ if ($CI_MODE) {
 
   gale-knowledge resolve-path --type solutions
     -> 期望: 输出全局知识仓库路径
+
+  gale-memory --help
+    -> 期望: 显示 task memory helper 帮助信息
 
   hkt-memory stats
     -> 期望: HKTMemory 统计信息

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -375,6 +375,9 @@ ${BOLD}  自检清单 — 配置生效后，依次运行以下命令验证:${NC}
   ${CYAN}gale-knowledge resolve-path --type solutions${NC}
     → 期望: 输出全局知识仓库路径
 
+  ${CYAN}gale-memory --help${NC}
+    → 期望: 显示 task memory helper 帮助信息
+
   ${CYAN}hkt-memory stats${NC}
     → 期望: HKTMemory 统计信息
 

--- a/src/utils/update.ts
+++ b/src/utils/update.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url"
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
-const BINARY_NAMES = ["gale-harness", "compound-plugin", "gale-knowledge"] as const
+const BINARY_NAMES = ["gale-harness", "compound-plugin", "gale-knowledge", "gale-memory"] as const
 const TAG_PREFIX = "galeharness-cli-v"
 const DEFAULT_REPO = "wangrenzhu-ola/GaleHarnessCLI"
 const BACKUP_DIR = path.join(os.homedir(), ".galeharness", "backup")
@@ -113,7 +113,7 @@ export function isCompiledBinary(): boolean {
   if (!execPath) return false
   // If the executable name is one of our binaries, we're in compiled mode
   const basename = path.basename(execPath)
-  return BINARY_NAMES.includes(basename as any) || basename === "gale-harness" || basename === "compound-plugin" || basename === "gale-knowledge"
+  return BINARY_NAMES.includes(basename as any)
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the release surface for the new `gale-memory` CLI binary.

This PR adds `gale-memory` to:
- compiled release archives built by `scripts/release/build.ts`
- self-update validation, backup, replace, and rollback via `src/utils/update.ts`
- `scripts/install-release.sh`
- development link/unlink scripts
- setup self-check / CI verification surfaces

Without this, `package.json` exposes `gale-memory` as a bin but compiled release installs and self-updates would omit the binary.

## Verification

- `bun test tests/gale-memory-runtime.test.ts tests/hkt-memory-compounding.test.ts tests/task-writer.test.ts` -> 104 passed
- `bun run release:validate` -> passed
- `bun run scripts/release/build.ts --version 0.0.0-gale-memory-check --platform darwin-arm64` -> passed
- `tar -tzf galeharness-cli-0.0.0-gale-memory-check-darwin-arm64.tar.gz | sort` -> includes `gale-memory`
- `git diff --check -- scripts/release/build.ts src/utils/update.ts scripts/install-release.sh scripts/dev-link.sh scripts/dev-unlink.sh scripts/setup.sh scripts/setup.ps1` -> passed

Note: full `git diff --check` is currently blocked by pre-existing unstaged whitespace in local `memory/` files that are not part of this PR.
