### PR TITLE
feat(release): 支持全平台 release 二进制

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -13,28 +13,22 @@ on:
         required: false
 
 jobs:
-  build-and-upload:
+  determine-version:
     if: >-
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main')
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      skip: ${{ steps.version.outputs.skip }}
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Determine version
         id: version
         env:
@@ -42,6 +36,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             TAG="$DISPATCH_TAG"
@@ -67,19 +62,57 @@ jobs:
             exit 0
           fi
 
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            TARGET_COMMITISH="$(gh release view "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json targetCommitish \
+              --jq '.targetCommitish')"
+            if [ "$TARGET_COMMITISH" != "$WORKFLOW_HEAD_SHA" ]; then
+              echo "Latest galeharness-cli release '$TAG' points to '$TARGET_COMMITISH', not workflow head '$WORKFLOW_HEAD_SHA'; skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           VERSION="${TAG#galeharness-cli-v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
+  build-and-upload:
+    needs: determine-version
+    if: needs.determine-version.result == 'success' && needs.determine-version.outputs.skip != 'true'
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - darwin-arm64
+          - darwin-x64
+          - linux-arm64
+          - linux-x64
+          - windows-arm64
+          - windows-x64
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Build release binaries
-        if: steps.version.outputs.skip != 'true'
-        run: bun run build:release --version ${{ steps.version.outputs.version }}
+        run: bun run build:release --version ${{ needs.determine-version.outputs.version }} --platform ${{ matrix.platform }}
 
       - name: Upload assets to release
-        if: steps.version.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARCHIVE="galeharness-cli-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz"
-          gh release upload "${{ steps.version.outputs.tag }}" "$ARCHIVE" --clobber
+          ARCHIVE="galeharness-cli-${{ needs.determine-version.outputs.version }}-${{ matrix.platform }}.tar.gz"
+          gh release upload "${{ needs.determine-version.outputs.tag }}" "$ARCHIVE" --clobber

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ gale-knowledge rebuild-index --full  # 全量
 curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/install-release.sh | bash
 ```
 
-脚本会优先安装到当前 `gale-harness` 所在目录，并移除旧的 `bun link` symlink 后写入编译二进制。没有已安装命令时，默认安装到 `~/.local/bin`。
+脚本会优先安装到当前 `gale-harness` 所在目录，并移除旧的 `bun link` symlink 后写入编译二进制。没有已安装命令时，默认安装到 `~/.local/bin`。Release assets 覆盖 macOS、Linux、Windows 的 arm64/x64 平台。
 
 #### macOS / Linux
 

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -32,6 +32,8 @@ detect_platform() {
     Darwin:x86_64) echo "darwin-x64" ;;
     Linux:x86_64) echo "linux-x64" ;;
     Linux:aarch64 | Linux:arm64) echo "linux-arm64" ;;
+    MINGW*:x86_64 | MSYS*:x86_64 | CYGWIN*:x86_64) echo "windows-x64" ;;
+    MINGW*:aarch64 | MINGW*:arm64 | MSYS*:aarch64 | MSYS*:arm64 | CYGWIN*:aarch64 | CYGWIN*:arm64) echo "windows-arm64" ;;
     *)
       err "unsupported platform: $os $arch"
       exit 1
@@ -85,6 +87,10 @@ fi
 
 version="${tag#$TAG_PREFIX}"
 platform="$(detect_platform)"
+exe=""
+if [[ "$platform" == windows-* ]]; then
+  exe=".exe"
+fi
 asset="galeharness-cli-$version-$platform.tar.gz"
 url="https://github.com/$REPO/releases/download/$tag/$asset"
 tmpdir="$(mktemp -d -t galeharness-install-XXXXXX)"
@@ -102,21 +108,17 @@ curl -fL "$url" -o "$tmpdir/$asset"
 tar -xzf "$tmpdir/$asset" -C "$tmpdir"
 
 mkdir -p "$install_dir"
-for bin in gale-harness compound-plugin gale-knowledge; do
-  dest="$install_dir/$bin"
+for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
+  src="$tmpdir/$bin$exe"
+  if [ ! -f "$src" ]; then
+    continue
+  fi
+  dest="$install_dir/$bin$exe"
   if [ -L "$dest" ]; then
     rm "$dest"
   fi
-  install -m 0755 "$tmpdir/$bin" "$dest"
+  install -m 0755 "$src" "$dest"
 done
-
-if [ -f "$tmpdir/gale-memory" ]; then
-  dest="$install_dir/gale-memory"
-  if [ -L "$dest" ]; then
-    rm "$dest"
-  fi
-  install -m 0755 "$tmpdir/gale-memory" "$dest"
-fi
 
 install -m 0644 "$tmpdir/VERSION" "$install_dir/VERSION"
 

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -13,11 +13,17 @@
  *   Prints the tar.gz file path to stdout (for CI consumption).
  */
 
-import { execSync } from "node:child_process"
+import { execFileSync } from "node:child_process"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import {
+  RELEASE_BINARY_BASENAMES,
+  detectReleasePlatform,
+  getReleaseBinaryFileName,
+  getReleasePlatformConfig,
+} from "../../src/utils/release-platforms"
 
 // ── Parse CLI args ──────────────────────────────────────────────────────────
 
@@ -41,29 +47,12 @@ const repoRoot = path.resolve(__dirname, "../..")
 const packageJsonPath = path.join(repoRoot, "package.json")
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"))
 const version = parsed.version || packageJson.version
-function detectPlatform(): string {
-  const platform = os.platform()
-  const arch = os.arch()
-  const platformMap: Record<string, Record<string, string>> = {
-    darwin: { arm64: "darwin-arm64", x64: "darwin-x64" },
-    linux: { x64: "linux-x64", arm64: "linux-arm64" },
-    win32: { x64: "windows-x64" },
-  }
-  return platformMap[platform]?.[arch] || `${platform}-${arch}`
-}
-
-const platform = parsed.platform || detectPlatform()
-const bunTargetByPlatform: Record<string, string> = {
-  "darwin-arm64": "bun-darwin-arm64",
-  "darwin-x64": "bun-darwin-x64",
-  "linux-arm64": "bun-linux-arm64",
-  "linux-x64": "bun-linux-x64",
-}
-const bunTarget = bunTargetByPlatform[platform] || "bun"
+const platform = parsed.platform || detectReleasePlatform()
+const platformConfig = getReleasePlatformConfig(platform)
 
 // ── Build ───────────────────────────────────────────────────────────────────
 
-const buildDir = path.join(os.tmpdir(), `galeharness-build-${version}`)
+const buildDir = path.join(os.tmpdir(), `galeharness-build-${version}-${platform}`)
 const archiveName = `galeharness-cli-${version}-${platform}.tar.gz`
 const archivePath = path.join(repoRoot, archiveName)
 
@@ -77,35 +66,66 @@ if (fs.existsSync(archivePath)) {
   fs.unlinkSync(archivePath)
 }
 
-console.error(`[build] Compiling binaries (v${version}, ${platform}, target ${bunTarget})...`)
+console.error(`[build] Compiling binaries (v${version}, ${platform}, target ${platformConfig.bunTarget})...`)
 
 // 1. Compile gale-harness (src/index.ts)
-execSync(`bun build --compile src/index.ts --outfile ${path.join(buildDir, "gale-harness")} --target ${bunTarget}`, {
-  cwd: repoRoot,
-  stdio: "inherit",
-})
-
-// 2. Copy as compound-plugin (same entry point, different binary name)
-fs.copyFileSync(
-  path.join(buildDir, "gale-harness"),
-  path.join(buildDir, "compound-plugin"),
-)
-
-// 3. Compile gale-knowledge (cmd/gale-knowledge/index.ts)
-execSync(
-  `bun build --compile cmd/gale-knowledge/index.ts --outfile ${path.join(buildDir, "gale-knowledge")} --target ${bunTarget}`,
+const galeHarnessBinary = getReleaseBinaryFileName("gale-harness", platform)
+execFileSync(
+  "bun",
+  [
+    "build",
+    "--compile",
+    "src/index.ts",
+    "--outfile",
+    path.join(buildDir, galeHarnessBinary),
+    "--target",
+    platformConfig.bunTarget,
+  ],
   {
     cwd: repoRoot,
     stdio: "inherit",
   },
 )
 
+// 2. Copy as compound-plugin (same entry point, different binary name)
+fs.copyFileSync(
+  path.join(buildDir, galeHarnessBinary),
+  path.join(buildDir, getReleaseBinaryFileName("compound-plugin", platform)),
+)
+
+// 3. Compile auxiliary CLIs.
+for (const [basename, entrypoint] of [
+  ["gale-knowledge", "cmd/gale-knowledge/index.ts"],
+  ["gale-memory", "cmd/gale-memory/index.ts"],
+] as const) {
+  execFileSync(
+    "bun",
+    [
+      "build",
+      "--compile",
+      entrypoint,
+      "--outfile",
+      path.join(buildDir, getReleaseBinaryFileName(basename, platform)),
+      "--target",
+      platformConfig.bunTarget,
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+    },
+  )
+}
+
 // 4. Write VERSION file
 fs.writeFileSync(path.join(buildDir, "VERSION"), `${version}\n`, "utf-8")
 
 // 5. Package into tar.gz
 console.error(`[build] Packaging ${archiveName}...`)
-execSync(`tar -czf ${archivePath} -C ${buildDir} gale-harness compound-plugin gale-knowledge VERSION`, {
+const archiveFiles = [
+  ...RELEASE_BINARY_BASENAMES.map((basename) => getReleaseBinaryFileName(basename, platform)),
+  "VERSION",
+]
+execFileSync("tar", ["-czf", archivePath, "-C", buildDir, ...archiveFiles], {
   cwd: repoRoot,
   stdio: "inherit",
 })

--- a/src/utils/release-platforms.ts
+++ b/src/utils/release-platforms.ts
@@ -1,0 +1,99 @@
+import os from "node:os"
+
+export const RELEASE_BINARY_BASENAMES = [
+  "gale-harness",
+  "compound-plugin",
+  "gale-knowledge",
+  "gale-memory",
+] as const
+
+export type ReleaseBinaryBaseName = (typeof RELEASE_BINARY_BASENAMES)[number]
+
+export const RELEASE_PLATFORMS = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64",
+  "linux-x64",
+  "windows-arm64",
+  "windows-x64",
+] as const
+
+export type ReleasePlatform = (typeof RELEASE_PLATFORMS)[number]
+
+export interface ReleasePlatformConfig {
+  platform: ReleasePlatform
+  bunTarget: string
+  executableExtension: "" | ".exe"
+}
+
+const RELEASE_PLATFORM_CONFIGS: Record<ReleasePlatform, ReleasePlatformConfig> = {
+  "darwin-arm64": {
+    platform: "darwin-arm64",
+    bunTarget: "bun-darwin-arm64",
+    executableExtension: "",
+  },
+  "darwin-x64": {
+    platform: "darwin-x64",
+    bunTarget: "bun-darwin-x64",
+    executableExtension: "",
+  },
+  "linux-arm64": {
+    platform: "linux-arm64",
+    bunTarget: "bun-linux-arm64",
+    executableExtension: "",
+  },
+  "linux-x64": {
+    platform: "linux-x64",
+    bunTarget: "bun-linux-x64",
+    executableExtension: "",
+  },
+  "windows-arm64": {
+    platform: "windows-arm64",
+    bunTarget: "bun-windows-arm64",
+    executableExtension: ".exe",
+  },
+  "windows-x64": {
+    platform: "windows-x64",
+    bunTarget: "bun-windows-x64",
+    executableExtension: ".exe",
+  },
+}
+
+export function getReleasePlatformConfig(platform: string): ReleasePlatformConfig {
+  if (isReleasePlatform(platform)) {
+    return RELEASE_PLATFORM_CONFIGS[platform]
+  }
+
+  throw new Error(
+    `Unsupported release platform '${platform}'. Supported platforms: ${RELEASE_PLATFORMS.join(", ")}`,
+  )
+}
+
+export function isReleasePlatform(platform: string): platform is ReleasePlatform {
+  return (RELEASE_PLATFORMS as readonly string[]).includes(platform)
+}
+
+export function detectReleasePlatform(
+  platform: NodeJS.Platform = os.platform(),
+  arch: string = os.arch(),
+): ReleasePlatform {
+  if (platform === "darwin" && arch === "arm64") return "darwin-arm64"
+  if (platform === "darwin" && arch === "x64") return "darwin-x64"
+  if (platform === "linux" && arch === "arm64") return "linux-arm64"
+  if (platform === "linux" && arch === "x64") return "linux-x64"
+  if (platform === "win32" && arch === "arm64") return "windows-arm64"
+  if (platform === "win32" && arch === "x64") return "windows-x64"
+
+  throw new Error(`Unsupported platform: ${platform} ${arch}`)
+}
+
+export function getReleaseBinaryFileName(
+  basename: ReleaseBinaryBaseName,
+  platform: string,
+): string {
+  return `${basename}${getReleasePlatformConfig(platform).executableExtension}`
+}
+
+export function getReleaseBinaryFileNames(platform: string): string[] {
+  return RELEASE_BINARY_BASENAMES.map((basename) => getReleaseBinaryFileName(basename, platform))
+}

--- a/src/utils/update.ts
+++ b/src/utils/update.ts
@@ -15,10 +15,14 @@ import os from "node:os"
 import path from "node:path"
 import { execSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
+import {
+  RELEASE_BINARY_BASENAMES,
+  detectReleasePlatform,
+  getReleaseBinaryFileNames,
+} from "./release-platforms"
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
-const BINARY_NAMES = ["gale-harness", "compound-plugin", "gale-knowledge"] as const
 const TAG_PREFIX = "galeharness-cli-v"
 const DEFAULT_REPO = "wangrenzhu-ola/GaleHarnessCodingCLI"
 const BACKUP_DIR = path.join(os.homedir(), ".galeharness", "backup")
@@ -38,6 +42,13 @@ export interface UpdateResult {
   message: string
   previousVersion?: string
   newVersion?: string
+}
+
+interface GitHubRelease {
+  tag_name: string
+  draft?: boolean
+  prerelease?: boolean
+  assets: Array<{ name: string; browser_download_url: string; size: number }>
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -106,14 +117,15 @@ export function isCompiledBinary(): boolean {
   if (!execPath) return false
   // If the executable name is one of our binaries, we're in compiled mode
   const basename = path.basename(execPath)
-  return BINARY_NAMES.includes(basename as any) || basename === "gale-harness" || basename === "compound-plugin" || basename === "gale-knowledge"
+  const normalizedBasename = basename.endsWith(".exe") ? basename.slice(0, -4) : basename
+  return RELEASE_BINARY_BASENAMES.includes(normalizedBasename as any)
 }
 
 /**
  * Query GitHub Release API for the latest version matching our tag prefix.
  */
 export async function getLatestVersion(repo: string): Promise<{ version: string; assetUrl: string; assetName: string }> {
-  const url = `https://api.github.com/repos/${repo}/releases/latest`
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=20`
   const response = await fetch(url, {
     headers: {
       "User-Agent": "gale-harness-update",
@@ -128,14 +140,16 @@ export async function getLatestVersion(repo: string): Promise<{ version: string;
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`)
   }
 
-  const release = (await response.json()) as {
-    tag_name: string
-    assets: Array<{ name: string; browser_download_url: string; size: number }>
-  }
+  const releases = (await response.json()) as GitHubRelease[]
+  const release = releases.find(
+    (candidate) =>
+      !candidate.draft &&
+      !candidate.prerelease &&
+      candidate.tag_name.startsWith(TAG_PREFIX),
+  )
 
-  // Verify tag prefix
-  if (!release.tag_name.startsWith(TAG_PREFIX)) {
-    throw new Error(`Latest release tag '${release.tag_name}' does not match expected prefix '${TAG_PREFIX}'.`)
+  if (!release) {
+    throw new Error(`No releases found for ${repo} with tag prefix '${TAG_PREFIX}'.`)
   }
 
   const version = release.tag_name.slice(TAG_PREFIX.length)
@@ -163,14 +177,7 @@ export async function getLatestVersion(repo: string): Promise<{ version: string;
  * Detect the current platform suffix for asset selection.
  */
 export function detectPlatform(): string {
-  const platform = os.platform()
-  const arch = os.arch()
-  const platformMap: Record<string, Record<string, string>> = {
-    darwin: { arm64: "darwin-arm64", x64: "darwin-x64" },
-    linux: { x64: "linux-x64", arm64: "linux-arm64" },
-    win32: { x64: "windows-x64" },
-  }
-  return platformMap[platform]?.[arch] || `${platform}-${arch}`
+  return detectReleasePlatform()
 }
 
 // ── Check ───────────────────────────────────────────────────────────────────
@@ -236,7 +243,7 @@ export async function performUpdate(): Promise<UpdateResult> {
     execSync(`tar -xzf ${archivePath} -C ${extractDir}`, { stdio: "pipe" })
 
     // Verify extracted files
-    for (const name of BINARY_NAMES) {
+    for (const name of getReleaseBinaryFileNames(detectPlatform())) {
       const extracted = path.join(extractDir, name)
       if (!fs.existsSync(extracted)) {
         throw new Error(`Expected binary '${name}' not found in archive.`)
@@ -306,7 +313,7 @@ async function backupBinaries(binDir: string, version: string): Promise<void> {
   const versionBackupDir = path.join(BACKUP_DIR, version)
   fs.mkdirSync(versionBackupDir, { recursive: true })
 
-  for (const name of BINARY_NAMES) {
+  for (const name of getReleaseBinaryFileNames(detectPlatform())) {
     const src = path.join(binDir, name)
     if (fs.existsSync(src)) {
       await fs.promises.copyFile(src, path.join(versionBackupDir, name))
@@ -324,7 +331,7 @@ async function backupBinaries(binDir: string, version: string): Promise<void> {
  * Replace binaries in the install directory with new ones from extractDir.
  */
 async function replaceBinaries(binDir: string, extractDir: string): Promise<void> {
-  for (const name of BINARY_NAMES) {
+  for (const name of getReleaseBinaryFileNames(detectPlatform())) {
     const src = path.join(extractDir, name)
     const dest = path.join(binDir, name)
     await fs.promises.copyFile(src, dest)
@@ -384,7 +391,7 @@ async function rollbackBinaries(binDir: string, version: string): Promise<Update
     }
   }
 
-  for (const name of BINARY_NAMES) {
+  for (const name of getReleaseBinaryFileNames(detectPlatform())) {
     const src = path.join(backupVersionDir, name)
     const dest = path.join(binDir, name)
     if (fs.existsSync(src)) {

--- a/tests/update-command.test.ts
+++ b/tests/update-command.test.ts
@@ -7,11 +7,18 @@ import {
   getCurrentVersion,
   detectPlatform,
   detectBinDir,
+  getLatestVersion,
   isCompiledBinary,
   checkForUpdate,
   performUpdate,
   performRollback,
 } from "../src/utils/update"
+import {
+  RELEASE_PLATFORMS,
+  detectReleasePlatform,
+  getReleaseBinaryFileName,
+  getReleaseBinaryFileNames,
+} from "../src/utils/release-platforms"
 
 // ── Unit tests (pure logic) ─────────────────────────────────────────────────
 
@@ -73,6 +80,110 @@ describe("update utils", () => {
       if (process.platform === "darwin" && process.arch === "arm64") {
         expect(platform).toBe("darwin-arm64")
       }
+    })
+  })
+
+  describe("release platform metadata", () => {
+    test("includes macOS, Linux, and Windows release platforms", () => {
+      expect(RELEASE_PLATFORMS).toEqual([
+        "darwin-arm64",
+        "darwin-x64",
+        "linux-arm64",
+        "linux-x64",
+        "windows-arm64",
+        "windows-x64",
+      ])
+    })
+
+    test("maps Node platform and arch values to release platform names", () => {
+      expect(detectReleasePlatform("darwin", "arm64")).toBe("darwin-arm64")
+      expect(detectReleasePlatform("darwin", "x64")).toBe("darwin-x64")
+      expect(detectReleasePlatform("linux", "arm64")).toBe("linux-arm64")
+      expect(detectReleasePlatform("linux", "x64")).toBe("linux-x64")
+      expect(detectReleasePlatform("win32", "arm64")).toBe("windows-arm64")
+      expect(detectReleasePlatform("win32", "x64")).toBe("windows-x64")
+    })
+
+    test("uses .exe binary names for Windows release archives", () => {
+      expect(getReleaseBinaryFileName("gale-harness", "windows-x64")).toBe("gale-harness.exe")
+      expect(getReleaseBinaryFileNames("windows-arm64")).toEqual([
+        "gale-harness.exe",
+        "compound-plugin.exe",
+        "gale-knowledge.exe",
+        "gale-memory.exe",
+      ])
+    })
+  })
+
+  describe("getLatestVersion", () => {
+    const originalFetch = globalThis.fetch
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    test("selects the latest galeharness-cli release instead of sibling release components", async () => {
+      const platform = detectPlatform()
+      const assetName = `galeharness-cli-2.4.0-${platform}.tar.gz`
+      globalThis.fetch = mock(async () =>
+        new Response(
+          JSON.stringify([
+            {
+              tag_name: "cli-v2.4.0",
+              draft: false,
+              prerelease: false,
+              assets: [],
+            },
+            {
+              tag_name: "galeharness-cli-v2.4.0",
+              draft: false,
+              prerelease: false,
+              assets: [
+                {
+                  name: assetName,
+                  browser_download_url: "https://example.test/download",
+                  size: 123,
+                },
+              ],
+            },
+          ]),
+          { status: 200 },
+        ),
+      ) as typeof fetch
+
+      const latest = await getLatestVersion("owner/repo")
+
+      expect(latest).toEqual({
+        version: "2.4.0",
+        assetName,
+        assetUrl: "https://example.test/download",
+      })
+    })
+
+    test("reports available assets when the matching release lacks this platform", async () => {
+      const otherPlatform = detectPlatform() === "linux-x64" ? "darwin-arm64" : "linux-x64"
+      const otherAsset = `galeharness-cli-2.4.0-${otherPlatform}.tar.gz`
+      globalThis.fetch = mock(async () =>
+        new Response(
+          JSON.stringify([
+            {
+              tag_name: "galeharness-cli-v2.4.0",
+              draft: false,
+              prerelease: false,
+              assets: [
+                {
+                  name: otherAsset,
+                  browser_download_url: "https://example.test/linux",
+                  size: 123,
+                },
+              ],
+            },
+          ]),
+          { status: 200 },
+        ),
+      ) as typeof fetch
+
+      await expect(getLatestVersion("owner/repo")).rejects.toThrow(`Available assets: ${otherAsset}`)
     })
   })
 


### PR DESCRIPTION
## 摘要

- 新增统一的 release 平台元数据，覆盖 macOS、Linux、Windows 的 arm64/x64
- release 构建脚本按平台选择 Bun compile target，并生成对应平台归档
- release 归档包含 `gale-harness`、`compound-plugin`、`gale-knowledge`、`gale-memory` 和 `VERSION`
- Windows 归档内使用 `.exe` 二进制文件名
- `Release Assets` workflow 改为先确认本次 workflow 对应真实 release commit，再启动 6 平台上传矩阵，避免普通 main push 重打最新 release asset
- `install-release.sh` 和 `gale-harness update` 的平台检测、asset 选择、二进制文件名逻辑保持一致

## 验证

- `bun test tests/update-command.test.ts`
- `bun test`
- `bun run release:validate`
- `bash -n scripts/install-release.sh`
- 使用 `js-yaml` 解析 `.github/workflows/release-assets.yml`
- `bun run scripts/release/build.ts --version 0.0.0-test --platform darwin-arm64`
- `bun run scripts/release/build.ts --version 0.0.0-test --platform linux-x64`
- `bun run scripts/release/build.ts --version 0.0.0-test --platform windows-x64`

## 说明

全量 `git diff --check` 仍会报告本地 memory 文件里的既有空白问题；本 PR 涉及文件的 diff check 已通过。