### PR TITLE
feat(memory): 迁移 Gale-managed HKTMemory 到公共知识库

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,9 +483,34 @@ uv --version                     # 期望: uv x.x.x
 gale-harness --help              # 期望: 显示 CLI 帮助
 gale-knowledge init              # 初始化知识仓库
 gale-knowledge resolve-home      # 期望: ~/.galeharness/knowledge/
-hkt-memory stats                   # 期望: 统计信息
+gale-memory status               # 期望: 显示 Gale-managed HKTMemory 路径和迁移状态
+hkt-memory stats                 # 期望: 统计信息（裸命令使用自身默认路径）
 bun test                         # 期望: 测试通过
 ```
+
+---
+
+### Gale-managed HKTMemory 记忆根目录
+
+通过 GaleHarness 入口使用的 HKTMemory 默认写入公共知识库：
+
+```text
+~/.galeharness/knowledge/<project>/hkt-memory
+```
+
+`gale-memory` 是统一入口。`start`、`capture`、`feedback`、`status` 和 `migrate` 会解析同一个 root，并在首次发现项目本地 `memory/` 时执行 copy-first 迁移：Markdown 记忆和必要 manifest 会复制到公共知识库，`.db`、vector cache、session transcript index、`_lifecycle/events.jsonl` 等派生缓存不会复制，本地 `memory/` 保留为 legacy backup。
+
+覆盖优先级为：`gale-memory --memory-dir` -> 已有 `HKT_MEMORY_DIR` -> `~/.galeharness/config.{json,yaml}` 中的 `memory.hkt_memory_dir` -> 默认公共知识库 root。裸 `hkt-memory` 命令仍保留上游默认语义，通常会使用当前目录下的 `memory/`；需要进入公共知识库时请显式设置 `HKT_MEMORY_DIR` 或使用 `gale-memory`。
+
+常用诊断：
+
+```bash
+gale-memory status --json
+gale-memory migrate --cwd /path/to/project
+gale-memory resolve-root
+```
+
+状态可能为 `global`、`legacy-local`、`migration-needed`、`migrated`、`migration-conflict` 或 `unavailable`。冲突迁移不会覆盖目标文件，会在全局 root 写入 `MIGRATION_CONFLICTS.md`。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ uv --version                     # 期望: uv x.x.x
 gale-harness --help              # 期望: 显示 CLI 帮助
 gale-knowledge init              # 初始化知识仓库
 gale-knowledge resolve-home      # 期望: ~/.galeharness/knowledge/
-gale-memory status               # 期望: 显示 Gale-managed HKTMemory 路径和迁移状态
+gale-memory status               # 期望: 诊断 Gale-managed HKTMemory 路径和迁移状态
 hkt-memory stats                 # 期望: 统计信息（裸命令使用自身默认路径）
 bun test                         # 期望: 测试通过
 ```
@@ -498,7 +498,7 @@ bun test                         # 期望: 测试通过
 ~/.galeharness/knowledge/<project>/hkt-memory
 ```
 
-`gale-memory` 是统一入口。`start`、`capture`、`feedback`、`status` 和 `migrate` 会解析同一个 root，并在首次发现项目本地 `memory/` 时执行 copy-first 迁移：Markdown 记忆和必要 manifest 会复制到公共知识库，`.db`、vector cache、session transcript index、`_lifecycle/events.jsonl` 等派生缓存不会复制，本地 `memory/` 保留为 legacy backup。
+`gale-memory` 是统一入口。`start`、`capture`、`feedback` 和 `migrate` 会解析同一个 root；`migrate` 或 task runtime 在首次发现项目本地 `memory/` 时执行 copy-first 迁移。`status` 只诊断 root 和迁移状态，不复制 legacy 文件。迁移时 Markdown 记忆和必要 manifest 会复制到公共知识库，`.db`、vector cache、session transcript index、`_lifecycle/events.jsonl` 等派生缓存不会复制，本地 `memory/` 保留为 legacy backup。
 
 覆盖优先级为：`gale-memory --memory-dir` -> 已有 `HKT_MEMORY_DIR` -> `~/.galeharness/config.{json,yaml}` 中的 `memory.hkt_memory_dir` -> 默认公共知识库 root。裸 `hkt-memory` 命令仍保留上游默认语义，通常会使用当前目录下的 `memory/`；需要进入公共知识库时请显式设置 `HKT_MEMORY_DIR` 或使用 `gale-memory`。
 

--- a/cmd/gale-knowledge/init.ts
+++ b/cmd/gale-knowledge/init.ts
@@ -20,6 +20,8 @@ import { resolveKnowledgeHome } from "../../src/knowledge/home.js"
 const GITIGNORE_CONTENT = `*.db
 *.db-shm
 *.db-wal
+*.json
+!.gale-migration-manifest.json
 vector_store/
 vector_store.db
 bm25_index.db

--- a/cmd/gale-knowledge/init.ts
+++ b/cmd/gale-knowledge/init.ts
@@ -9,7 +9,7 @@
 
 import { defineCommand } from "citty"
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { resolveKnowledgeHome } from "../../src/knowledge/home.js"
 
@@ -18,8 +18,20 @@ import { resolveKnowledgeHome } from "../../src/knowledge/home.js"
 // ---------------------------------------------------------------------------
 
 const GITIGNORE_CONTENT = `*.db
+*.db-shm
+*.db-wal
+vector_store/
+vector_store.db
+bm25_index.db
+entity_index.db
+session_transcript_index.db
 vector-index/
 .last-rebuild-commit
+_lifecycle/events.jsonl
+.cache/
+cache/
+tmp/
+temp/
 `
 
 // ---------------------------------------------------------------------------
@@ -35,6 +47,7 @@ export function initKnowledgeRepo(home: string): boolean {
   const gitDir = join(home, ".git")
 
   if (existsSync(gitDir)) {
+    ensureGitignoreRules(home)
     return false
   }
 
@@ -51,7 +64,7 @@ export function initKnowledgeRepo(home: string): boolean {
   }
 
   // 写入 .gitignore
-  writeFileSync(join(home, ".gitignore"), GITIGNORE_CONTENT, "utf8")
+  ensureGitignoreRules(home)
 
   // 配置本地 git 用户身份（CI 环境可能无全局配置）
   const emailResult = spawnSync("git", ["config", "user.email", "gale-knowledge@local"], { cwd: home, stdio: ["ignore", "ignore", "pipe"], timeout: 15000 })
@@ -74,6 +87,16 @@ export function initKnowledgeRepo(home: string): boolean {
   }
 
   return true
+}
+
+export function ensureGitignoreRules(home: string): void {
+  const gitignore = join(home, ".gitignore")
+  const existing = existsSync(gitignore) ? readFileSync(gitignore, "utf8") : ""
+  const lines = new Set(existing.split(/\r?\n/).filter(Boolean))
+  for (const line of GITIGNORE_CONTENT.split(/\r?\n/).filter(Boolean)) {
+    lines.add(line)
+  }
+  writeFileSync(gitignore, Array.from(lines).join("\n") + "\n", "utf8")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/gale-knowledge/rebuild-index.ts
+++ b/cmd/gale-knowledge/rebuild-index.ts
@@ -18,6 +18,7 @@ import {
 import { join, relative } from "node:path"
 import { tmpdir } from "node:os"
 import { resolveKnowledgeHome } from "../../src/knowledge/home.js"
+import { ensurePublicMemoryRoot, resolveKnowledgeIndexMemoryRoot } from "../../src/memory/public-root.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,6 +29,7 @@ export interface RebuildIndexOptions {
   full?: boolean
   /** 知识仓库路径 */
   knowledgeHome?: string
+  indexMemoryDir?: string
 }
 
 export interface RebuildIndexResult {
@@ -39,6 +41,7 @@ export interface RebuildIndexResult {
   errors: number
   /** 模式 */
   mode: "full" | "incremental"
+  indexMemoryDir: string
 }
 
 // ---------------------------------------------------------------------------
@@ -175,6 +178,7 @@ function storeToHktMemory(
   filePath: string,
   content: string,
   title: string,
+  indexMemoryDir: string,
 ): boolean {
   // 将内容写入临时文件
   const tmpFile = join(
@@ -203,7 +207,7 @@ function storeToHktMemory(
       {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 30000,
-        env: { ...process.env },
+        env: { ...process.env, HKT_MEMORY_DIR: indexMemoryDir },
       },
     )
 
@@ -227,7 +231,7 @@ function storeToHktMemory(
           input: content,
           stdio: ["pipe", "pipe", "pipe"],
           timeout: 30000,
-          env: { ...process.env },
+          env: { ...process.env, HKT_MEMORY_DIR: indexMemoryDir },
         },
       )
       return result2.status === 0
@@ -269,6 +273,8 @@ export function saveLastRebuildCommit(
  */
 export function rebuildIndex(options?: RebuildIndexOptions): RebuildIndexResult {
   const knowledgeHome = options?.knowledgeHome ?? resolveKnowledgeHome()
+  const indexMemoryDir = options?.indexMemoryDir ?? resolveKnowledgeIndexMemoryRoot()
+  ensurePublicMemoryRoot(indexMemoryDir)
   const full = options?.full ?? false
 
   // Determine mode and files to process first (before checking uv availability)
@@ -339,7 +345,7 @@ export function rebuildIndex(options?: RebuildIndexOptions): RebuildIndexResult 
         const content = readFileSync(fullPath, "utf8")
         const title = file // Use relative path as title
 
-        const success = storeToHktMemory(scriptPath!, file, content, title)
+        const success = storeToHktMemory(scriptPath!, file, content, title, indexMemoryDir)
         if (success) {
           processed++
         } else {
@@ -372,6 +378,7 @@ export function rebuildIndex(options?: RebuildIndexOptions): RebuildIndexResult 
     skipped: totalFiles - processed - errors,
     errors,
     mode,
+    indexMemoryDir,
   }
 }
 
@@ -397,6 +404,7 @@ const rebuildIndexCommand = defineCommand({
 
       process.stdout.write(
         `[gale-knowledge] rebuild-index complete (${result.mode} mode)\n` +
+        `  Index root: ${result.indexMemoryDir}\n` +
         `  Processed: ${result.processed}\n` +
         `  Skipped:   ${result.skipped}\n` +
         `  Errors:    ${result.errors}\n`,

--- a/cmd/gale-memory/index.ts
+++ b/cmd/gale-memory/index.ts
@@ -6,6 +6,8 @@ import {
   startTaskMemory,
 } from "../../src/memory/task-runtime.js"
 import { skippedResult } from "../../src/memory/hkt-client.js"
+import { migrateLegacyMemory, migrationStatus } from "../../src/memory/migration.js"
+import { ensurePublicMemoryRoot, resolvePublicMemoryRoot } from "../../src/memory/public-root.js"
 
 function parseFlags(argv: string[]): Record<string, string> {
   const flags: Record<string, string> = {}
@@ -57,12 +59,47 @@ async function main(): Promise<void> {
     project: flags.project,
     branch: flags.branch,
     taskId: flags["task-id"],
+    memoryDir: flags["memory-dir"],
   }
 
   try {
     if (command === "start") {
       const result = await startTaskMemory({ ...common, phase: flags.phase ?? "start" })
       process.stdout.write(JSON.stringify(result, null, 2) + "\n")
+      return
+    }
+
+    if (command === "resolve-root") {
+      const root = resolvePublicMemoryRoot({ cwd, project: flags.project, memoryDir: flags["memory-dir"] })
+      if (flags.json === "true") {
+        process.stdout.write(JSON.stringify(root, null, 2) + "\n")
+      } else {
+        process.stdout.write(`${root.memoryDir}\n`)
+      }
+      return
+    }
+
+    if (command === "status") {
+      const root = resolvePublicMemoryRoot({ cwd, project: flags.project, memoryDir: flags["memory-dir"] })
+      ensurePublicMemoryRoot(root.memoryDir)
+      const status = migrationStatus(cwd, root.memoryDir)
+      const result = {
+        success: true,
+        status,
+        project: root.project,
+        memory_dir: root.memoryDir,
+        source: root.source,
+        knowledge_home: root.knowledgeHome,
+        diagnostics: root.diagnostics,
+      }
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n")
+      return
+    }
+
+    if (command === "migrate") {
+      const root = resolvePublicMemoryRoot({ cwd, project: flags.project, memoryDir: flags["memory-dir"] })
+      const migration = migrateLegacyMemory({ cwd, targetDir: root.memoryDir })
+      process.stdout.write(JSON.stringify({ success: migration.status !== "failed", ...root, migration }, null, 2) + "\n")
       return
     }
 
@@ -90,7 +127,15 @@ async function main(): Promise<void> {
       return
     }
 
-    process.stdout.write(JSON.stringify(skippedResult("Usage: gale-memory <start|capture|feedback> [flags]")) + "\n")
+    if (!command || command === "--help" || command === "-h") {
+      process.stdout.write(
+        "Usage: gale-memory <start|capture|feedback|status|resolve-root|migrate> [flags]\n" +
+        "Flags: --cwd <path> --project <name> --memory-dir <path> --json\n",
+      )
+      return
+    }
+
+    process.stdout.write(JSON.stringify(skippedResult("Usage: gale-memory <start|capture|feedback|status|resolve-root|migrate> [flags]")) + "\n")
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     process.stdout.write(JSON.stringify(skippedResult(message)) + "\n")

--- a/docs/brainstorms/2026-04-24-hktmemory-public-knowledge-migration-requirements.md
+++ b/docs/brainstorms/2026-04-24-hktmemory-public-knowledge-migration-requirements.md
@@ -1,0 +1,173 @@
+---
+date: 2026-04-24
+topic: hktmemory-public-knowledge-migration
+title: HKTMemory Public Knowledge Migration Requirements
+category: brainstorm
+project: GaleHarnessCodingCLI
+---
+
+# HKTMemory Public Knowledge Migration Requirements
+
+## Problem Frame
+
+GaleHarness 已经有全局公共知识库 `~/.galeharness/knowledge/<project>/...`，`gh:brainstorm`、`gh:plan`、`gh:compound` 等技能产出的 durable 文档会优先写入这里，并由 `gale-knowledge` 管理路径、提交和索引。与此同时，HKTMemory 的分层记忆默认仍落在项目仓库自己的 `memory/` 目录，例如 `memory/L0-Abstract`、`memory/L1-Overview`、`memory/L2-Full`，并混合了 Markdown 记忆、生命周期文件和本地数据库缓存。
+
+这造成两个割裂：用户通过 GaleHarness 安装和使用工作流后，公共知识文档进入全局知识库，但 HKTMemory 记忆仍留在单个项目目录；跨项目、换机器或清理项目仓库时，HKTMemory 的高价值记忆不能自然进入 GaleHarness 的公共知识体系。目标不是重写 HKTMemory，而是让 Gale-managed 使用路径把 HKTMemory 的记忆根目录迁移或同步到公共知识库下，使用户默认获得统一、可迁移、可审计的知识存储。
+
+---
+
+## Actors
+
+- A1. GaleHarness 用户：通过 release binary、source setup 或 GaleHarness 技能使用 HKTMemory，希望无需手工管理多个记忆位置。
+- A2. GaleHarness 安装/运行脚本：负责初始化 `gale-knowledge`、`gale-memory`、HKTMemory CLI/env，并在安全时触发迁移。
+- A3. Gale memory runtime：通过 `gale-memory`、技能模板或后续 runtime contract 调用 HKTMemory，需要稳定的 per-project memory root。
+- A4. HKTMemory CLI/runtime：继续负责 L0/L1/L2、ledger、vector store、session search、安全门禁和 task memory primitives。
+- A5. 公共知识库维护者：需要知道哪些内容会进入 `~/.galeharness/knowledge`、哪些是 git source of truth、哪些只是本地派生缓存。
+
+---
+
+## Approach Options
+
+| Option | Description | Pros | Cons | Decision |
+| --- | --- | --- | --- | --- |
+| A. 全局 re-home 作为 Gale-managed 默认 | GaleHarness 调用 HKTMemory 时默认把 `HKT_MEMORY_DIR` 指向 `~/.galeharness/knowledge/<project>/hkt-memory`，首次发现项目 `memory/` 时复制迁移，后续以全局路径为主。 | 与公共知识库统一；最少同步状态；利用 HKTMemory 已有 `--memory-dir`/`HKT_MEMORY_DIR`；项目仓库更干净。 | 需要处理已有本地 memory、bare `hkt-memory` 调用兼容和 git 忽略规则。 | 推荐采用。 |
+| B. 双写/镜像同步 | 保持项目 `memory/` 为主，同时把 Markdown 记忆镜像到公共知识库。 | 对现有裸 HKTMemory 行为影响最小。 | 双源一致性复杂；冲突、删除、重命名难处理；容易重复索引。 | 不作为默认。 |
+| C. 只索引不迁移文件 | 不移动 HKTMemory 文件，只把项目 `memory/` 内容 ingest 到公共知识索引。 | 改动小；适合临时兼容。 | source of truth 仍分散；换机器和 git 同步问题没有解决。 | 只作为过渡或 recovery 工具。 |
+
+推荐方案是 **Option A：Gale-managed 全局 re-home + 安全的一次性复制迁移**。它把公共知识库作为 GaleHarness 使用场景下的默认 source of truth，同时保留本地项目 `memory/` 的只读兼容和手动 recovery 路径，避免长期维护双写同步。
+
+---
+
+## Key Flows
+
+- F1. 新用户通过 GaleHarness 安装后首次使用 HKTMemory
+  - **Trigger:** 用户安装 release binary 或运行 source setup 后，首次执行 `gh:*` 技能、`gale-memory start/capture` 或 Gale-managed HKTMemory 命令。
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** 安装或运行入口初始化 `~/.galeharness/knowledge`；解析当前项目名；为 HKTMemory 解析全局 memory root；调用 HKTMemory 时注入 `HKT_MEMORY_DIR` 或等价 `--memory-dir`；目标目录不存在时创建标准 L0/L1/L2 结构。
+  - **Outcome:** 新记忆默认写入 `~/.galeharness/knowledge/<project>/hkt-memory/...`，项目仓库不再因为 Gale-managed 使用产生新的 `memory/` 目录。
+  - **Covered by:** R1, R2, R3, R5, R6, R11
+
+- F2. 现有项目有本地 `memory/` 时迁移
+  - **Trigger:** Gale-managed 入口发现当前项目存在 HKTMemory 形态的 `memory/`，且全局目标缺失或未完成迁移。
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** 系统生成迁移状态；默认复制 Markdown 分层记忆和必要轻量元数据到全局目标；跳过或重建本地派生数据库；记录迁移 manifest；不删除项目本地 `memory/`；后续调用使用全局目标。
+  - **Outcome:** 旧记忆进入公共知识体系，用户数据不被破坏，本地目录可作为备份或旧工具兼容。
+  - **Covered by:** R4, R7, R8, R9, R10, R12
+
+- F3. 公共知识库 git 化与索引
+  - **Trigger:** HKTMemory 全局目录新增或更新 Markdown 记忆后，用户或技能触发 `gale-knowledge commit` / `rebuild-index`，或后续自动化在安全时触发。
+  - **Actors:** A2, A4, A5
+  - **Steps:** Git 只跟踪 Markdown 记忆和必要的轻量 manifest；`*.db`、向量缓存、session transcript DB 等派生文件被忽略；公共知识索引可以读取 HKTMemory Markdown，但不得把同一内容无限回写到自身。
+  - **Outcome:** 高价值 HKTMemory 记忆可随公共知识库迁移和检索，派生缓存不污染 git。
+  - **Covered by:** R13, R14, R15, R16
+
+- F4. 用户继续使用裸 `hkt-memory`
+  - **Trigger:** 用户直接在项目目录运行 `hkt-memory`，未经过 `gale-memory` 或 GaleHarness 技能入口。
+  - **Actors:** A1, A4
+  - **Steps:** 系统不强行改变上游 HKTMemory 的全局默认；文档和诊断说明裸命令可能仍使用当前工作目录的 `memory/`，并提供显式 env/flag 或 Gale wrapper 路径。
+  - **Outcome:** Gale-managed 行为统一，同时不破坏上游 HKTMemory 的独立使用方式。
+  - **Covered by:** R17, R18
+
+---
+
+## Requirements
+
+**Global memory root**
+- R1. Gale-managed HKTMemory 调用必须解析 per-project 全局 memory root，默认形态为 `~/.galeharness/knowledge/<project>/hkt-memory`，除非用户显式配置其他位置。
+- R2. 项目名解析应与 `gale-knowledge extract-project` 保持一致；无 git remote 时使用当前目录名 fallback，并进行路径组件安全校验。
+- R3. Gale-managed 调用必须通过 `HKT_MEMORY_DIR` 或 HKTMemory 已支持的 `--memory-dir` 指向全局 memory root，不要求改变 HKTMemory 上游裸命令的默认行为。
+- R4. 全局 memory root 必须保留 HKTMemory 已有分层结构，包括 `L0-Abstract`、`L1-Overview`、`L2-Full`、governance 和 lifecycle 相关文件；规划阶段可决定是否把 task ledger 放在同一 root 下。
+
+**Migration behavior**
+- R5. 新安装或首次使用时，如果当前项目没有本地 HKTMemory `memory/`，系统应直接创建全局 memory root，不在项目仓库创建新的 `memory/`。
+- R6. 如果当前项目存在 HKTMemory 形态的 `memory/`，系统必须提供一次性迁移路径，把已有记忆复制到全局 memory root，并记录迁移状态。
+- R7. 默认迁移策略必须是 copy-first，不删除、不移动用户的项目本地 `memory/`；删除或清理只能作为显式后续操作。
+- R8. 迁移必须跳过或重新生成派生缓存文件，至少包括 `*.db`、vector store、session transcript index 和其他可重建索引；这些文件不得成为公共知识库的 git source of truth。
+- R9. 迁移必须处理目标目录已存在的情况：不能静默覆盖较新的全局记忆；冲突文件应保留双方内容或生成冲突报告，交由后续规划定义具体合并规则。
+- R10. 迁移完成后，Gale-managed 调用应优先使用全局 memory root；本地 `memory/` 只作为 legacy backup 或裸 HKTMemory 兼容来源。
+
+**Installation and runtime integration**
+- R11. Release binary 安装脚本、source setup 脚本和自检说明必须对齐：普通用户和贡献者都能初始化 `gale-knowledge`、验证 `gale-memory`，并看到 HKTMemory memory root 是否指向公共知识库。
+- R12. `gale-memory` helper 应成为技能和脚本的优先入口；它负责构造 task envelope，同时继承或设置全局 HKTMemory memory root，避免每个技能各自拼接 memory-dir 逻辑。
+- R13. `gale-knowledge init` 或相关 setup 应确保公共知识库 `.gitignore` 忽略 HKTMemory 派生缓存，并允许跟踪 Markdown 分层记忆和必要 manifest。
+- R14. `gale-knowledge rebuild-index` 需要明确处理 `hkt-memory` 目录：可以索引 Markdown 记忆，但必须防止把公共知识库内容重新写回同一 HKTMemory root 造成重复、递归或噪声污染。
+
+**User control and compatibility**
+- R15. 用户必须能通过环境变量或配置覆盖 Gale-managed HKTMemory memory root；覆盖后诊断应显示实际使用路径。
+- R16. 系统必须提供诊断或状态输出，说明当前项目的 HKTMemory 来源：global、legacy-local、migrated、migration-needed、migration-conflict 或 unavailable。
+- R17. 裸 `hkt-memory` 命令的独立使用方式不作为本需求的强制改变范围；如果用户绕过 Gale-managed 入口，系统只需通过文档和诊断说明如何显式设置全局路径。
+- R18. 当 `hkt-memory`、`gale-knowledge`、git 或权限不可用时，技能必须 graceful degradation：不阻塞核心工作流，并清楚说明记忆迁移或公共知识写入被跳过。
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R3, R5, R11.** Given 新用户通过 release binary 安装并运行 `gale-memory start`，when 当前项目没有 `memory/`，then HKTMemory 记忆目录应解析到 `~/.galeharness/knowledge/<project>/hkt-memory`，并创建 L0/L1/L2 结构。
+- AE2. **Covers R6, R7, R8, R10.** Given 现有项目包含 `memory/L0-Abstract`、`memory/L1-Overview`、`memory/L2-Full` 和多个 `.db` 文件，when Gale-managed 入口执行迁移，then Markdown 记忆被复制到全局目标，`.db` 文件不进入 git source of truth，本地 `memory/` 保留不删除，后续 Gale-managed 调用使用全局目标。
+- AE3. **Covers R9, R16.** Given 全局目标和本地 `memory/` 都有同名但内容不同的 Markdown 文件，when 迁移运行，then 系统不得静默覆盖；状态应显示 `migration-conflict` 或输出冲突报告。
+- AE4. **Covers R13, R14.** Given `gale-knowledge rebuild-index` 在包含 `<project>/hkt-memory` 的公共知识库中运行，when 它索引 Markdown 文件，then 派生数据库仍被 `.gitignore` 排除，且不会把索引结果递归追加成重复 HKTMemory 记忆。
+- AE5. **Covers R15, R17, R18.** Given 用户显式设置自定义 `HKT_MEMORY_DIR` 或裸跑 `hkt-memory`，when 诊断运行，then 系统能说明实际路径、Gale-managed 默认是否被覆盖，以及迁移未执行是否影响公共知识能力。
+
+---
+
+## Success Criteria
+
+- 通过 GaleHarness 脚本安装或使用的用户，新产生的 HKTMemory 分层记忆默认进入 `~/.galeharness/knowledge/<project>/hkt-memory`，而不是项目仓库 `memory/`。
+- 现有项目本地 HKTMemory 记忆可以安全复制进入公共知识库，且不会删除用户原始数据或提交派生数据库。
+- `gale-memory`、`gale-knowledge`、setup/release 安装脚本和 README 对 memory root 的说明一致，用户能用一个诊断入口看懂当前状态。
+- 公共知识库可以同时承载 `brainstorms/plans/solutions` 文档和 HKTMemory 分层记忆，但两者职责清晰，不发生重复索引或无限回写。
+- 后续 `gh:plan` 可以直接基于本文档规划实现，不需要重新决定默认路径、迁移策略、source of truth 或裸 HKTMemory 兼容边界。
+
+---
+
+## Scope Boundaries
+
+- 不重写 HKTMemory 的 L0/L1/L2 算法、向量后端、reranker、MCP server 或 task memory schema。
+- 不把项目本地 `memory/` 自动删除、移动或从用户仓库中清理；本需求只要求安全复制迁移和后续默认路径切换。
+- 不要求第一版实现实时双向同步；长期双写会制造一致性问题，不作为推荐方向。
+- 不要求公共知识库 git 跟踪 `.db`、embedding cache、transcript index 或其他可重建派生文件。
+- 不强制改变裸 `hkt-memory` 在非 GaleHarness 场景下的默认行为。
+- 不在 requirements 阶段规定具体文件合并算法、CLI flag 名称或测试实现细节；这些留给 `gh:plan`。
+
+---
+
+## Key Decisions
+
+- 采用 **全局 re-home 作为 Gale-managed 默认**，而不是长期双写同步：单一 source of truth 更容易解释、测试和恢复。
+- 迁移采用 **copy-first**：公共知识库获得旧记忆，本地 `memory/` 保留为备份，避免安装脚本意外破坏用户数据。
+- 公共知识库只把 Markdown 记忆和必要 manifest 作为可迁移事实；数据库和向量索引是可重建缓存。
+- `gale-memory` 是优先 runtime 入口：技能应逐步从直接 `hkt-memory` 命令收敛到统一 helper，减少路径逻辑分散。
+- 裸 HKTMemory 兼容作为边界条件处理：GaleHarness 负责自己管理的安装/使用路径，不冒然改变上游工具的独立语义。
+
+---
+
+## Dependencies / Assumptions
+
+- HKTMemory 当前已支持 `HKT_MEMORY_DIR` 和 `--memory-dir`，因此无需为路径迁移先改写上游存储层。
+- `gale-knowledge` 当前有效文档类型只有 `brainstorms`、`plans`、`solutions`；HKTMemory 分层记忆应作为项目目录下的独立 subtree，而不是伪装成这些文档类型。
+- 公共知识库 `.gitignore` 已包含 `*.db`，但 planning 仍需确认是否还要忽略更多 HKTMemory 派生文件。
+- Release binary 安装当前主要安装 GaleHarnessCLI 二进制并验证 `gale-memory`，source setup 当前会安装 HKTMemory CLI 并创建项目 `memory/`；两类安装路径需要在后续实现中统一语义。
+- 当前 worktree 已有未提交的 `memory/` 修改，因此任何实现阶段都必须继续遵守不覆盖用户数据的原则。
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- 无。
+
+### Deferred to Planning
+
+- [Affects R1, R15][Technical] 全局 memory root 的最终配置优先级应如何排序：显式 `HKT_MEMORY_DIR`、Gale config、`GALE_KNOWLEDGE_HOME` 派生路径、默认路径。
+- [Affects R6, R9][Technical] 迁移 manifest 和冲突报告的文件名、位置、幂等判断规则如何设计。
+- [Affects R8, R13][Technical] 除 `*.db` 外还需要忽略哪些 HKTMemory 派生文件或临时文件。
+- [Affects R11, R12][Technical] release binary 环境如何获得可用的 `hkt-memory` CLI：继续依赖用户已有安装、随 release 打包、还是由 `gale-memory` 提供更完整的 wrapper。
+- [Affects R14][Technical] `gale-knowledge rebuild-index` 索引公共知识库时，应写入哪个 memory root，如何避免把 HKTMemory subtree 重复 ingest 回自身。
+- [Affects R16][Technical] 状态诊断应挂在 `gale-memory status`、`gale-knowledge doctor`，还是安装脚本自检中。
+
+---
+
+## Next Steps
+
+-> `gh:plan` for structured implementation planning

--- a/docs/plans/2026-04-24-004-feat-hktmemory-public-knowledge-migration-plan.md
+++ b/docs/plans/2026-04-24-004-feat-hktmemory-public-knowledge-migration-plan.md
@@ -1,0 +1,504 @@
+---
+title: "feat: HKTMemory Public Knowledge Migration"
+type: feat
+status: active
+date: 2026-04-24
+origin: docs/brainstorms/2026-04-24-hktmemory-public-knowledge-migration-requirements.md
+---
+
+# feat: HKTMemory Public Knowledge Migration
+
+## Overview
+
+本计划把 Gale-managed 的 HKTMemory 默认记忆根目录收敛到公共知识库：`~/.galeharness/knowledge/<project>/hkt-memory`。核心做法是复用现有 `gale-knowledge` 的 home/project 解析，在 `gale-memory` 和 `HktClient` 这一层集中注入 `HKT_MEMORY_DIR`，首次发现项目本地 `memory/` 时执行 copy-first 迁移，并通过诊断/status 输出说明当前来源状态。
+
+这不是重写 HKTMemory，也不改变裸 `hkt-memory` 在独立场景下的默认 `memory/` 语义。只有通过 GaleHarness 脚本安装、`gale-memory` helper 或 Gale-managed runtime 进入的调用会默认使用公共知识库路径（see origin: `docs/brainstorms/2026-04-24-hktmemory-public-knowledge-migration-requirements.md`）。
+
+---
+
+## Problem Frame
+
+当前公共知识文档已经由 `gale-knowledge` 管理到全局 Git 仓库，但 HKTMemory 的 L0/L1/L2、governance、lifecycle 和 session 相关文件仍默认落在项目本地 `memory/`。这导致同一个 GaleHarness 工作流产生两套知识来源：durable Markdown 文档可迁移，HKTMemory 的高价值记忆却跟随单个 checkout，清理项目仓库或换机器时容易丢失上下文。
+
+现有代码已经有良好的全局知识仓库基础：`src/knowledge/home.ts` 解析 `GALE_KNOWLEDGE_HOME` 和项目名，`cmd/gale-knowledge/init.ts` 初始化 Git 仓库，`cmd/gale-knowledge/rebuild-index.ts` 扫描 Markdown 并写入 HKTMemory。缺口在 memory runtime：`cmd/gale-memory/index.ts` 只负责 task memory 子命令，`src/memory/hkt-client.ts` 直接调用 `hkt-memory`，没有统一 memory root、迁移或状态诊断。
+
+---
+
+## Requirements Trace
+
+- R1. Gale-managed HKTMemory 默认解析到 `~/.galeharness/knowledge/<project>/hkt-memory`，支持显式覆盖。
+- R2. 项目名解析复用 `gale-knowledge` 的 `extractProjectName` / `sanitizePathComponent` 规则。
+- R3. Gale-managed 调用通过 `HKT_MEMORY_DIR` 或 `--memory-dir` 指向全局 root，不改变裸 `hkt-memory` 默认行为。
+- R4. 全局 root 创建 HKTMemory 分层目录，并允许 governance / lifecycle / task ledger 使用同一 root。
+- R5-R10. 现有项目 `memory/` 执行 copy-first 一次性迁移；跳过派生缓存；不删除本地目录；冲突不静默覆盖；迁移后优先全局 root。
+- R11-R12. release binary、自源码 setup、自检和技能 runtime 统一通过 `gale-memory` 进入。
+- R13-R14. 公共知识库 `.gitignore` 忽略 HKTMemory 派生缓存；`rebuild-index` 可索引 Markdown，但避免递归污染同一 HKTMemory root。
+- R15-R18. 支持用户覆盖、状态诊断和 graceful degradation；裸 `hkt-memory` 只通过文档和诊断说明兼容边界。
+
+**Origin actors:** A1 GaleHarness 用户, A2 安装/运行脚本, A3 Gale memory runtime, A4 HKTMemory CLI/runtime, A5 公共知识库维护者
+**Origin flows:** F1 新用户首次使用, F2 现有项目迁移, F3 公共知识库 git 化与索引, F4 裸 `hkt-memory` 兼容
+**Origin acceptance examples:** AE1 新用户全局 root, AE2 copy-first 迁移, AE3 冲突报告, AE4 git ignore 与 rebuild-index, AE5 覆盖/裸命令/降级诊断
+
+---
+
+## Scope Boundaries
+
+- 不修改 HKTMemory 上游裸命令默认路径；`vendor/hkt-memory/scripts/hkt_memory_v5.py` 已支持 `HKT_MEMORY_DIR` 和 `--memory-dir`，本计划在 Gale wrapper 层使用它。
+- 不删除、不移动项目本地 `memory/`；它保留为 legacy backup 和裸命令兼容路径。
+- 不做长期双写、实时同步或双向合并。
+- 不把 `*.db`、vector store、BM25/session transcript index、`_lifecycle/events.jsonl` 等派生缓存作为公共知识库 Git source of truth。
+- 不改变 HKTMemory 的 L0/L1/L2 算法、MCP server、vector backend、session transcript schema 或 lifecycle 语义。
+
+### Deferred to Follow-Up Work
+
+- 裸 `hkt-memory` 默认全局化：如果未来要改变上游独立语义，应在 HKTMemory 自身仓库另起设计。
+- 项目本地 `memory/` 清理命令：可以后续增加显式 cleanup/archive 工具，但本计划不自动删除用户数据。
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/knowledge/home.ts` 已提供 `resolveKnowledgeHome`、`extractProjectName`、`sanitizePathComponent`，应作为公共 root 和 project 解析的基础。
+- `cmd/gale-knowledge/init.ts` 当前 `.gitignore` 只有 `*.db`、`vector-index/`、`.last-rebuild-commit`，需要补齐 HKTMemory 派生缓存规则。
+- `cmd/gale-knowledge/rebuild-index.ts` 当前递归扫描所有 Markdown 并调用 vendored `hkt_memory_v5.py store`，需要明确处理 `hkt-memory` subtree，避免把公共知识库 Markdown 重复写回同一 memory root。
+- `src/memory/hkt-client.ts` 是所有 task recall/capture 的集中调用点，适合注入 `HKT_MEMORY_DIR` 并保留 unavailable/timeout 的 skipped 结果。
+- `src/memory/task-runtime.ts` 负责 envelope、项目、repo root、branch 和 task id；状态诊断和 migration trigger 应复用这里的项目上下文，而不是每个技能拼路径。
+- `cmd/gale-memory/index.ts` 当前只有 `start`、`capture`、`feedback`，适合新增 `status`、`migrate` 或 `resolve-root` 等辅助子命令。
+- `scripts/setup.sh` / `scripts/setup.ps1` 当前主动创建项目本地 `memory/`，这正是需要调整的 source setup 行为。
+- `scripts/install-release.sh` / `scripts/install-release.ps1` 已安装 `gale-memory` 和 `gale-knowledge`，但安装后自检尚未验证 HKTMemory memory root 指向公共知识库。
+- `tests/gale-memory-runtime.test.ts`、`tests/knowledge-path.test.ts`、`tests/knowledge-init.test.ts`、`tests/knowledge-rebuild-index.test.ts`、`tests/install-release-sh.test.ts`、`tests/install-release-ps1.test.ts` 是本计划的主要测试扩展点。
+
+### Institutional Learnings
+
+- `docs/solutions/developer-experience/global-knowledge-repository-infrastructure-2026-04-20.md` 确认全局知识仓库采用 env -> config -> default 的路径优先级、fallback 策略和 CLI 职责分离。
+- `docs/solutions/integration-issues/hkt-memory-install-to-path-2026-04-23.md` 说明 HKTMemory 的实际风险在安装链路和 PATH 可见性；本计划应把诊断做清楚，避免技能静默失败。
+- HKTMemory 检索结果中已包含本需求文档自身，说明后续存储只需要保存摘要和路径，不需要把完整计划复制到向量层。
+
+### External References
+
+- 未使用外部资料。该变更主要受 repo-local CLI、vendored HKTMemory 和现有 GaleHarness 约束决定，外部最佳实践不会改变实现边界。
+
+---
+
+## Key Technical Decisions
+
+| Decision | Resolution | Rationale |
+| --- | --- | --- |
+| Gale-managed root | `<resolveKnowledgeHome()>/<project>/hkt-memory` | 直接继承公共知识库的 project 解析和 Git 管理，不再引入第二套 home 规则。 |
+| 覆盖优先级 | `gale-memory --memory-dir` -> 用户已有 `HKT_MEMORY_DIR` -> Gale config `memory.hkt_memory_dir` -> derived public root | 保留 HKTMemory 既有 env 语义，同时让 Gale 有持久配置入口；只有 wrapper 内部设置 child env。 |
+| 迁移策略 | copy-first、幂等 manifest、冲突报告 | 满足不破坏用户数据和不静默覆盖。 |
+| 统一入口 | `gale-memory` / `HktClient` 集中设置 env | 避免技能和脚本分散拼路径，后续 gh:* 都可自然继承。 |
+| Git source of truth | Markdown 分层记忆、governance Markdown、迁移 manifest；排除 DB/index/session 派生缓存 | 让公共知识库可审计可迁移，同时避免提交可重建噪声。 |
+| rebuild-index 自引用防护 | `gale-knowledge rebuild-index` 写入独立索引 root，例如 `~/.galeharness/vector-index/knowledge-repo`，不得写入任一 `<project>/hkt-memory` root | 允许索引 `hkt-memory/**/*.md`，同时防止这些 Markdown 被重复存回自身造成递归污染。 |
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- 全局 memory root 配置优先级：采用 `--memory-dir`、已有 `HKT_MEMORY_DIR`、Gale config、derived public root 的顺序。
+- 迁移 manifest 位置：放在全局 target root 下的 `.gale-migration-manifest.json`；冲突报告放在 `MIGRATION_CONFLICTS.md`，必要时同时输出机器可读冲突列表。
+- 忽略规则：公共知识库忽略 `*.db`、`vector_store/`、`vector_store.db`、`bm25_index.db`、`entity_index.db`、`session_transcript_index.db`、`.last-rebuild-commit`、`_lifecycle/events.jsonl`、临时/缓存目录；保留 Markdown 和必要 manifest。
+- release binary 如何获得 HKTMemory CLI：不在本计划强制打包 Python HKTMemory；release 安装只验证 `gale-memory` wrapper 可用并在缺失 `hkt-memory` 时给出可执行诊断。source setup 继续安装/验证 HKTMemory CLI。
+- 状态诊断位置：新增 `gale-memory status` 作为主入口，安装脚本和 README 引导用户运行；`gale-knowledge` 只负责 home/init/rebuild-index。
+
+### Deferred to Implementation
+
+- Gale config 字段的最终命名和兼容读取细节：实现时应优先复用现有 `~/.galeharness/config.{json,yaml}` 读取模式，保持向后兼容。
+- 冲突报告的具体字段顺序和输出文案：不影响架构，可在测试锁定前微调。
+- 独立索引 root 的精确配置字段名：默认位置按 `~/.galeharness/vector-index/knowledge-repo` 设计，实现时可复用现有 config 读取机制暴露覆盖项。
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Setup[setup/install scripts] --> GM[gale-memory CLI]
+  Skill[gh:* skills] --> GM
+  GM --> Runtime[src/memory/task-runtime.ts]
+  Runtime --> Resolver[src/memory/public-root resolver]
+  Resolver --> GK[src/knowledge/home.ts]
+  Resolver --> Migration[src/memory migration]
+  Migration --> GlobalRoot[knowledge/<project>/hkt-memory]
+  Runtime --> Client[src/memory/hkt-client.ts]
+  Client --> HKT[hkt-memory child process with HKT_MEMORY_DIR]
+  GKCLI[gale-knowledge init/rebuild-index] --> GlobalRoot
+```
+
+状态模型：
+
+| Status | Meaning | Primary action |
+| --- | --- | --- |
+| `global` | 全局 root 存在并被 Gale-managed 调用使用 | 正常运行 |
+| `legacy-local` | 只有项目本地 `memory/`，且未触发迁移 | 提示可运行迁移 |
+| `migration-needed` | 本地 `memory/` 存在且 target 缺失或 manifest 缺失 | 自动或显式 copy-first 迁移 |
+| `migrated` | manifest 显示已完成迁移，后续使用 global | 正常运行 |
+| `migration-conflict` | 同名 Markdown 内容不同或目标更近 | 不覆盖，输出冲突报告 |
+| `unavailable` | `hkt-memory`、git、权限或路径不可用 | graceful degradation |
+
+---
+
+## Implementation Units
+
+- [ ] U1. **Public Memory Root Resolver**
+
+**Goal:** 新增 Gale-managed HKTMemory root 解析层，集中决定当前项目的 target root、覆盖来源和状态基础信息。
+
+**Requirements:** R1, R2, R3, R4, R15, R16, AE1, AE5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/memory/public-root.ts`
+- Modify: `src/memory/task-runtime.ts`
+- Test: `tests/gale-memory-public-root.test.ts`
+- Test: `tests/knowledge-path.test.ts`
+
+**Approach:**
+- 复用 `resolveKnowledgeHome`、`extractProjectName` 和 `sanitizePathComponent`，组装 `<knowledgeHome>/<project>/hkt-memory`。
+- 支持 `gale-memory --memory-dir`、用户已有 `HKT_MEMORY_DIR`、Gale config、默认 derived root 的优先级，并在返回值中标明 source。
+- 提供创建标准 HKTMemory 目录结构的 helper：`L0-Abstract/topics`、`L1-Overview/topics`、`L2-Full/{daily,evergreen,episodes}` 和必要 index/MEMORY 文件。
+- 解析失败时返回可诊断对象，不直接抛到用户工作流顶层，保持 graceful degradation。
+
+**Execution note:** 先写路径优先级和 path-sanitization 的单元测试，再接 runtime。
+
+**Patterns to follow:**
+- `src/knowledge/home.ts` 的 env/config/default 优先级和 project 解析。
+- `tests/knowledge-path.test.ts` 的 env restore 模式。
+
+**Test scenarios:**
+- Happy path: 设置 `GALE_KNOWLEDGE_HOME` 和 project 后解析到 `<home>/<project>/hkt-memory`。
+- Happy path: 显式 `--memory-dir` 或等价 option 覆盖默认 root，status source 标记为 explicit。
+- Edge case: 用户已有 `HKT_MEMORY_DIR` 时不被 derived public root 覆盖。
+- Edge case: 无 git remote 时 fallback 到当前目录名，并拒绝包含路径分隔符或 traversal 的 project。
+- Error path: config 文件不可读或 git 不可用时仍返回默认路径或 `unavailable` 诊断，不阻塞 envelope 构造。
+- Covers AE1: 新项目无本地 `memory/` 时创建全局 L0/L1/L2 结构，不创建项目本地 `memory/`。
+
+**Verification:**
+- `buildTaskEnvelope` 可获得一致 project/root 信息。
+- 新 helper 在 macOS/Linux/Windows path 语义下不产生 traversal 风险。
+
+---
+
+- [ ] U2. **Copy-First Migration Engine**
+
+**Goal:** 为现有项目本地 `memory/` 提供幂等、安全的一次性复制迁移，保留本地目录并记录 manifest/冲突。
+
+**Requirements:** R4, R6, R7, R8, R9, R10, R16, AE2, AE3
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `src/memory/migration.ts`
+- Modify: `cmd/gale-memory/index.ts`
+- Test: `tests/gale-memory-migration.test.ts`
+
+**Approach:**
+- 识别 HKTMemory 形态的本地 `memory/`：至少存在 `L0-Abstract`、`L1-Overview` 或 `L2-Full` 中任一标准目录。
+- 迁移只复制 Markdown 分层记忆、governance Markdown、必要轻量 manifest；默认跳过 `.db`、vector/index/cache、session transcript index、`_lifecycle/events.jsonl` 等派生文件。
+- target 不存在时直接复制；target 已存在时逐文件比较：相同内容跳过，target 缺失则复制，内容不同则不覆盖并记录冲突。
+- 写入 `.gale-migration-manifest.json`，包含 source path、target path、timestamp、copied/skipped/conflicted counts、规则版本和 status。
+- 冲突时生成 `MIGRATION_CONFLICTS.md`，status 返回 `migration-conflict`，后续 Gale-managed 调用仍优先全局 root，但提示用户检查冲突。
+- 本地 `memory/` 永远不删除、不改名。
+
+**Execution note:** 先用临时目录做 characterization-style 测试，覆盖复制/跳过/冲突/幂等，再接 CLI。
+
+**Patterns to follow:**
+- `tests/knowledge-init.test.ts` 的临时目录和 cleanup 模式。
+- `cmd/gale-knowledge/init.ts` 的幂等初始化思路。
+
+**Test scenarios:**
+- Covers AE2: 本地 `memory/L0-Abstract`、`L1-Overview`、`L2-Full` 和多个 `.db` 文件迁移后，Markdown 存在于全局 target，`.db` 不复制，本地目录仍存在。
+- Covers AE3: source/target 同名 Markdown 内容不同，迁移不覆盖 target，返回 `migration-conflict` 并写冲突报告。
+- Happy path: target 缺失时复制标准层级和 index/MEMORY 文件，并写 completed manifest。
+- Edge case: 重复运行迁移时 copied count 为 0 或只复制新增文件，manifest 更新但不重复内容。
+- Error path: source 不可读或 target 权限不足时返回 `unavailable`/failed diagnostic，不删除任何文件。
+- Integration: `gale-memory migrate --cwd <repo>` 可触发同一 migration engine，并输出 JSON 诊断。
+
+**Verification:**
+- 迁移过程不会修改或删除项目本地 `memory/`。
+- manifest 足以判断后续运行是否已迁移、是否有冲突、是否需要人工处理。
+
+---
+
+- [ ] U3. **Runtime Injection Through gale-memory and HktClient**
+
+**Goal:** 让所有 Gale-managed task memory 调用自动使用 U1 解析出的 memory root，并在首次使用时触发安全初始化/迁移。
+
+**Requirements:** R3, R5, R10, R12, R15, R18, AE1, AE2, AE5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `src/memory/hkt-client.ts`
+- Modify: `src/memory/task-runtime.ts`
+- Modify: `cmd/gale-memory/index.ts`
+- Test: `tests/gale-memory-runtime.test.ts`
+- Test: `tests/gale-memory-cli.test.ts`
+
+**Approach:**
+- `HktClient` 增加 env 注入能力：child process 使用 `{ ...process.env, HKT_MEMORY_DIR: resolvedRoot }`，但如果 resolver 判定用户显式设置了 `HKT_MEMORY_DIR`，保留其值并在 diagnostics 中标注 override。
+- `startTaskMemory` / `captureTaskMemory` / `feedbackTaskMemory` 在构造 client 前解析 root，并按策略执行 `ensureGlobalMemoryRoot` 与 migration check。
+- `cmd/gale-memory` 增加 `status`、`resolve-root`、`migrate` 子命令；现有 `start`、`capture`、`feedback` 输出中附带 memory diagnostics。
+- 保持 `skippedResult` 语义：`hkt-memory` 不可用、超时、JSON malformed 都不阻塞核心工作流，但 reason 更清楚地包含 memory root 和安装建议。
+- 不在 gh:* skill 中直接拼 `HKT_MEMORY_DIR`；技能层继续调用 `gale-memory start/capture`。
+
+**Execution note:** 先扩展 fake client/child spawn 测试，确保 env 注入契约清楚，再改 CLI 输出。
+
+**Patterns to follow:**
+- `src/memory/hkt-client.ts` 的 timeout/unavailable skipped result。
+- `cmd/gale-memory/index.ts` 当前 JSON 输出风格。
+- `tests/hkt-memory-compounding.test.ts` 中“技能应使用 gale-memory helper 而不是 raw hkt-memory”的约束。
+
+**Test scenarios:**
+- Happy path: `startTaskMemory` 在无本地 `memory/` 时创建全局 root，并调用 fake client。
+- Happy path: `HktClient` spawn 时传入 `HKT_MEMORY_DIR=<globalRoot>`。
+- Edge case: 用户显式 `HKT_MEMORY_DIR=/custom` 时 child env 使用 `/custom`，status 显示 override。
+- Error path: `hkt-memory` binary 不存在时仍返回 skipped，并包含 `hkt-memory unavailable` 与 resolved memory root 诊断。
+- Integration: `gale-memory status --json` 返回 `global`、`legacy-local`、`migration-needed`、`migrated`、`migration-conflict` 或 `unavailable` 之一。
+- Covers AE5: 裸命令或自定义 env 场景下，诊断说明实际路径与 Gale-managed 默认是否被覆盖。
+
+**Verification:**
+- 所有 Gale-managed memory 调用只有一个 runtime/helper 入口负责 root 注入。
+- 旧的 `start`、`capture`、`feedback` CLI JSON 消费者不因新增 diagnostics 破坏。
+
+---
+
+- [ ] U4. **Knowledge Repo Git Ignore and Rebuild-Index Safety**
+
+**Goal:** 让公共知识库能容纳 `<project>/hkt-memory`，只把 Markdown/manifest 作为 source of truth，并让 rebuild-index 写入独立索引 root，避免递归污染当前 HKTMemory root。
+
+**Requirements:** R8, R13, R14, AE4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `cmd/gale-knowledge/init.ts`
+- Modify: `cmd/gale-knowledge/rebuild-index.ts`
+- Test: `tests/knowledge-init.test.ts`
+- Test: `tests/knowledge-rebuild-index.test.ts`
+
+**Approach:**
+- 扩展 `GITIGNORE_CONTENT`，覆盖 HKTMemory 派生缓存：`*.db`、`vector_store/`、`vector_store.db`、`bm25_index.db`、`entity_index.db`、`session_transcript_index.db`、`.last-rebuild-commit`、`_lifecycle/events.jsonl`、临时缓存目录。
+- `initKnowledgeRepo` 对已存在 `.gitignore` 的仓库提供幂等补丁逻辑，不只在首次 init 写入规则。
+- `collectMarkdownFiles` 默认仍可扫描 `hkt-memory/**/*.md`，但 `rebuildIndex` 调用 HKTMemory store 时必须设置独立 `HKT_MEMORY_DIR`，默认位于 `~/.galeharness/vector-index/knowledge-repo`，而不是任何 `<project>/hkt-memory` root。
+- 独立 index root 是可重建缓存，不属于公共知识库 Git source of truth；公共知识库只保存 Markdown 和必要 manifest。
+
+**Patterns to follow:**
+- `cmd/gale-knowledge/rebuild-index.ts` 当前增量/full 模式、`.last-rebuild-commit` 逻辑和 skipped/error 计数。
+- `tests/knowledge-rebuild-index.test.ts` 对 collect、changed files、uv unavailable 的覆盖方式。
+
+**Test scenarios:**
+- Covers AE4: `gale-knowledge init` 后 `.gitignore` 包含 HKTMemory DB/index/session 派生缓存，但不忽略 `hkt-memory/**/*.md`。
+- Happy path: 已存在 `.gitignore` 的知识仓库重新 init 后追加缺失规则，不删除用户自定义规则。
+- Edge case: `collectMarkdownFiles` 可找到 `project/hkt-memory/L2-Full/daily/foo.md`，但 `rebuildIndex` 的 child process env 指向独立 index root，不会把它重复写回同一 root。
+- Error path: `uv` 或 HKTMemory script 不可用时仍只输出 warning，不推进失败文件的 rebuild pointer。
+- Integration: full rebuild 处理普通 `plans/` Markdown 与 `hkt-memory/` Markdown 时，processed/skipped/errors 计数可解释。
+
+**Verification:**
+- 公共知识库 Git 状态不会出现 `.db` 或可重建 index 文件。
+- `rebuild-index` 不会在 `<project>/hkt-memory` 下产生重复 L2 记忆；索引产物只出现在独立 index root。
+
+---
+
+- [ ] U5. **Installation and Source Setup Alignment**
+
+**Goal:** 调整 release binary 安装、自源码 setup 和自检输出，使新用户不再由 GaleHarness 脚本默认创建项目本地 `memory/`。
+
+**Requirements:** R5, R11, R12, R16, R18, AE1, AE5
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Modify: `scripts/setup.sh`
+- Modify: `scripts/setup.ps1`
+- Modify: `scripts/install-release.sh`
+- Modify: `scripts/install-release.ps1`
+- Modify: `tests/setup-scripts-ci-mode.test.ts`
+- Modify: `tests/install-release-sh.test.ts`
+- Modify: `tests/install-release-ps1.test.ts`
+
+**Approach:**
+- Source setup 移除或替换当前直接 `mkdir -p memory/...` 的步骤，改为调用/提示 `gale-memory status` 或 `gale-memory resolve-root`，由 runtime 在公共知识库创建 root。
+- source setup 仍继续安装和验证 `hkt-memory` CLI，因为 HKTMemory 是 Python 工具，release binary 暂不打包它。
+- release installer 的 post-install verification 增加 `gale-memory status` 建议；如果 `hkt-memory` 不在 PATH，输出清晰诊断但不让二进制安装失败。
+- Windows setup 保留 `hkt-memory.cmd` 安装逻辑，同时让自检说明 memory root 是公共知识库路径。
+- CI mode 不写用户 profile，不污染 repo `memory/`。
+
+**Patterns to follow:**
+- `scripts/setup.sh` / `scripts/setup.ps1` 已有 CI mode、PATH 和 HKTMemory install 自检结构。
+- `tests/install-release-sh.test.ts` 使用本地 archive 和 stdout contract。
+
+**Test scenarios:**
+- Covers AE1: source setup 文本和 CI 测试不再创建项目本地 `memory/L0-Abstract`。
+- Happy path: install-release stdout 包含 `gale-memory status` 或等价诊断建议。
+- Edge case: `hkt-memory` 不可用时 setup 输出 warning，不阻塞 `gale-harness` / `gale-knowledge` binary 安装。
+- Windows: PowerShell installer/self-check 文案包含 `gale-memory.exe status`，且不依赖 bash。
+- CI: `GHALE_CI=1` 下不会尝试交互配置或写 shell profile，仍能验证 CLI 启动。
+
+**Verification:**
+- 新安装用户通过 Gale-managed 入口产生的记忆进入公共知识库。
+- 贡献者 setup 不再把 repo 根目录 `memory/` 当作默认事实来源。
+
+---
+
+- [ ] U6. **Documentation and Skill Contract Updates**
+
+**Goal:** 更新 README、技能约束和测试契约，让用户和后续 agent 都知道 `gale-memory` 是统一入口，裸 `hkt-memory` 是兼容边界。
+
+**Requirements:** R11, R12, R15, R16, R17, R18, AE5
+
+**Dependencies:** U3, U5
+
+**Files:**
+- Modify: `README.md`
+- Modify: `plugins/galeharness-cli/README.md`
+- Modify: `plugins/galeharness-cli/skills/**/SKILL.md` where raw HKTMemory calls remain
+- Modify: `tests/hkt-memory-compounding.test.ts`
+- Test: `tests/x-skill-contract.test.ts`
+
+**Approach:**
+- README 的“全局知识仓库”和“环境变量”章节新增 HKTMemory public root 说明：Gale-managed 默认、覆盖优先级、裸命令兼容、诊断状态含义。
+- 安装后自检从 `hkt-memory stats` 单独检查，扩展为 `gale-memory status` + 可选 `hkt-memory stats`。
+- 检查 gh:* 技能是否仍直接调用 `hkt-memory retrieve/store/session-search`；能收敛的改为 `gale-memory start/capture`，暂不能收敛的至少明确 graceful fallback 和 public root 约束。
+- 明确公共知识库 Git source of truth：Markdown 和必要 manifest 跟踪，DB/index/session transcript cache 不跟踪。
+
+**Patterns to follow:**
+- `tests/hkt-memory-compounding.test.ts` 已验证部分技能使用 `gale-memory` helper。
+- README 当前安装和环境变量结构。
+
+**Test scenarios:**
+- Happy path: 文档包含 `~/.galeharness/knowledge/<project>/hkt-memory` 和 `gale-memory status`。
+- Edge case: 文档明确裸 `hkt-memory` 仍可能使用当前工作目录 `memory/`，需要 env/flag 才进入全局 root。
+- Contract: 技能内容不再新增 raw `hkt-memory` 调用，或测试允许的例外有明确注释。
+- Covers AE5: README 说明自定义 `HKT_MEMORY_DIR`、Gale-managed 默认和 unavailable 降级。
+
+**Verification:**
+- 用户能从 README 独立理解新路径、迁移状态和覆盖方式。
+- 技能约束防止后续改动重新分散 memory-dir 逻辑。
+
+---
+
+- [ ] U7. **Release Validation and End-to-End Acceptance Coverage**
+
+**Goal:** 补齐跨模块验收测试，确保路径迁移、安装脚本、知识库索引和文档契约作为一个系统工作。
+
+**Requirements:** All, especially AE1-AE5
+
+**Dependencies:** U1, U2, U3, U4, U5, U6
+
+**Files:**
+- Modify: `tests/hkt-memory-cli-smoke.test.ts`
+- Create: `tests/hktmemory-public-knowledge-migration.test.ts`
+- Modify: `tests/release-archive.test.ts`
+- Modify: `tests/release-components.test.ts`
+- Modify: `tests/release-metadata.test.ts` if release-owned descriptions/counts change
+
+**Approach:**
+- 增加端到端临时目录测试：模拟 knowledge home、repo cwd、本地 legacy memory、运行 `gale-memory status/migrate/start`，验证 target root 和 manifest。
+- release archive 已包含 `gale-memory` / `gale-knowledge`，只在行为或 help text 变化时更新断言。
+- 若插件 README、技能 inventory 或 release-owned metadata 受影响，运行 release validation 并更新对应 fixtures/metadata。
+- 保持真实 HKTMemory CLI smoke 测试用临时 `--memory-dir`，避免污染 repo 或用户公共知识库。
+
+**Patterns to follow:**
+- `tests/hkt-memory-cli-smoke.test.ts` 使用临时 memory dir 避免污染 repo。
+- `tests/release-archive.test.ts` 验证 release binary 文件完整性。
+
+**Test scenarios:**
+- Covers AE1: 空项目首次 `gale-memory start` 使用全局 root，并创建 L0/L1/L2。
+- Covers AE2: legacy local memory 迁移复制 Markdown、跳过 DB、本地保留。
+- Covers AE3: 同名冲突返回 `migration-conflict`。
+- Covers AE4: `gale-knowledge rebuild-index` 在包含 `hkt-memory` subtree 时不会递归写回。
+- Covers AE5: 显式 env override 和 missing binary 场景有可解释诊断。
+- Release: release archive 仍包含四个 binary，install scripts 的自检文案和实际 binary 名称一致。
+
+**Verification:**
+- 推荐测试命令：`bun test tests/gale-memory-runtime.test.ts tests/gale-memory-public-root.test.ts tests/gale-memory-migration.test.ts tests/knowledge-init.test.ts tests/knowledge-rebuild-index.test.ts tests/install-release-sh.test.ts tests/install-release-ps1.test.ts tests/hktmemory-public-knowledge-migration.test.ts`
+- 全量验证命令：`bun test`
+- release 元数据验证命令：`bun run release:validate`
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** 安装脚本、`gale-memory`、`src/memory/*`、`gale-knowledge init/rebuild-index`、README 和技能契约都会受到影响。实现必须保持 root 解析集中，避免多处拼路径。
+- **Error propagation:** memory unavailable、migration conflict、permission denied 应作为 diagnostics 返回或 warning 输出，不应让 gh:* 核心工作流失败。
+- **State lifecycle risks:** copy-first 迁移会产生 manifest 和冲突报告；重复运行必须幂等。全局 root 成为 Gale-managed source of truth，本地 `memory/` 只作为 backup。
+- **API surface parity:** macOS/Linux shell、Windows PowerShell、release binary、source setup、programmatic `HktClient` 都要看到同一 root 规则。
+- **Integration coverage:** 单元测试不足以证明安装和 runtime 一致，需要端到端临时目录测试覆盖 status/migrate/start。
+- **Unchanged invariants:** 裸 `hkt-memory` 默认仍是上游行为；`gale-knowledge` 的 `brainstorms/plans/solutions` 文档类型不扩展为 `hkt-memory` 类型；公共知识库仍是 Git 管理根。
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| 错误覆盖用户已有全局记忆 | Medium | High | U2 使用逐文件比较、冲突报告和 no-overwrite 策略。 |
+| 安装脚本仍创建项目本地 `memory/` | Medium | Medium | U5 移除 source setup 的本地 mkdir，并用测试锁定。 |
+| `rebuild-index` 把 `hkt-memory` Markdown 重复写回自身 | Medium | High | U4 固定使用独立 index root，并用 AE4 测试 child env 与输出位置。 |
+| 用户自定义 `HKT_MEMORY_DIR` 被 wrapper 覆盖 | Low | Medium | U1/U3 把用户已有 env 设为高优先级，并在 status 中显式显示。 |
+| Windows path / PATH 诊断不一致 | Medium | Medium | U5 复用现有 PowerShell setup/installer 测试，避免 bash 依赖。 |
+| HKTMemory CLI 缺失导致技能看似成功但没记忆 | Medium | Medium | U3/U5 用 `gale-memory status` 和 skipped diagnostics 暴露原因。 |
+
+---
+
+## Phased Delivery
+
+### Phase 1: Runtime Foundation
+
+- 完成 U1、U2、U3。此阶段让 `gale-memory` 能解析 root、迁移 legacy memory、向 HKTMemory child process 注入 `HKT_MEMORY_DIR`。
+
+### Phase 2: Knowledge Repository Safety
+
+- 完成 U4。此阶段保证公共知识库 Git source of truth 和 rebuild-index 行为不会污染或递归。
+
+### Phase 3: Installation and Documentation
+
+- 完成 U5、U6、U7。此阶段对齐 release/source 安装、自检、README、技能契约和端到端验收。
+
+---
+
+## Documentation / Operational Notes
+
+- README 需要增加“Gale-managed HKTMemory root”小节，并列出 status 值、覆盖优先级和裸命令兼容说明。
+- 安装脚本输出应引导 `gale-memory status`，不要只要求用户运行裸 `hkt-memory stats`。
+- 迁移是 copy-first，可回滚方式是删除或重命名全局 target root/manifest 后重新运行；项目本地 `memory/` 一直保留作为恢复来源。
+- 如果公共知识库 Git 状态出现 `.db` 或 index 文件，说明 `.gitignore` 或 migration skip 规则有缺口，应先修规则再提交知识库。
+
+---
+
+## Acceptance Criteria
+
+- 新项目通过 `gale-memory start` 首次使用后，全局 target root 存在，项目仓库未新增 `memory/`。
+- legacy 项目本地 `memory/` 的 Markdown 被复制到 `~/.galeharness/knowledge/<project>/hkt-memory`，`.db` / index 缓存未复制，本地目录保留。
+- 冲突文件不被覆盖，`gale-memory status` 输出 `migration-conflict` 或等价 JSON 诊断。
+- `gale-knowledge init` 生成的 `.gitignore` 排除 HKTMemory 派生缓存但允许 Markdown 记忆和 manifest。
+- `gale-knowledge rebuild-index` 不会把 `hkt-memory` subtree 重复 ingest 回自身，索引写入独立 index root。
+- release/source 安装自检和 README 均说明 `gale-memory status`、覆盖优先级和裸 `hkt-memory` 兼容边界。
+- `bun test` 和 `bun run release:validate` 通过。
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-24-hktmemory-public-knowledge-migration-requirements.md`
+- Related plan: `docs/plans/2026-04-20-001-feat-global-knowledge-repo-plan.md`
+- Related solution: `docs/solutions/developer-experience/global-knowledge-repository-infrastructure-2026-04-20.md`
+- Related solution: `docs/solutions/integration-issues/hkt-memory-install-to-path-2026-04-23.md`
+- Related code: `src/knowledge/home.ts`
+- Related code: `cmd/gale-knowledge/init.ts`
+- Related code: `cmd/gale-knowledge/rebuild-index.ts`
+- Related code: `cmd/gale-memory/index.ts`
+- Related code: `src/memory/hkt-client.ts`
+- Related code: `src/memory/task-runtime.ts`
+- Related code: `scripts/setup.sh`
+- Related code: `scripts/setup.ps1`
+- Related code: `scripts/install-release.sh`
+- Related code: `scripts/install-release.ps1`

--- a/docs/solutions/developer-experience/gale-managed-hktmemory-public-knowledge-root-2026-04-24.md
+++ b/docs/solutions/developer-experience/gale-managed-hktmemory-public-knowledge-root-2026-04-24.md
@@ -1,0 +1,181 @@
+---
+title: "Gale-managed HKTMemory 公共知识库 root 迁移"
+date: 2026-04-24
+category: developer-experience
+module: "gale-memory / hkt-memory public knowledge root"
+problem_type: developer_experience
+component: development_workflow
+severity: high
+applies_when:
+  - Gale-managed HKTMemory 需要默认写入公共知识库，而不是项目本地 memory/
+  - 既有项目本地 HKTMemory 记忆需要安全迁移到 per-project 全局 root
+  - 公共知识库同时承载 Markdown 文档和 HKTMemory 分层记忆
+tags: [hktmemory, gale-memory, knowledge-root, migration, public-knowledge, rebuild-index]
+related_components: [gale-knowledge, hkt-client, setup-scripts, gh-skills]
+---
+
+# Gale-managed HKTMemory 公共知识库 root 迁移
+
+## Context
+
+GaleHarness 已经用 `gale-knowledge` 把 brainstorm、plan、solution 文档集中到 `~/.galeharness/knowledge/<project>/...`，但 Gale-managed HKTMemory 仍默认使用项目本地 `memory/`。这会让同一个工作流产生两套知识来源：durable Markdown 文档可以跟随公共知识库迁移，HKTMemory 的 L0/L1/L2 记忆、task ledger 和 lifecycle 相关内容却绑定在单个 checkout 上。
+
+PR #68 的解决目标是把通过 GaleHarness 入口使用的 HKTMemory 默认收敛到：
+
+```text
+~/.galeharness/knowledge/<project>/hkt-memory
+```
+
+关键边界是：不改变裸 `hkt-memory` 的上游默认语义。裸命令仍可按 HKTMemory 自己的规则使用当前目录 `memory/`；需要公共 root 时，通过 `gale-memory` 或显式 `HKT_MEMORY_DIR` 进入。
+
+相关已有文档 `global-knowledge-repository-infrastructure-2026-04-20.md` 解决的是公共知识文档仓库本身的 path resolution、commit 和 indexing 基础设施。本次沉淀的是 HKTMemory runtime 如何并入这套公共知识体系，属于同一基础设施的后续演进，不是重复问题。
+
+## Guidance
+
+### 1. 把 Gale-managed root 解析集中在 runtime 边界
+
+不要让每个 `gh:*` 技能各自拼 `HKT_MEMORY_DIR`。公共 root 的解析应集中在 `gale-memory` / task runtime / `HktClient` 这一层：
+
+- `--memory-dir` 显式参数优先级最高，适合临时诊断和测试。
+- 已有 `HKT_MEMORY_DIR` 次之，保留 HKTMemory 用户的既有 env 语义。
+- `~/.galeharness/config.{json,yaml}` 中的 `memory.hkt_memory_dir` 作为持久配置入口。
+- 默认值派生自 `gale-knowledge` 的 home/project 规则：`<knowledgeHome>/<project>/hkt-memory`。
+
+PR #68 用 `src/memory/public-root.ts` 承载这条规则，并复用 `src/knowledge/home.ts` 的 `resolveKnowledgeHome`、`extractProjectName` 和 `sanitizePathComponent`。这样 Gale-managed HKTMemory 与公共知识文档使用同一套 project 名和 home 解析，不会产生第二套目录语义。
+
+### 2. 迁移必须 copy-first，不能删除或静默覆盖
+
+已有项目可能已经有 `memory/L0-Abstract`、`memory/L1-Overview` 或 `memory/L2-Full`。迁移策略应把本地 `memory/` 视为 legacy source，而不是待移动目录：
+
+- 只复制 Markdown 分层记忆和必要轻量 manifest。
+- 跳过 `*.db`、vector store、BM25/entity/session transcript index、`_lifecycle/events.jsonl`、cache/tmp 等可重建派生文件。
+- target 缺失时复制；target 已存在且内容相同则跳过；target scaffold 为空时允许用 source 覆盖；target 已有不同内容时不覆盖，记录冲突。
+- 在 target root 写 `.gale-migration-manifest.json`，冲突时写 `MIGRATION_CONFLICTS.md`。
+- 本地 `memory/` 永远不删除、不改名，继续作为 legacy backup 和裸命令兼容路径。
+
+这条规则避免了安装或首次运行时破坏用户数据，也避免把本地数据库缓存错误提交到公共知识库。
+
+### 3. `gale-memory status/migrate/resolve-root` 是用户可理解的诊断面
+
+公共 root 迁移不是只靠内部 env 注入完成。用户需要一个稳定命令回答三个问题：当前项目用哪个 root、root 来源是什么、是否有 legacy migration 状态。
+
+PR #68 在 `cmd/gale-memory/index.ts` 增加：
+
+- `gale-memory resolve-root`：输出当前 Gale-managed HKTMemory root，脚本和技能可用于注入。
+- `gale-memory status --json`：输出 `global`、`legacy-local`、`migration-needed`、`migrated`、`migration-conflict` 等状态，以及 root/source/project。
+- `gale-memory migrate --cwd <repo>`：显式触发同一 copy-first migration engine。
+
+现有 `start`、`capture`、`feedback` 继续通过 task runtime 使用统一 resolver，并由 `HktClient` 给 child process 注入 `HKT_MEMORY_DIR`。这样技能层可以从 raw `hkt-memory retrieve/store` 收敛为先调用 `gale-memory resolve-root`，再显式注入公共 root。
+
+### 4. 公共知识库 git 只跟踪 source-of-truth，index root 必须独立
+
+公共知识库现在同时包含：
+
+- `brainstorms/`、`plans/`、`solutions/` 等 durable 文档。
+- `<project>/hkt-memory/` 下的 HKTMemory Markdown 分层记忆和 migration manifest。
+
+因此 `gale-knowledge init` 的 `.gitignore` 必须排除 HKTMemory 派生缓存，例如 `*.db`、`vector_store/`、`vector-index/`、`bm25_index.db`、`entity_index.db`、`session_transcript_index.db`、`.last-rebuild-commit` 和 `_lifecycle/events.jsonl`。Markdown 和必要 manifest 才是可审计、可迁移的事实。
+
+`gale-knowledge rebuild-index` 也不能把公共知识库内容索引回任一 `<project>/hkt-memory` subtree，否则会出现自引用和递归污染。PR #68 让 rebuild-index 使用独立的可重建 index root，例如 `~/.galeharness/vector-index/knowledge-repo`，允许扫描 `hkt-memory/**/*.md`，但索引产物不会写回被扫描的 HKTMemory source tree。
+
+### 5. 安装脚本和文档要明确裸命令边界
+
+setup/install 文案不应继续默认创建项目本地 `memory/`，否则会和公共 root 的默认行为冲突。PR #68 把安装后的验证引导改为 `gale-memory status`，并在 README / 插件 README 中明确：
+
+- Gale-managed 调用默认进入 `~/.galeharness/knowledge/<project>/hkt-memory`。
+- 覆盖优先级是 `--memory-dir` -> `HKT_MEMORY_DIR` -> `memory.hkt_memory_dir` -> derived public root。
+- 裸 `hkt-memory` 保留 upstream 默认语义；如果要使用公共 root，需要显式 env/flag 或通过 `gale-memory`。
+
+## Why This Matters
+
+HKTMemory 的价值在于长期可复用的上下文。如果 Gale-managed 记忆默认留在单个 checkout 的 `memory/`，用户清理仓库、换机器或从 release binary 迁移到源码环境时，很容易丢失高价值经验。把默认 root 收敛到公共知识库后，Markdown 记忆、解决方案文档和索引能力可以共享同一套 Git 化、可审计、可迁移的知识体系。
+
+同时，保留裸 `hkt-memory` 默认语义是必要的兼容边界。GaleHarness 只管理自己入口下的 runtime 行为，不冒然改变 vendored 上游工具在独立使用场景中的默认路径。这个边界让迁移可以安全落地，也降低了未来同步 upstream HKTMemory 的维护成本。
+
+copy-first 迁移和冲突报告是这类工具迁移的最低安全线：旧数据不能被安装脚本删除，已有全局记忆不能被本地旧内容静默覆盖，派生缓存不能进入公共知识 Git source-of-truth。
+
+## When to Apply
+
+- 为 workflow runtime 增加 per-project 全局数据目录，但仍需要兼容上游裸 CLI 的默认行为。
+- 把项目本地历史数据迁移到全局知识库，且不能自动删除或改名用户原始目录。
+- 公共知识仓库既要跟踪 Markdown source-of-truth，又要排除可重建数据库、向量索引和 transcript cache。
+- 技能、安装脚本、runtime client 都需要同一个诊断入口说明实际路径和覆盖来源。
+
+## Examples
+
+### 解析 Gale-managed root
+
+```bash
+gale-memory resolve-root
+# ~/.galeharness/knowledge/GaleHarnessCodingCLI/hkt-memory
+
+gale-memory status --json
+```
+
+`status` 输出应包含实际 `memory_dir`、`source`、`project`、`knowledge_home` 和 migration status。测试中需要覆盖新项目不会创建 repo-local `memory/`。
+
+### 显式迁移 legacy memory
+
+```bash
+gale-memory migrate --cwd /path/to/project
+```
+
+迁移完成后，全局 target 中应包含 legacy Markdown，例如：
+
+```text
+~/.galeharness/knowledge/<project>/hkt-memory/L2-Full/daily/legacy.md
+```
+
+但不应包含：
+
+```text
+bm25_index.db
+entity_index.db
+session_transcript_index.db
+vector_store.db
+_lifecycle/events.jsonl
+```
+
+本地 `/path/to/project/memory/` 应保持存在，作为 legacy backup 和裸 `hkt-memory` 兼容来源。
+
+### 技能中注入公共 root
+
+```bash
+MEMORY_DIR=$(gale-memory resolve-root 2>/dev/null)
+if [ -n "$MEMORY_DIR" ]; then
+  HKT_MEMORY_DIR="$MEMORY_DIR" hkt-memory retrieve \
+    --query "<query>" \
+    --layer all \
+    --limit 10
+fi
+```
+
+长期看，优先把更多 raw HKTMemory 工作流收敛成结构化 `gale-memory` 子命令，减少技能层 shell 拼接。
+
+### 防止 rebuild-index 递归污染
+
+```bash
+gale-knowledge rebuild-index --full
+```
+
+该命令可以扫描公共知识库中的 Markdown，包括 `<project>/hkt-memory/**/*.md`，但写入的 HKTMemory index root 应是独立的可重建目录，例如：
+
+```text
+~/.galeharness/vector-index/knowledge-repo
+```
+
+不要把索引结果写回当前正在扫描的 `<project>/hkt-memory`。
+
+## Related
+
+- PR #68: https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI/pull/68
+- `docs/brainstorms/2026-04-24-hktmemory-public-knowledge-migration-requirements.md`
+- `docs/plans/2026-04-24-004-feat-hktmemory-public-knowledge-migration-plan.md`
+- `docs/solutions/developer-experience/global-knowledge-repository-infrastructure-2026-04-20.md`
+- `docs/solutions/integration-issues/hkt-memory-install-to-path-2026-04-23.md`
+- `src/memory/public-root.ts`
+- `src/memory/migration.ts`
+- `src/memory/hkt-client.ts`
+- `cmd/gale-memory/index.ts`
+- `cmd/gale-knowledge/rebuild-index.ts`
+- `tests/hktmemory-public-knowledge-migration.test.ts`

--- a/plugins/galeharness-cli/README.md
+++ b/plugins/galeharness-cli/README.md
@@ -14,7 +14,9 @@ Gale-managed memory calls use `gale-memory` as the runtime boundary. By default,
 ~/.galeharness/knowledge/<project>/hkt-memory
 ```
 
-Run `gale-memory status` to see the active root, source, and migration state. Existing project-local `memory/` directories are copied into the public root on first Gale-managed use, but they are not deleted or renamed. The copy-first migration preserves Markdown memories and the migration manifest while skipping derived caches such as `*.db`, vector stores, session transcript indexes, and `_lifecycle/events.jsonl`.
+Run `gale-memory status` to see the active root, source, and migration state. `status` only diagnoses; it does not copy legacy files.
+
+Existing project-local `memory/` directories are copied into the public root by `gale-memory migrate` or task runtime on first migrating use, but they are not deleted or renamed. The copy-first migration preserves Markdown memories and the migration manifest while skipping derived caches such as `*.db`, vector stores, session transcript indexes, and `_lifecycle/events.jsonl`.
 
 Override order: `gale-memory --memory-dir`, existing `HKT_MEMORY_DIR`, `memory.hkt_memory_dir` in `~/.galeharness/config.{json,yaml}`, then the derived public root. Bare `hkt-memory` keeps its upstream default path behavior; use `gale-memory` or set `HKT_MEMORY_DIR` when you want the public knowledge root.
 

--- a/plugins/galeharness-cli/README.md
+++ b/plugins/galeharness-cli/README.md
@@ -6,6 +6,18 @@ AI-powered development tools that get smarter with every use. Make each unit of 
 
 After installing, run `/gh:setup` in any project. It diagnoses your environment, installs missing tools, and bootstraps project config in one interactive flow.
 
+## HKTMemory Public Knowledge Root
+
+Gale-managed memory calls use `gale-memory` as the runtime boundary. By default, task memory resolves to:
+
+```text
+~/.galeharness/knowledge/<project>/hkt-memory
+```
+
+Run `gale-memory status` to see the active root, source, and migration state. Existing project-local `memory/` directories are copied into the public root on first Gale-managed use, but they are not deleted or renamed. The copy-first migration preserves Markdown memories and the migration manifest while skipping derived caches such as `*.db`, vector stores, session transcript indexes, and `_lifecycle/events.jsonl`.
+
+Override order: `gale-memory --memory-dir`, existing `HKT_MEMORY_DIR`, `memory.hkt_memory_dir` in `~/.galeharness/config.{json,yaml}`, then the derived public root. Bare `hkt-memory` keeps its upstream default path behavior; use `gale-memory` or set `HKT_MEMORY_DIR` when you want the public knowledge root.
+
 ## Document Language
 
 Control the output language for workflow skills via `.compound-engineering/config.local.yaml`:

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -120,7 +120,9 @@ Before Phase 1, query the vector memory database for related brainstorms and req
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -322,7 +324,9 @@ After successfully writing or updating the requirements document:
 2. Extract `title` and `category` values from its YAML frontmatter (if present)
 3. Run:
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory store \
      --content "<summary + repo-relative file path>" \
      --title "<frontmatter title or filename>" \
      --topic "<frontmatter category or 'brainstorm'>" \

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -120,7 +120,7 @@ Before Phase 1, query the vector memory database for related brainstorms and req
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory retrieve \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -322,7 +322,7 @@ After successfully writing or updating the requirements document:
 2. Extract `title` and `category` values from its YAML frontmatter (if present)
 3. Run:
    ```bash
-   hkt-memory store \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
      --content "<summary + repo-relative file path>" \
      --title "<frontmatter title or filename>" \
      --topic "<frontmatter category or 'brainstorm'>" \

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -90,7 +90,9 @@ Before Phase 0.5, query the vector memory database for related solutions:
 1. Extract a 1-2 sentence search query from: problem being documented, error messages, component names, fix approach
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -282,7 +284,9 @@ After successfully writing the solution doc to `docs/solutions/`:
 2. Extract `title` and `category` values from its YAML frontmatter
 3. Run:
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory store \
      --content "<summary + repo-relative file path>" \
      --title "<frontmatter title>" \
      --topic "<frontmatter category>" \

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -90,7 +90,7 @@ Before Phase 0.5, query the vector memory database for related solutions:
 1. Extract a 1-2 sentence search query from: problem being documented, error messages, component names, fix approach
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory retrieve \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -282,7 +282,7 @@ After successfully writing the solution doc to `docs/solutions/`:
 2. Extract `title` and `category` values from its YAML frontmatter
 3. Run:
    ```bash
-   hkt-memory store \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
      --content "<summary + repo-relative file path>" \
      --title "<frontmatter title>" \
      --topic "<frontmatter category>" \

--- a/plugins/galeharness-cli/skills/gh-debug-x/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug-x/SKILL.md
@@ -52,7 +52,7 @@ If the input references an issue tracker, fetch the issue when possible and extr
 Retrieve related bugs, root causes, implementation constraints, and prior Morph-X blueprint/strategy fingerprints:
 
 ```bash
-hkt-memory retrieve \
+HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
   --query "<error, symptom, iOS component, Swift/ObjC file, blueprint or strategy tags>" \
   --layer all --limit 10 --min-similarity 0.35 \
   --vector-weight 0.7 --bm25-weight 0.3
@@ -67,7 +67,7 @@ Use results as context only. They may inform hypotheses and blueprint constraint
 Search related historical debug sessions:
 
 ```bash
-hkt-memory session-search \
+HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory session-search \
   --query "gh:debug-x <error message or bug summary>" \
   --limit 5
 ```
@@ -144,7 +144,7 @@ After the fix is implemented:
 After diagnosis, or after the fix and Morph-X audit when a fix was applied, store a concise memory record:
 
 ```bash
-hkt-memory store \
+HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
   --content "<bug, root cause, fix or diagnosis-only result, repo-relative files, blueprint constraints, strategy fingerprint, audit status, degraded fallback notes>" \
   --title "<debug-x bug title>" \
   --topic "debug-x morph blueprint strategy fingerprint" \

--- a/plugins/galeharness-cli/skills/gh-debug-x/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug-x/SKILL.md
@@ -52,7 +52,9 @@ If the input references an issue tracker, fetch the issue when possible and extr
 Retrieve related bugs, root causes, implementation constraints, and prior Morph-X blueprint/strategy fingerprints:
 
 ```bash
-HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+hkt-memory retrieve \
   --query "<error, symptom, iOS component, Swift/ObjC file, blueprint or strategy tags>" \
   --layer all --limit 10 --min-similarity 0.35 \
   --vector-weight 0.7 --bm25-weight 0.3
@@ -67,7 +69,9 @@ Use results as context only. They may inform hypotheses and blueprint constraint
 Search related historical debug sessions:
 
 ```bash
-HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory session-search \
+memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+hkt-memory session-search \
   --query "gh:debug-x <error message or bug summary>" \
   --limit 5
 ```
@@ -144,7 +148,9 @@ After the fix is implemented:
 After diagnosis, or after the fix and Morph-X audit when a fix was applied, store a concise memory record:
 
 ```bash
-HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+hkt-memory store \
   --content "<bug, root cause, fix or diagnosis-only result, repo-relative files, blueprint constraints, strategy fingerprint, audit status, degraded fallback notes>" \
   --title "<debug-x bug title>" \
   --topic "debug-x morph blueprint strategy fingerprint" \

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -119,7 +119,7 @@ Before Phase 1, query the vector memory database for related ideation and improv
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory retrieve \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -214,7 +214,7 @@ After the ideation artifact is written to `docs/ideation/`:
 2. Extract the title and key themes from the frontmatter/content
 3. Run:
    ```bash
-   hkt-memory store \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
      --content "<full ideation document>" \
      --title "Ideation: [document title]" \
      --topic "ideation" \

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -119,7 +119,9 @@ Before Phase 1, query the vector memory database for related ideation and improv
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -214,7 +216,9 @@ After the ideation artifact is written to `docs/ideation/`:
 2. Extract the title and key themes from the frontmatter/content
 3. Run:
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory store \
      --content "<full ideation document>" \
      --title "Ideation: [document title]" \
      --topic "ideation" \

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -196,7 +196,9 @@ Before Phase 1, query the vector memory database for related plans and requireme
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -905,7 +907,9 @@ After the plan file is finalized and document review has run:
 2. Extract `title` and `type` values from its YAML frontmatter
 3. Run:
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory store \
      --content "<summary + repo-relative file path>" \
      --title "<frontmatter title>" \
      --topic "<frontmatter type or 'plan'>" \

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -196,7 +196,7 @@ Before Phase 1, query the vector memory database for related plans and requireme
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory retrieve \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -905,7 +905,7 @@ After the plan file is finalized and document review has run:
 2. Extract `title` and `type` values from its YAML frontmatter
 3. Run:
    ```bash
-   hkt-memory store \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
      --content "<summary + repo-relative file path>" \
      --title "<frontmatter title>" \
      --topic "<frontmatter type or 'plan'>" \

--- a/plugins/galeharness-cli/skills/gh-review/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-review/SKILL.md
@@ -183,7 +183,9 @@ Before Stage 1, query the vector memory database for related code review context
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -691,7 +693,9 @@ After the review is complete and findings have been synthesized:
 
 2. Run:
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory store \
      --content "<review summary>" \
      --title "Code Review: [PR title or branch name]" \
      --topic "code-review" \

--- a/plugins/galeharness-cli/skills/gh-review/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-review/SKILL.md
@@ -183,7 +183,7 @@ Before Stage 1, query the vector memory database for related code review context
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory retrieve \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -691,7 +691,7 @@ After the review is complete and findings have been synthesized:
 
 2. Run:
    ```bash
-   hkt-memory store \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
      --content "<review summary>" \
      --title "Code Review: [PR title or branch name]" \
      --topic "code-review" \

--- a/plugins/galeharness-cli/skills/gh-work-x/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work-x/SKILL.md
@@ -46,7 +46,9 @@ If `gale-task` is unavailable, skip silently. This must never block execution.
 Before choosing a blueprint, retrieve related implementation context and historical Morph-X fingerprints:
 
 ```bash
-HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+hkt-memory retrieve \
   --query "<task summary, iOS components, Swift/ObjC files, prior blueprint or strategy tags>" \
   --layer all --limit 10 --min-similarity 0.35 \
   --vector-weight 0.7 --bm25-weight 0.3
@@ -61,7 +63,9 @@ Use results only as context: extract constraints, avoided patterns, and prior bl
 Query related work sessions:
 
 ```bash
-HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory session-search \
+memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+hkt-memory session-search \
   --query "gh:work-x <task title or iOS feature summary>" \
   --limit 5
 ```
@@ -148,7 +152,9 @@ After Swift/ObjC code is produced and before final summary:
 After implementation and Morph-X audit, store a concise memory record:
 
 ```bash
-HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+hkt-memory store \
   --content "<summary with repo-relative files, blueprint constraints, strategy fingerprint, audit status, degraded fallback notes>" \
   --title "<work-x title>" \
   --topic "work-x morph blueprint strategy fingerprint" \

--- a/plugins/galeharness-cli/skills/gh-work-x/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work-x/SKILL.md
@@ -46,7 +46,7 @@ If `gale-task` is unavailable, skip silently. This must never block execution.
 Before choosing a blueprint, retrieve related implementation context and historical Morph-X fingerprints:
 
 ```bash
-hkt-memory retrieve \
+HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
   --query "<task summary, iOS components, Swift/ObjC files, prior blueprint or strategy tags>" \
   --layer all --limit 10 --min-similarity 0.35 \
   --vector-weight 0.7 --bm25-weight 0.3
@@ -61,7 +61,7 @@ Use results only as context: extract constraints, avoided patterns, and prior bl
 Query related work sessions:
 
 ```bash
-hkt-memory session-search \
+HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory session-search \
   --query "gh:work-x <task title or iOS feature summary>" \
   --limit 5
 ```
@@ -148,7 +148,7 @@ After Swift/ObjC code is produced and before final summary:
 After implementation and Morph-X audit, store a concise memory record:
 
 ```bash
-hkt-memory store \
+HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
   --content "<summary with repo-relative files, blueprint constraints, strategy fingerprint, audit status, degraded fallback notes>" \
   --title "<work-x title>" \
   --topic "work-x morph blueprint strategy fingerprint" \

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -69,7 +69,7 @@ Before Phase 1, query the vector memory database for related execution context:
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory retrieve \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -100,7 +100,7 @@ In addition to vector retrieval, query related historical work session records:
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   hkt-memory session-search \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory session-search \
      --query "<skill name: gh:work — task title or feature description>" \
      --limit 5
    ```
@@ -398,7 +398,7 @@ After the work is complete and the shipping workflow has finished (PR created or
 
 2. Run:
    ```bash
-   hkt-memory store \
+   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
      --content "<execution summary with context>" \
      --title "Work: [plan title or feature description]" \
      --topic "work-execution" \

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -69,7 +69,9 @@ Before Phase 1, query the vector memory database for related execution context:
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory retrieve \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory retrieve \
      --query "<extracted query>" \
      --layer all --limit 10 --min-similarity 0.35 \
      --vector-weight 0.7 --bm25-weight 0.3
@@ -100,7 +102,9 @@ In addition to vector retrieval, query related historical work session records:
 
 2. Run (requires env vars HKT_MEMORY_API_KEY, HKT_MEMORY_BASE_URL, HKT_MEMORY_MODEL):
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory session-search \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory session-search \
      --query "<skill name: gh:work — task title or feature description>" \
      --limit 5
    ```
@@ -398,7 +402,9 @@ After the work is complete and the shipping workflow has finished (PR created or
 
 2. Run:
    ```bash
-   HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)" hkt-memory store \
+   memory_root="$(gale-memory resolve-root 2>/dev/null || true)"
+   [ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"
+   hkt-memory store \
      --content "<execution summary with context>" \
      --title "Work: [plan title or feature description]" \
      --topic "work-execution" \

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -134,4 +134,9 @@ Then verify:
 
   gale-harness --version
   gale-harness update --check
+  gale-memory status
+
+Gale-managed HKTMemory uses ~/.galeharness/knowledge/<project>/hkt-memory by default.
+If hkt-memory is not on PATH, gale-memory status/start will report a diagnostic instead
+of failing the binary install.
 EOF

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -189,21 +189,14 @@ try {
 }
 
 # =====================================================
-#  6. HKTMemory Directory Structure
+#  6. HKTMemory Public Knowledge Root
 # =====================================================
-header "6. 创建 HKTMemory 目录结构"
+header "6. 配置 Gale-managed HKTMemory 公共知识库路径"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 Set-Location $repoRoot
 
-New-Item -ItemType Directory -Force -Path "memory/L0-Abstract/topics" | Out-Null
-New-Item -ItemType Directory -Force -Path "memory/L1-Overview/topics" | Out-Null
-New-Item -ItemType Directory -Force -Path "memory/L2-Full/daily" | Out-Null
-New-Item -ItemType Directory -Force -Path "memory/L2-Full/evergreen" | Out-Null
-New-Item -ItemType Directory -Force -Path "memory/L2-Full/episodes" | Out-Null
-New-Item -ItemType File -Force -Path "memory/L0-Abstract/index.md" | Out-Null
-New-Item -ItemType File -Force -Path "memory/L1-Overview/index.md" | Out-Null
-New-Item -ItemType File -Force -Path "memory/L2-Full/evergreen/MEMORY.md" | Out-Null
-ok "HKTMemory 目录结构就绪"
+info "Gale-managed HKTMemory now uses ~/.galeharness/knowledge/<project>/hkt-memory by default."
+info "Project-local memory/ is left untouched as a legacy backup for bare hkt-memory commands."
 
 # ── HKTMemory CLI installation (Windows) ──
 Write-Host ""
@@ -445,8 +438,11 @@ if ($CI_MODE) {
   gale-memory --help
     -> 期望: 显示 task memory helper 帮助信息
 
+  gale-memory status
+    -> 期望: 输出 Gale-managed HKTMemory 公共知识库路径和迁移状态
+
   hkt-memory stats
-    -> 期望: HKTMemory 统计信息
+    -> 期望: HKTMemory 统计信息（裸命令仍使用自身默认路径，必要时设置 HKT_MEMORY_DIR）
 
   bun test
     -> 期望: 测试通过

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -178,21 +178,14 @@ else
 fi
 
 # =====================================================
-#  6. HKTMemory Directory Structure
+#  6. HKTMemory Public Knowledge Root
 # =====================================================
-header "6. 创建 HKTMemory 目录结构"
+header "6. 配置 Gale-managed HKTMemory 公共知识库路径"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-mkdir -p memory/L0-Abstract/topics
-mkdir -p memory/L1-Overview/topics
-mkdir -p memory/L2-Full/daily
-mkdir -p memory/L2-Full/evergreen
-mkdir -p memory/L2-Full/episodes
-touch memory/L0-Abstract/index.md
-touch memory/L1-Overview/index.md
-touch memory/L2-Full/evergreen/MEMORY.md
-ok "HKTMemory 目录结构就绪"
+info "Gale-managed HKTMemory now uses ~/.galeharness/knowledge/<project>/hkt-memory by default."
+info "Project-local memory/ is left untouched as a legacy backup for bare hkt-memory commands."
 
 # ── HKTMemory CLI installation ──
 echo ""
@@ -378,8 +371,11 @@ ${BOLD}  自检清单 — 配置生效后，依次运行以下命令验证:${NC}
   ${CYAN}gale-memory --help${NC}
     → 期望: 显示 task memory helper 帮助信息
 
+  ${CYAN}gale-memory status${NC}
+    → 期望: 输出 Gale-managed HKTMemory 公共知识库路径和迁移状态
+
   ${CYAN}hkt-memory stats${NC}
-    → 期望: HKTMemory 统计信息
+    → 期望: HKTMemory 统计信息（裸命令仍使用自身默认路径，必要时设置 HKT_MEMORY_DIR）
 
   ${CYAN}bun test${NC}
     → 期望: 测试通过

--- a/scripts/upstream-sync/sync-cli.py
+++ b/scripts/upstream-sync/sync-cli.py
@@ -172,6 +172,11 @@ def run_cmd_checked(
     return result
 
 
+def gh_argv(*args: str) -> List[str]:
+    """Return a GitHub CLI argv, allowing tests to bypass platform PATH lookup."""
+    return [os.environ.get("GALE_SYNC_GH_BIN", "gh"), *args]
+
+
 # ---------------------------------------------------------------------------
 # Utility: main worktree root resolution
 # ---------------------------------------------------------------------------
@@ -747,14 +752,14 @@ def cmd_next(args: argparse.Namespace) -> int:
             f"- Baseline: `{state.baseline_sha[:7]}`\n"
         )
         result = run_cmd(
-            [
-                "gh", "pr", "create",
+            gh_argv(
+                "pr", "create",
                 "--base", state.base_branch,
                 "--head", branch_name,
                 "--title", pr_title,
                 "--body", pr_body,
                 "--repo", state.github_repo,
-            ],
+            ),
             wt_path,
         )
         if result.returncode != 0:
@@ -982,14 +987,14 @@ def _resume_from_failed(state: SyncState, state_path: Path, dry_run: bool) -> in
                     f"- Sequence: {commit.sequence}/{len(state.commits)}\n"
                 )
                 result = run_cmd(
-                    [
-                        "gh", "pr", "create",
+                    gh_argv(
+                        "pr", "create",
                         "--base", state.base_branch,
                         "--head", commit.branch,
                         "--title", pr_title,
                         "--body", pr_body,
                         "--repo", state.github_repo,
-                    ],
+                    ),
                     wt_path,
                 )
                 if result.returncode != 0:
@@ -1040,11 +1045,11 @@ def _resume_from_review(state: SyncState, state_path: Path, dry_run: bool) -> in
 
     # Query PR status
     result = run_cmd(
-        [
-            "gh", "pr", "view", str(commit.pr_number),
+        gh_argv(
+            "pr", "view", str(commit.pr_number),
             "--repo", state.github_repo,
             "--json", "state,mergedAt,url,number,headRefName,baseRefName",
-        ],
+        ),
         main_root_path,
     )
     if result.returncode != 0:
@@ -1330,11 +1335,11 @@ def _verify_cleanup_pr_target(state: SyncState, commit: CommitEntry, main_root_p
         return False
 
     result = run_cmd(
-        [
-            "gh", "pr", "view", str(commit.pr_number),
+        gh_argv(
+            "pr", "view", str(commit.pr_number),
             "--repo", state.github_repo,
             "--json", "state,number,headRefName,baseRefName,headRepository",
-        ],
+        ),
         main_root_path,
     )
     if result.returncode != 0:

--- a/src/memory/hkt-client.ts
+++ b/src/memory/hkt-client.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
 
 export interface HktClientOptions {
   binary?: string
@@ -58,7 +60,8 @@ export class HktClient {
         resolve(result)
       }
 
-      const proc = spawn(this.binary, args, {
+      const command = resolveExecutableCommand(this.binary, args)
+      const proc = spawn(command.executable, command.args, {
         cwd: this.cwd,
         stdio: ["ignore", "pipe", "pipe"],
         env: this.memoryDir ? { ...process.env, HKT_MEMORY_DIR: this.memoryDir } : { ...process.env },
@@ -117,5 +120,34 @@ export function skippedResult(reason: string): HktTaskResult {
     injectable_markdown: "",
     items: [],
     diagnostics: { blocked: [], omitted_sources: [] },
+  }
+}
+
+function resolveExecutableCommand(executable: string, args: string[]): { executable: string; args: string[] } {
+  if (process.platform !== "win32" || !isPathLike(executable)) {
+    return { executable, args }
+  }
+
+  if (shouldRunWithBun(executable)) {
+    return { executable: process.execPath, args: [executable, ...args] }
+  }
+
+  return { executable, args }
+}
+
+function isPathLike(executable: string): boolean {
+  return path.isAbsolute(executable) || executable.includes("/") || executable.includes("\\")
+}
+
+function shouldRunWithBun(executable: string): boolean {
+  const ext = path.extname(executable).toLowerCase()
+  if ([".js", ".mjs", ".cjs", ".ts"].includes(ext)) return true
+  if (!existsSync(executable)) return false
+
+  try {
+    const firstLine = readFileSync(executable, "utf8").split(/\r?\n/, 1)[0] ?? ""
+    return firstLine.startsWith("#!") && /\b(?:bun|node)\b/.test(firstLine)
+  } catch {
+    return false
   }
 }

--- a/src/memory/hkt-client.ts
+++ b/src/memory/hkt-client.ts
@@ -4,6 +4,8 @@ export interface HktClientOptions {
   binary?: string
   cwd?: string
   timeoutMs?: number
+  memoryDir?: string
+  diagnostics?: Record<string, unknown>
 }
 
 export interface HktTaskResult {
@@ -21,11 +23,15 @@ export class HktClient {
   private binary: string
   private cwd: string
   private timeoutMs: number
+  private memoryDir?: string
+  private diagnostics: Record<string, unknown>
 
   constructor(options: HktClientOptions = {}) {
     this.binary = options.binary ?? process.env.HKT_MEMORY_BIN ?? "hkt-memory"
     this.cwd = options.cwd ?? process.cwd()
     this.timeoutMs = options.timeoutMs ?? 5000
+    this.memoryDir = options.memoryDir
+    this.diagnostics = options.diagnostics ?? {}
   }
 
   taskRecall(envelope: Record<string, unknown>, limit = 5): Promise<HktTaskResult> {
@@ -55,11 +61,12 @@ export class HktClient {
       const proc = spawn(this.binary, args, {
         cwd: this.cwd,
         stdio: ["ignore", "pipe", "pipe"],
+        env: this.memoryDir ? { ...process.env, HKT_MEMORY_DIR: this.memoryDir } : { ...process.env },
       })
 
       const timer = setTimeout(() => {
         proc.kill("SIGKILL")
-        finish(skippedResult(`hkt-memory timed out after ${this.timeoutMs}ms`))
+        finish(this.withDiagnostics(skippedResult(`hkt-memory timed out after ${this.timeoutMs}ms`)))
       }, this.timeoutMs)
 
       proc.stdout.on("data", (chunk: Buffer) => {
@@ -70,23 +77,34 @@ export class HktClient {
       })
       proc.on("error", (err) => {
         clearTimeout(timer)
-        finish(skippedResult(`hkt-memory unavailable: ${err.message}`))
+        finish(this.withDiagnostics(skippedResult(`hkt-memory unavailable: ${err.message}`)))
       })
       proc.on("close", (code) => {
         clearTimeout(timer)
         if (settled) return
         if (code !== 0) {
-          finish(skippedResult(`hkt-memory exited ${code}: ${stderr.trim()}`.trim()))
+          finish(this.withDiagnostics(skippedResult(`hkt-memory exited ${code}: ${stderr.trim()}`.trim())))
           return
         }
         try {
           const parsed = JSON.parse(stdout) as HktTaskResult
-          finish(parsed)
+          finish(this.withDiagnostics(parsed))
         } catch {
-          finish(skippedResult("hkt-memory returned malformed JSON"))
+          finish(this.withDiagnostics(skippedResult("hkt-memory returned malformed JSON")))
         }
       })
     })
+  }
+
+  private withDiagnostics(result: HktTaskResult): HktTaskResult {
+    return {
+      ...result,
+      diagnostics: {
+        ...(result.diagnostics ?? {}),
+        ...this.diagnostics,
+        memory_dir: this.memoryDir ?? process.env.HKT_MEMORY_DIR ?? null,
+      },
+    }
   }
 }
 

--- a/src/memory/migration.ts
+++ b/src/memory/migration.ts
@@ -30,7 +30,7 @@ const CONFLICTS = "MIGRATION_CONFLICTS.md"
 const RULE_VERSION = 1
 
 const HKT_DIR_HINTS = ["L0-Abstract", "L1-Overview", "L2-Full"]
-const ALLOWED_EXTENSIONS = new Set([".md", ".json"])
+const ALLOWED_EXTENSIONS = new Set([".md"])
 const ALLOWED_BASENAMES = new Set([MANIFEST])
 const SKIPPED_PARTS = new Set([
   ".git",

--- a/src/memory/migration.ts
+++ b/src/memory/migration.ts
@@ -1,0 +1,234 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import path from "node:path"
+import { ensurePublicMemoryRoot } from "./public-root.js"
+
+export type MigrationStatus = "none" | "completed" | "migration-conflict" | "failed"
+
+export interface MemoryMigrationResult {
+  status: MigrationStatus
+  sourceDir: string
+  targetDir: string
+  copied: number
+  skipped: number
+  conflicted: number
+  conflicts: string[]
+  manifestPath: string
+  conflictReportPath?: string
+  reason?: string
+}
+
+const MANIFEST = ".gale-migration-manifest.json"
+const CONFLICTS = "MIGRATION_CONFLICTS.md"
+const RULE_VERSION = 1
+
+const HKT_DIR_HINTS = ["L0-Abstract", "L1-Overview", "L2-Full"]
+const ALLOWED_EXTENSIONS = new Set([".md", ".json"])
+const ALLOWED_BASENAMES = new Set([MANIFEST])
+const SKIPPED_PARTS = new Set([
+  ".git",
+  ".cache",
+  "cache",
+  "tmp",
+  "temp",
+  "vector_store",
+  "vector-index",
+  "__pycache__",
+])
+const SKIPPED_BASENAMES = new Set([
+  "vector_store.db",
+  "bm25_index.db",
+  "entity_index.db",
+  "session_transcript_index.db",
+  "events.jsonl",
+])
+
+export function localMemoryDir(cwd: string): string {
+  return path.join(cwd, "memory")
+}
+
+export function isLegacyHktMemoryDir(memoryDir: string): boolean {
+  return existsSync(memoryDir) && HKT_DIR_HINTS.some((dir) => existsSync(path.join(memoryDir, dir)))
+}
+
+export function migrateLegacyMemory(options: { cwd: string; targetDir: string }): MemoryMigrationResult {
+  const sourceDir = localMemoryDir(options.cwd)
+  const targetDir = options.targetDir
+  const manifestPath = path.join(targetDir, MANIFEST)
+
+  if (!isLegacyHktMemoryDir(sourceDir)) {
+    ensurePublicMemoryRoot(targetDir)
+    return {
+      status: "none",
+      sourceDir,
+      targetDir,
+      copied: 0,
+      skipped: 0,
+      conflicted: 0,
+      conflicts: [],
+      manifestPath,
+    }
+  }
+
+  try {
+    ensurePublicMemoryRoot(targetDir)
+    const files = collectMigratableFiles(sourceDir)
+    let copied = 0
+    let skipped = 0
+    const conflicts: string[] = []
+
+    for (const rel of files) {
+      const source = path.join(sourceDir, rel)
+      const target = path.join(targetDir, rel)
+      if (!existsSync(target)) {
+        mkdirSync(path.dirname(target), { recursive: true })
+        copyFileSync(source, target)
+        copied++
+        continue
+      }
+      const sourceContent = readFileSync(source, "utf8")
+      const targetContent = readFileSync(target, "utf8")
+      if (sourceContent === targetContent) {
+        skipped++
+      } else if (targetContent === "" && isScaffoldFile(rel)) {
+        copyFileSync(source, target)
+        copied++
+      } else {
+        conflicts.push(rel)
+      }
+    }
+
+    const status: MigrationStatus = conflicts.length > 0 ? "migration-conflict" : "completed"
+    const result: MemoryMigrationResult = {
+      status,
+      sourceDir,
+      targetDir,
+      copied,
+      skipped,
+      conflicted: conflicts.length,
+      conflicts,
+      manifestPath,
+      conflictReportPath: conflicts.length > 0 ? path.join(targetDir, CONFLICTS) : undefined,
+    }
+    writeManifest(result)
+    if (conflicts.length > 0) writeConflictReport(result)
+    return result
+  } catch (err) {
+    return {
+      status: "failed",
+      sourceDir,
+      targetDir,
+      copied: 0,
+      skipped: 0,
+      conflicted: 0,
+      conflicts: [],
+      manifestPath,
+      reason: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function isScaffoldFile(rel: string): boolean {
+  return rel === path.join("L0-Abstract", "index.md") ||
+    rel === path.join("L1-Overview", "index.md") ||
+    rel === path.join("L2-Full", "evergreen", "MEMORY.md")
+}
+
+export function readMigrationManifest(targetDir: string): Record<string, unknown> | null {
+  try {
+    const manifestPath = path.join(targetDir, MANIFEST)
+    if (!existsSync(manifestPath)) return null
+    return JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+export function migrationStatus(cwd: string, targetDir: string): "global" | "legacy-local" | "migration-needed" | "migrated" | "migration-conflict" {
+  const manifest = readMigrationManifest(targetDir)
+  if (manifest?.status === "migration-conflict") return "migration-conflict"
+  if (manifest?.status === "completed") return "migrated"
+  if (isLegacyHktMemoryDir(localMemoryDir(cwd))) {
+    return existsSync(targetDir) ? "migration-needed" : "legacy-local"
+  }
+  return "global"
+}
+
+function collectMigratableFiles(root: string, dir = root): string[] {
+  const files: string[] = []
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return files
+  }
+
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    const rel = path.relative(root, full)
+    const parts = rel.split(path.sep)
+    if (parts.some((part) => SKIPPED_PARTS.has(part))) continue
+    if (entry.isSymbolicLink()) continue
+    if (entry.isDirectory()) {
+      files.push(...collectMigratableFiles(root, full))
+      continue
+    }
+    if (!entry.isFile() || shouldSkipFile(full, entry.name)) continue
+    if (statSync(full).size > 5 * 1024 * 1024) continue
+    files.push(rel)
+  }
+  return files.sort()
+}
+
+function shouldSkipFile(filePath: string, basename: string): boolean {
+  if (SKIPPED_BASENAMES.has(basename)) return true
+  if (basename.endsWith(".db") || basename.endsWith(".db-shm") || basename.endsWith(".db-wal")) return true
+  if (basename.endsWith(".jsonl")) return true
+  const ext = path.extname(filePath)
+  return !ALLOWED_EXTENSIONS.has(ext) && !ALLOWED_BASENAMES.has(basename)
+}
+
+function writeManifest(result: MemoryMigrationResult): void {
+  writeFileSync(
+    result.manifestPath,
+    JSON.stringify(
+      {
+        rule_version: RULE_VERSION,
+        status: result.status,
+        source_path: result.sourceDir,
+        target_path: result.targetDir,
+        migrated_at: new Date().toISOString(),
+        copied: result.copied,
+        skipped: result.skipped,
+        conflicted: result.conflicted,
+        conflicts: result.conflicts,
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf8",
+  )
+}
+
+function writeConflictReport(result: MemoryMigrationResult): void {
+  if (!result.conflictReportPath) return
+  const lines = [
+    "# HKTMemory Migration Conflicts",
+    "",
+    "The copy-first migration did not overwrite these target files because their contents differ.",
+    "",
+    `Source: ${result.sourceDir}`,
+    `Target: ${result.targetDir}`,
+    "",
+    ...result.conflicts.map((file) => `- ${file}`),
+    "",
+  ]
+  writeFileSync(result.conflictReportPath, lines.join("\n"), "utf8")
+}

--- a/src/memory/migration.ts
+++ b/src/memory/migration.ts
@@ -136,9 +136,9 @@ export function migrateLegacyMemory(options: { cwd: string; targetDir: string })
 }
 
 function isScaffoldFile(rel: string): boolean {
-  return rel === path.join("L0-Abstract", "index.md") ||
-    rel === path.join("L1-Overview", "index.md") ||
-    rel === path.join("L2-Full", "evergreen", "MEMORY.md")
+  return rel === "L0-Abstract/index.md" ||
+    rel === "L1-Overview/index.md" ||
+    rel === "L2-Full/evergreen/MEMORY.md"
 }
 
 export function readMigrationManifest(targetDir: string): Record<string, unknown> | null {
@@ -173,6 +173,7 @@ function collectMigratableFiles(root: string, dir = root): string[] {
   for (const entry of entries) {
     const full = path.join(dir, entry.name)
     const rel = path.relative(root, full)
+    const displayRel = rel.split(path.sep).join("/")
     const parts = rel.split(path.sep)
     if (parts.some((part) => SKIPPED_PARTS.has(part))) continue
     if (entry.isSymbolicLink()) continue
@@ -182,7 +183,7 @@ function collectMigratableFiles(root: string, dir = root): string[] {
     }
     if (!entry.isFile() || shouldSkipFile(full, entry.name)) continue
     if (statSync(full).size > 5 * 1024 * 1024) continue
-    files.push(rel)
+    files.push(displayRel)
   }
   return files.sort()
 }

--- a/src/memory/public-root.ts
+++ b/src/memory/public-root.ts
@@ -1,0 +1,137 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+import yaml from "js-yaml"
+import { extractProjectName, resolveKnowledgeHome, sanitizePathComponent } from "../knowledge/home.js"
+
+export type MemoryRootSource = "explicit" | "env" | "config" | "derived"
+
+export interface ResolvePublicMemoryRootOptions {
+  cwd?: string
+  project?: string
+  memoryDir?: string
+}
+
+export interface PublicMemoryRoot {
+  project: string
+  knowledgeHome: string
+  memoryDir: string
+  source: MemoryRootSource
+  diagnostics: Record<string, unknown>
+}
+
+const CONFIG_JSON = path.join(homedir(), ".galeharness", "config.json")
+const CONFIG_YAML = path.join(homedir(), ".galeharness", "config.yaml")
+
+const STANDARD_DIRS = [
+  "L0-Abstract/topics",
+  "L1-Overview/topics",
+  "L2-Full/daily",
+  "L2-Full/evergreen",
+  "L2-Full/episodes",
+]
+
+const STANDARD_FILES = [
+  "L0-Abstract/index.md",
+  "L1-Overview/index.md",
+  "L2-Full/evergreen/MEMORY.md",
+]
+
+export function resolvePublicMemoryRoot(options: ResolvePublicMemoryRootOptions = {}): PublicMemoryRoot {
+  const cwd = options.cwd ?? process.cwd()
+  const project = sanitizePathComponent(options.project ?? extractProjectName(cwd))
+  const knowledgeHome = resolveKnowledgeHome()
+
+  if (options.memoryDir) {
+    return root(project, knowledgeHome, options.memoryDir, "explicit")
+  }
+
+  if (process.env.HKT_MEMORY_DIR) {
+    return root(project, knowledgeHome, process.env.HKT_MEMORY_DIR, "env")
+  }
+
+  const configured = readConfiguredMemoryDir()
+  if (configured) {
+    return root(project, knowledgeHome, configured, "config")
+  }
+
+  return root(project, knowledgeHome, path.join(knowledgeHome, project, "hkt-memory"), "derived")
+}
+
+export function ensurePublicMemoryRoot(memoryDir: string): void {
+  for (const dir of STANDARD_DIRS) {
+    mkdirSync(path.join(memoryDir, dir), { recursive: true })
+  }
+  for (const file of STANDARD_FILES) {
+    const filePath = path.join(memoryDir, file)
+    if (!existsSync(filePath)) {
+      mkdirSync(path.dirname(filePath), { recursive: true })
+      writeFileSync(filePath, "", "utf8")
+    }
+  }
+}
+
+export function standardMemoryPaths(): { dirs: string[]; files: string[] } {
+  return { dirs: [...STANDARD_DIRS], files: [...STANDARD_FILES] }
+}
+
+export function resolveKnowledgeIndexMemoryRoot(): string {
+  const configured = readConfiguredKnowledgeIndexDir()
+  return path.resolve(configured ?? path.join(homedir(), ".galeharness", "vector-index", "knowledge-repo"))
+}
+
+function root(project: string, knowledgeHome: string, memoryDir: string, source: MemoryRootSource): PublicMemoryRoot {
+  return {
+    project,
+    knowledgeHome,
+    memoryDir: path.resolve(memoryDir),
+    source,
+    diagnostics: {
+      project,
+      knowledge_home: knowledgeHome,
+      memory_dir: path.resolve(memoryDir),
+      source,
+    },
+  }
+}
+
+function readConfiguredMemoryDir(): string | null {
+  const config = readGaleConfig()
+  const memory = config?.memory
+  if (memory && typeof memory === "object" && typeof (memory as Record<string, unknown>).hkt_memory_dir === "string") {
+    return (memory as Record<string, unknown>).hkt_memory_dir as string
+  }
+  return null
+}
+
+function readConfiguredKnowledgeIndexDir(): string | null {
+  const config = readGaleConfig()
+  const knowledge = config?.knowledge
+  if (
+    knowledge &&
+    typeof knowledge === "object" &&
+    typeof (knowledge as Record<string, unknown>).index_memory_dir === "string"
+  ) {
+    return (knowledge as Record<string, unknown>).index_memory_dir as string
+  }
+  return null
+}
+
+function readGaleConfig(): Record<string, unknown> | null {
+  if (existsSync(CONFIG_JSON)) {
+    try {
+      return JSON.parse(readFileSync(CONFIG_JSON, "utf8")) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+  if (existsSync(CONFIG_YAML)) {
+    try {
+      const parsed = yaml.load(readFileSync(CONFIG_YAML, "utf8"))
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}

--- a/src/memory/task-runtime.ts
+++ b/src/memory/task-runtime.ts
@@ -3,6 +3,8 @@ import { promises as fs } from "node:fs"
 import path from "node:path"
 import { randomUUID } from "node:crypto"
 import { HktClient, type HktTaskResult } from "./hkt-client.js"
+import { migrateLegacyMemory, migrationStatus } from "./migration.js"
+import { ensurePublicMemoryRoot, resolvePublicMemoryRoot, type PublicMemoryRoot } from "./public-root.js"
 
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
 
@@ -55,6 +57,7 @@ export interface BuildEnvelopeOptions {
   prId?: string | null
   issueId?: string | null
   capturePolicy?: string[]
+  memoryDir?: string
 }
 
 export interface CaptureOptions extends BuildEnvelopeOptions {
@@ -98,18 +101,21 @@ export async function buildTaskEnvelope(options: BuildEnvelopeOptions): Promise<
 
 export async function startTaskMemory(
   options: BuildEnvelopeOptions,
-  client: Pick<HktClient, "taskRecall"> = new HktClient({ cwd: options.cwd }),
+  client?: Pick<HktClient, "taskRecall">,
 ): Promise<{ envelope: TaskEnvelope; recall: HktTaskResult }> {
   const envelope = await buildTaskEnvelope({ ...options, phase: options.phase ?? "start" })
-  const recall = await client.taskRecall(envelope)
+  const memory = prepareTaskMemory(options)
+  const hktClient = client ?? new HktClient({ cwd: options.cwd, memoryDir: memory.root.memoryDir, diagnostics: memory.diagnostics })
+  const recall = withMemoryDiagnostics(await hktClient.taskRecall(envelope as unknown as Record<string, unknown>), memory.diagnostics)
   return { envelope, recall }
 }
 
 export async function captureTaskMemory(
   options: CaptureOptions,
-  client: Pick<HktClient, "taskCapture"> = new HktClient({ cwd: options.cwd }),
+  client?: Pick<HktClient, "taskCapture">,
 ): Promise<{ event: Record<string, unknown>; capture: HktTaskResult }> {
   const envelope = await buildTaskEnvelope(options)
+  const memory = prepareTaskMemory(options)
   const event = {
     ...envelope,
     event_type: options.eventType,
@@ -117,7 +123,8 @@ export async function captureTaskMemory(
     summary: options.summary ?? options.inputSummary ?? "",
     payload: options.payload ?? {},
   }
-  const capture = await client.taskCapture(event)
+  const hktClient = client ?? new HktClient({ cwd: options.cwd, memoryDir: memory.root.memoryDir, diagnostics: memory.diagnostics })
+  const capture = withMemoryDiagnostics(await hktClient.taskCapture(event), memory.diagnostics)
   if (capture.success && capture.durable_memory_id && capture.memory_link_required !== false) {
     await logMemoryLinked({
       cwd: options.cwd ?? process.cwd(),
@@ -131,7 +138,7 @@ export async function captureTaskMemory(
 
 export async function feedbackTaskMemory(
   options: BuildEnvelopeOptions & { label: string; memoryId?: string; note?: string; source?: string },
-  client: Pick<HktClient, "taskCapture"> = new HktClient({ cwd: options.cwd }),
+  client?: Pick<HktClient, "taskCapture">,
 ): Promise<{ event: Record<string, unknown>; capture: HktTaskResult }> {
   return captureTaskMemory(
     {
@@ -148,6 +155,35 @@ export async function feedbackTaskMemory(
     },
     client,
   )
+}
+
+export function prepareTaskMemory(options: Pick<BuildEnvelopeOptions, "cwd" | "project" | "memoryDir">): {
+  root: PublicMemoryRoot
+  diagnostics: Record<string, unknown>
+} {
+  const cwd = options.cwd ?? process.cwd()
+  const root = resolvePublicMemoryRoot({ cwd, project: options.project, memoryDir: options.memoryDir })
+  ensurePublicMemoryRoot(root.memoryDir)
+  const migration = root.source === "derived" ? migrateLegacyMemory({ cwd, targetDir: root.memoryDir }) : null
+  const status = migration?.status === "none" ? migrationStatus(cwd, root.memoryDir) : (migration?.status ?? migrationStatus(cwd, root.memoryDir))
+  return {
+    root,
+    diagnostics: {
+      ...root.diagnostics,
+      status,
+      migration,
+    },
+  }
+}
+
+function withMemoryDiagnostics(result: HktTaskResult, diagnostics: Record<string, unknown>): HktTaskResult {
+  return {
+    ...result,
+    diagnostics: {
+      ...(result.diagnostics ?? {}),
+      ...diagnostics,
+    },
+  }
 }
 
 async function readCurrentTask(filePath: string): Promise<CurrentTask | null> {

--- a/src/morph/swift-adapter.ts
+++ b/src/morph/swift-adapter.ts
@@ -46,7 +46,8 @@ export async function runSwiftAdapter(
     return adapterUnavailable(`Swift adapter executable not found: ${executable}`)
   }
 
-  const proc = Bun.spawn([executable], {
+  const command = resolveExecutableCommand(executable)
+  const proc = Bun.spawn(command, {
     cwd: options.cwd,
     stdin: "pipe",
     stdout: "pipe",
@@ -135,7 +136,7 @@ function readStringArray(value: unknown): string[] {
 }
 
 async function executableExists(executable: string): Promise<boolean> {
-  if (executable.includes(path.sep)) {
+  if (isPathLike(executable)) {
     try {
       await fs.access(executable, fs.constants.X_OK)
       return true
@@ -144,8 +145,23 @@ async function executableExists(executable: string): Promise<boolean> {
     }
   }
 
-  const proc = Bun.spawn(["which", executable], { stdout: "pipe", stderr: "pipe" })
+  const proc = Bun.spawn([process.platform === "win32" ? "where" : "which", executable], { stdout: "pipe", stderr: "pipe" })
   return (await proc.exited) === 0
+}
+
+function resolveExecutableCommand(executable: string): string[] {
+  if (process.platform === "win32" && isPathLike(executable) && shouldRunWithBun(executable)) {
+    return [process.execPath, executable]
+  }
+  return [executable]
+}
+
+function isPathLike(executable: string): boolean {
+  return path.isAbsolute(executable) || executable.includes("/") || executable.includes("\\")
+}
+
+function shouldRunWithBun(executable: string): boolean {
+  return [".js", ".mjs", ".cjs", ".ts"].includes(path.extname(executable).toLowerCase())
 }
 
 function adapterUnavailable(message: string): SwiftAdapterResult {

--- a/tests/gale-memory-migration.test.ts
+++ b/tests/gale-memory-migration.test.ts
@@ -18,12 +18,13 @@ describe("copy-first HKTMemory migration", () => {
     await rm(tmpDir, { recursive: true, force: true })
   })
 
-  test("copies markdown memory and skips derived databases", async () => {
+  test("copies markdown memory and skips derived databases and arbitrary json", async () => {
     await mkdir(path.join(tmpDir, "memory", "L0-Abstract"), { recursive: true })
     await mkdir(path.join(tmpDir, "memory", "L2-Full", "daily"), { recursive: true })
     await writeFile(path.join(tmpDir, "memory", "L0-Abstract", "index.md"), "abstract\n", "utf8")
     await writeFile(path.join(tmpDir, "memory", "L2-Full", "daily", "note.md"), "daily\n", "utf8")
     await writeFile(path.join(tmpDir, "memory", "vector_store.db"), "db", "utf8")
+    await writeFile(path.join(tmpDir, "memory", "state.json"), "{\"derived\":true}\n", "utf8")
 
     const result = migrateLegacyMemory({ cwd: tmpDir, targetDir })
 
@@ -31,8 +32,27 @@ describe("copy-first HKTMemory migration", () => {
     expect(existsSync(path.join(targetDir, "L0-Abstract", "index.md"))).toBe(true)
     expect(existsSync(path.join(targetDir, "L2-Full", "daily", "note.md"))).toBe(true)
     expect(existsSync(path.join(targetDir, "vector_store.db"))).toBe(false)
+    expect(existsSync(path.join(targetDir, "state.json"))).toBe(false)
     expect(existsSync(path.join(tmpDir, "memory", "L2-Full", "daily", "note.md"))).toBe(true)
     expect(existsSync(path.join(targetDir, ".gale-migration-manifest.json"))).toBe(true)
+  })
+
+  test("allows only the explicit migration manifest json basename", async () => {
+    await mkdir(path.join(tmpDir, "memory", "L1-Overview"), { recursive: true })
+    await writeFile(path.join(tmpDir, "memory", "L1-Overview", "index.md"), "overview\n", "utf8")
+    await writeFile(
+      path.join(tmpDir, "memory", ".gale-migration-manifest.json"),
+      "{\"status\":\"completed\"}\n",
+      "utf8",
+    )
+    await writeFile(path.join(tmpDir, "memory", "manifest.json"), "{\"status\":\"derived\"}\n", "utf8")
+
+    const result = migrateLegacyMemory({ cwd: tmpDir, targetDir })
+
+    expect(result.status).toBe("completed")
+    expect(existsSync(path.join(targetDir, ".gale-migration-manifest.json"))).toBe(true)
+    expect(readFileSync(path.join(targetDir, ".gale-migration-manifest.json"), "utf8")).toContain("\"status\": \"completed\"")
+    expect(existsSync(path.join(targetDir, "manifest.json"))).toBe(false)
   })
 
   test("does not overwrite conflicting target markdown", async () => {

--- a/tests/gale-memory-migration.test.ts
+++ b/tests/gale-memory-migration.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { migrateLegacyMemory } from "../src/memory/migration.js"
+
+describe("copy-first HKTMemory migration", () => {
+  let tmpDir: string
+  let targetDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "gale-memory-migration-"))
+    targetDir = path.join(tmpDir, "knowledge", "Project", "hkt-memory")
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("copies markdown memory and skips derived databases", async () => {
+    await mkdir(path.join(tmpDir, "memory", "L0-Abstract"), { recursive: true })
+    await mkdir(path.join(tmpDir, "memory", "L2-Full", "daily"), { recursive: true })
+    await writeFile(path.join(tmpDir, "memory", "L0-Abstract", "index.md"), "abstract\n", "utf8")
+    await writeFile(path.join(tmpDir, "memory", "L2-Full", "daily", "note.md"), "daily\n", "utf8")
+    await writeFile(path.join(tmpDir, "memory", "vector_store.db"), "db", "utf8")
+
+    const result = migrateLegacyMemory({ cwd: tmpDir, targetDir })
+
+    expect(result.status).toBe("completed")
+    expect(existsSync(path.join(targetDir, "L0-Abstract", "index.md"))).toBe(true)
+    expect(existsSync(path.join(targetDir, "L2-Full", "daily", "note.md"))).toBe(true)
+    expect(existsSync(path.join(targetDir, "vector_store.db"))).toBe(false)
+    expect(existsSync(path.join(tmpDir, "memory", "L2-Full", "daily", "note.md"))).toBe(true)
+    expect(existsSync(path.join(targetDir, ".gale-migration-manifest.json"))).toBe(true)
+  })
+
+  test("does not overwrite conflicting target markdown", async () => {
+    await mkdir(path.join(tmpDir, "memory", "L2-Full", "daily"), { recursive: true })
+    await mkdir(path.join(targetDir, "L2-Full", "daily"), { recursive: true })
+    await writeFile(path.join(tmpDir, "memory", "L2-Full", "daily", "note.md"), "source\n", "utf8")
+    await writeFile(path.join(targetDir, "L2-Full", "daily", "note.md"), "target\n", "utf8")
+
+    const result = migrateLegacyMemory({ cwd: tmpDir, targetDir })
+
+    expect(result.status).toBe("migration-conflict")
+    expect(result.conflicts).toEqual(["L2-Full/daily/note.md"])
+    expect(readFileSync(path.join(targetDir, "L2-Full", "daily", "note.md"), "utf8")).toBe("target\n")
+    expect(readFileSync(path.join(targetDir, "MIGRATION_CONFLICTS.md"), "utf8")).toContain("L2-Full/daily/note.md")
+  })
+
+  test("is idempotent after a completed migration", async () => {
+    await mkdir(path.join(tmpDir, "memory", "L1-Overview"), { recursive: true })
+    await writeFile(path.join(tmpDir, "memory", "L1-Overview", "index.md"), "overview\n", "utf8")
+
+    const first = migrateLegacyMemory({ cwd: tmpDir, targetDir })
+    const second = migrateLegacyMemory({ cwd: tmpDir, targetDir })
+
+    expect(first.copied).toBeGreaterThan(0)
+    expect(second.copied).toBe(0)
+    expect(second.skipped).toBeGreaterThan(0)
+    expect(second.status).toBe("completed")
+  })
+})

--- a/tests/gale-memory-public-root.test.ts
+++ b/tests/gale-memory-public-root.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { ensurePublicMemoryRoot, resolvePublicMemoryRoot } from "../src/memory/public-root.js"
+
+describe("Gale-managed HKTMemory public root", () => {
+  let tmpDir: string
+  let oldKnowledgeHome: string | undefined
+  let oldMemoryDir: string | undefined
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "gale-memory-root-"))
+    oldKnowledgeHome = process.env.GALE_KNOWLEDGE_HOME
+    oldMemoryDir = process.env.HKT_MEMORY_DIR
+    process.env.GALE_KNOWLEDGE_HOME = path.join(tmpDir, "knowledge")
+    delete process.env.HKT_MEMORY_DIR
+  })
+
+  afterEach(async () => {
+    if (oldKnowledgeHome === undefined) delete process.env.GALE_KNOWLEDGE_HOME
+    else process.env.GALE_KNOWLEDGE_HOME = oldKnowledgeHome
+    if (oldMemoryDir === undefined) delete process.env.HKT_MEMORY_DIR
+    else process.env.HKT_MEMORY_DIR = oldMemoryDir
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("derives public HKTMemory root under the knowledge project", () => {
+    const resolved = resolvePublicMemoryRoot({ cwd: tmpDir, project: "MyProject" })
+
+    expect(resolved.source).toBe("derived")
+    expect(resolved.memoryDir).toBe(path.join(tmpDir, "knowledge", "MyProject", "hkt-memory"))
+  })
+
+  test("explicit memory dir wins over env and derived roots", () => {
+    process.env.HKT_MEMORY_DIR = path.join(tmpDir, "env-memory")
+
+    const resolved = resolvePublicMemoryRoot({
+      cwd: tmpDir,
+      project: "MyProject",
+      memoryDir: path.join(tmpDir, "explicit-memory"),
+    })
+
+    expect(resolved.source).toBe("explicit")
+    expect(resolved.memoryDir).toBe(path.join(tmpDir, "explicit-memory"))
+  })
+
+  test("existing HKT_MEMORY_DIR is preserved for Gale-managed child calls", () => {
+    process.env.HKT_MEMORY_DIR = path.join(tmpDir, "custom-memory")
+
+    const resolved = resolvePublicMemoryRoot({ cwd: tmpDir, project: "MyProject" })
+
+    expect(resolved.source).toBe("env")
+    expect(resolved.memoryDir).toBe(path.join(tmpDir, "custom-memory"))
+  })
+
+  test("creates standard HKTMemory layer structure without local memory", () => {
+    const resolved = resolvePublicMemoryRoot({ cwd: tmpDir, project: "MyProject" })
+
+    ensurePublicMemoryRoot(resolved.memoryDir)
+
+    expect(existsSync(path.join(resolved.memoryDir, "L0-Abstract", "topics"))).toBe(true)
+    expect(existsSync(path.join(resolved.memoryDir, "L1-Overview", "topics"))).toBe(true)
+    expect(existsSync(path.join(resolved.memoryDir, "L2-Full", "evergreen", "MEMORY.md"))).toBe(true)
+    expect(existsSync(path.join(tmpDir, "memory"))).toBe(false)
+  })
+
+  test("rejects traversal project names", () => {
+    expect(() => resolvePublicMemoryRoot({ cwd: tmpDir, project: "../bad" })).toThrow("Invalid path component")
+  })
+})

--- a/tests/gale-memory-runtime.test.ts
+++ b/tests/gale-memory-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { chmod, mkdtemp, rm, mkdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import {
@@ -42,14 +43,24 @@ class FakeHktClient {
 describe("Gale task memory runtime", () => {
   let tmpDir: string
   let contextFile: string
+  let oldKnowledgeHome: string | undefined
+  let oldMemoryDir: string | undefined
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(tmpdir(), "gale-memory-runtime-"))
+    oldKnowledgeHome = process.env.GALE_KNOWLEDGE_HOME
+    oldMemoryDir = process.env.HKT_MEMORY_DIR
+    process.env.GALE_KNOWLEDGE_HOME = path.join(tmpDir, "knowledge")
+    delete process.env.HKT_MEMORY_DIR
     contextFile = path.join(tmpDir, ".context", "galeharness-cli", "current-task.json")
     await mkdir(path.dirname(contextFile), { recursive: true })
   })
 
   afterEach(async () => {
+    if (oldKnowledgeHome === undefined) delete process.env.GALE_KNOWLEDGE_HOME
+    else process.env.GALE_KNOWLEDGE_HOME = oldKnowledgeHome
+    if (oldMemoryDir === undefined) delete process.env.HKT_MEMORY_DIR
+    else process.env.HKT_MEMORY_DIR = oldMemoryDir
     await rm(tmpDir, { recursive: true, force: true })
   })
 
@@ -127,6 +138,33 @@ describe("Gale task memory runtime", () => {
     expect(result.recall.success).toBe(true)
     expect(client.recallEnvelope?.schema_version).toBe("gale-task-memory.v1")
     expect(client.recallEnvelope?.artifact_type).toBe("debug_session")
+    expect(result.recall.diagnostics?.memory_dir).toBe(path.join(tmpDir, "knowledge", "HKTMemory", "hkt-memory"))
+    expect(existsSync(path.join(tmpDir, "memory"))).toBe(false)
+  })
+
+  test("start migrates legacy local memory before recall", async () => {
+    await mkdir(path.join(tmpDir, "memory", "L2-Full", "daily"), { recursive: true })
+    await writeFile(path.join(tmpDir, "memory", "L2-Full", "daily", "legacy.md"), "legacy\n", "utf8")
+    await writeFile(path.join(tmpDir, "memory", "vector_store.db"), "db", "utf8")
+    const client = new FakeHktClient()
+
+    const result = await startTaskMemory(
+      {
+        cwd: tmpDir,
+        contextFile,
+        project: "HKTMemory",
+        repoRoot: tmpDir,
+        branch: "feature/task-memory",
+        skill: "gh:debug",
+      },
+      client,
+    )
+
+    const memoryDir = path.join(tmpDir, "knowledge", "HKTMemory", "hkt-memory")
+    expect(result.recall.diagnostics?.status).toBe("completed")
+    expect(existsSync(path.join(memoryDir, "L2-Full", "daily", "legacy.md"))).toBe(true)
+    expect(existsSync(path.join(memoryDir, "vector_store.db"))).toBe(false)
+    expect(existsSync(path.join(tmpDir, "memory", "L2-Full", "daily", "legacy.md"))).toBe(true)
   })
 
   test("capture sends structured events instead of raw store content", async () => {
@@ -190,5 +228,22 @@ describe("Gale task memory runtime", () => {
     expect(result.success).toBe(false)
     expect(result.skipped).toBe(true)
     expect(String(result.reason)).toContain("hkt-memory unavailable")
+  })
+
+  test("HktClient passes HKT_MEMORY_DIR to child process", async () => {
+    const script = path.join(tmpDir, "fake-hkt")
+    const memoryDir = path.join(tmpDir, "custom-memory")
+    await writeFile(
+      script,
+      "#!/usr/bin/env node\nconsole.log(JSON.stringify({ success: true, diagnostics: { child_memory_dir: process.env.HKT_MEMORY_DIR } }))\n",
+      "utf8",
+    )
+    await chmod(script, 0o755)
+    const client = new HktClient({ binary: script, cwd: tmpDir, timeoutMs: 1000, memoryDir })
+
+    const result = await client.taskRecall({ schema_version: "gale-task-memory.v1" })
+
+    expect(result.success).toBe(true)
+    expect(result.diagnostics?.child_memory_dir).toBe(memoryDir)
   })
 })

--- a/tests/hkt-memory-compounding.test.ts
+++ b/tests/hkt-memory-compounding.test.ts
@@ -371,6 +371,18 @@ describe("HKTMemory Compounding — Non-Blocking on HKTMemory Failure", () => {
   }
 })
 
+describe("HKTMemory Compounding — Safe Root Fallback", () => {
+  for (const skill of COMPOUNDING_SKILLS) {
+    test(`${skill} never exports an empty resolved memory root`, async () => {
+      const content = await readFile(path.join(PLUGIN_ROOT, skill, "SKILL.md"), "utf8")
+
+      expect(content).not.toContain('HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)"')
+      expect(content).toContain('memory_root="$(gale-memory resolve-root 2>/dev/null || true)"')
+      expect(content).toContain('[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"')
+    })
+  }
+})
+
 describe("HKTMemory Compounding — Loop Completeness", () => {
   test("All compounding loop steps are documented in README", async () => {
     const readme = await readFile(path.join(process.cwd(), "README.md"), "utf8")

--- a/tests/hktmemory-public-knowledge-migration.test.ts
+++ b/tests/hktmemory-public-knowledge-migration.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+describe("HKTMemory public knowledge migration acceptance", () => {
+  let tmpDir: string
+  let oldKnowledgeHome: string | undefined
+  let oldMemoryDir: string | undefined
+  const projectRoot = path.resolve(import.meta.dir, "..")
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "hktmemory-public-acceptance-"))
+    oldKnowledgeHome = process.env.GALE_KNOWLEDGE_HOME
+    oldMemoryDir = process.env.HKT_MEMORY_DIR
+    process.env.GALE_KNOWLEDGE_HOME = path.join(tmpDir, "knowledge")
+    delete process.env.HKT_MEMORY_DIR
+  })
+
+  afterEach(async () => {
+    if (oldKnowledgeHome === undefined) delete process.env.GALE_KNOWLEDGE_HOME
+    else process.env.GALE_KNOWLEDGE_HOME = oldKnowledgeHome
+    if (oldMemoryDir === undefined) delete process.env.HKT_MEMORY_DIR
+    else process.env.HKT_MEMORY_DIR = oldMemoryDir
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("gale-memory status creates the global root without creating repo-local memory", async () => {
+    const repo = path.join(tmpDir, "repo")
+    await mkdir(repo, { recursive: true })
+
+    const result = await runGaleMemory(["status", "--cwd", repo, "--project", "Project"])
+    const body = JSON.parse(result.stdout) as Record<string, unknown>
+
+    expect(result.exitCode).toBe(0)
+    expect(body.status).toBe("global")
+    expect(body.memory_dir).toBe(path.join(tmpDir, "knowledge", "Project", "hkt-memory"))
+    expect(existsSync(path.join(tmpDir, "knowledge", "Project", "hkt-memory", "L2-Full", "evergreen", "MEMORY.md"))).toBe(true)
+    expect(existsSync(path.join(repo, "memory"))).toBe(false)
+  })
+
+  test("gale-memory migrate copies legacy markdown, skips db files, and preserves local memory", async () => {
+    const repo = path.join(tmpDir, "repo")
+    await mkdir(path.join(repo, "memory", "L2-Full", "daily"), { recursive: true })
+    await writeFile(path.join(repo, "memory", "L2-Full", "daily", "legacy.md"), "legacy\n", "utf8")
+    await writeFile(path.join(repo, "memory", "bm25_index.db"), "db", "utf8")
+
+    const result = await runGaleMemory(["migrate", "--cwd", repo, "--project", "Project"])
+    const body = JSON.parse(result.stdout) as Record<string, any>
+    const target = path.join(tmpDir, "knowledge", "Project", "hkt-memory")
+
+    expect(result.exitCode).toBe(0)
+    expect(body.migration.status).toBe("completed")
+    expect(existsSync(path.join(target, "L2-Full", "daily", "legacy.md"))).toBe(true)
+    expect(existsSync(path.join(target, "bm25_index.db"))).toBe(false)
+    expect(existsSync(path.join(repo, "memory", "L2-Full", "daily", "legacy.md"))).toBe(true)
+  })
+
+  async function runGaleMemory(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn(["bun", "cmd/gale-memory/index.ts", ...args], {
+      cwd: projectRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env },
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    return { exitCode, stdout, stderr }
+  }
+})

--- a/tests/knowledge-init.test.ts
+++ b/tests/knowledge-init.test.ts
@@ -56,6 +56,8 @@ describe("initKnowledgeRepo", () => {
 
     const content = readFileSync(gitignorePath, "utf8")
     expect(content).toContain("*.db")
+    expect(content).toContain("*.json")
+    expect(content).toContain("!.gale-migration-manifest.json")
     expect(content).toContain("vector_store/")
     expect(content).toContain("session_transcript_index.db")
     expect(content).toContain("_lifecycle/events.jsonl")
@@ -74,6 +76,8 @@ describe("initKnowledgeRepo", () => {
     expect(created).toBe(false)
     const content = readFileSync(join(repoDir, ".gitignore"), "utf8")
     expect(content).toContain("custom-rule")
+    expect(content).toContain("*.json")
+    expect(content).toContain("!.gale-migration-manifest.json")
     expect(content).toContain("vector_store/")
     expect(content).toContain("session_transcript_index.db")
   })

--- a/tests/knowledge-init.test.ts
+++ b/tests/knowledge-init.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { execSync } from "node:child_process"
-import { existsSync, readFileSync, mkdirSync, rmSync } from "node:fs"
+import { existsSync, readFileSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -56,8 +56,26 @@ describe("initKnowledgeRepo", () => {
 
     const content = readFileSync(gitignorePath, "utf8")
     expect(content).toContain("*.db")
+    expect(content).toContain("vector_store/")
+    expect(content).toContain("session_transcript_index.db")
+    expect(content).toContain("_lifecycle/events.jsonl")
     expect(content).toContain("vector-index/")
     expect(content).toContain(".last-rebuild-commit")
+    expect(content).not.toContain("hkt-memory/**/*.md")
+  })
+
+  it("appends missing .gitignore rules for an existing knowledge repo", () => {
+    const repoDir = join(testDir, "knowledge")
+    initKnowledgeRepo(repoDir)
+    writeFileSync(join(repoDir, ".gitignore"), "custom-rule\n*.db\n", "utf8")
+
+    const created = initKnowledgeRepo(repoDir)
+
+    expect(created).toBe(false)
+    const content = readFileSync(join(repoDir, ".gitignore"), "utf8")
+    expect(content).toContain("custom-rule")
+    expect(content).toContain("vector_store/")
+    expect(content).toContain("session_transcript_index.db")
   })
 
   it("creates an initial commit", () => {

--- a/tests/knowledge-rebuild-index.test.ts
+++ b/tests/knowledge-rebuild-index.test.ts
@@ -85,13 +85,16 @@ describe("collectMarkdownFiles", () => {
 
   it("collects .md files recursively", () => {
     mkdirSync(join(testDir, "sub"), { recursive: true })
+    mkdirSync(join(testDir, "Project", "hkt-memory", "L2-Full", "daily"), { recursive: true })
     writeFileSync(join(testDir, "root.md"), "# Root\n")
     writeFileSync(join(testDir, "sub", "nested.md"), "# Nested\n")
+    writeFileSync(join(testDir, "Project", "hkt-memory", "L2-Full", "daily", "memory.md"), "# Memory\n")
     writeFileSync(join(testDir, "other.txt"), "not md\n")
 
     const files = collectMarkdownFiles(testDir)
     expect(files).toContain("root.md")
     expect(files).toContain(join("sub", "nested.md"))
+    expect(files).toContain(join("Project", "hkt-memory", "L2-Full", "daily", "memory.md"))
     expect(files).not.toContain("other.txt")
   })
 
@@ -306,6 +309,21 @@ describe("rebuildIndex", () => {
     const result = rebuildIndex({ knowledgeHome: repoDir, full: true })
 
     expect(result.mode).toBe("full")
+    expect(result.indexMemoryDir).toContain(join(".galeharness", "vector-index", "knowledge-repo"))
+  })
+
+  it("uses an independent HKTMemory index root when rebuilding knowledge markdown", () => {
+    const repoDir = createInitializedRepo(testDir)
+    const indexMemoryDir = join(testDir, "knowledge-index")
+    addAndCommit(repoDir, {
+      "Project/hkt-memory/L2-Full/daily/memory.md": "# Memory\n",
+      "plans/plan.md": "# Plan\n",
+    }, "initial docs")
+
+    const result = rebuildIndex({ knowledgeHome: repoDir, full: true, indexMemoryDir })
+
+    expect(result.indexMemoryDir).toBe(indexMemoryDir)
+    expect(existsSync(join(indexMemoryDir, "L0-Abstract", "topics"))).toBe(true)
   })
 
   it("updates .last-rebuild-commit after processing when no errors", () => {

--- a/tests/upstream-sync-cli.test.ts
+++ b/tests/upstream-sync-cli.test.ts
@@ -122,11 +122,12 @@ async function writeMockGh(mockBin: string, json: string): Promise<void> {
 function envWithMockBin(mockBin: string): NodeJS.ProcessEnv {
   const originalPath = process.env.PATH ?? process.env.Path ?? ""
   const mockPath = `${mockBin}${path.delimiter}${originalPath}`
-  return {
-    ...gitEnv,
-    PATH: mockPath,
-    Path: mockPath,
-  }
+  const env = { ...gitEnv }
+  delete env.PATH
+  delete env.Path
+  env[process.platform === "win32" ? "Path" : "PATH"] = mockPath
+  env.GALE_SYNC_GH_BIN = path.join(mockBin, process.platform === "win32" ? "gh.cmd" : "gh")
+  return env
 }
 
 function createMinimalState(
@@ -773,8 +774,7 @@ describe("sync-cli.py", () => {
       await writeState(repoRoot, state)
 
       const r = await runSyncCli(["resume"], repoRoot, {
-        ...gitEnv,
-        PATH: envWithMockBin(mockBin).PATH,
+        ...envWithMockBin(mockBin),
       })
       expect(r.exitCode).toBe(3)
       expect(r.stderr).toContain("upstream 对账失败")
@@ -964,8 +964,7 @@ describe("sync-cli.py", () => {
       await writeState(repoRoot, state)
 
       const r = await runSyncCli(["skip", "--force-cleanup"], repoRoot, {
-        ...gitEnv,
-        PATH: envWithMockBin(mockBin).PATH,
+        ...envWithMockBin(mockBin),
       })
       expect(r.exitCode).toBe(0)
       expect(r.stderr).toContain("PR 验真未通过")

--- a/tests/x-skill-contract.test.ts
+++ b/tests/x-skill-contract.test.ts
@@ -84,6 +84,14 @@ describe("Morph-X skill contract", () => {
       expect(content).toMatch(/non-blocking|proceed silently|continue silently|skip silently/i)
     })
 
+    test(`${skill.dir} never exports an empty resolved memory root`, async () => {
+      const content = await readSkill(skill.dir)
+
+      expect(content).not.toContain('HKT_MEMORY_DIR="$(gale-memory resolve-root 2>/dev/null || true)"')
+      expect(content).toContain('memory_root="$(gale-memory resolve-root 2>/dev/null || true)"')
+      expect(content).toContain('[ -n "$memory_root" ] && export HKT_MEMORY_DIR="$memory_root"')
+    })
+
     test(`${skill.dir} retrieves before storing fingerprints`, async () => {
       const content = await readSkill(skill.dir)
       const retrieveLine = skill.dir === "gh-work-x" ? hktPatchLine(content, "phase-0.6") : hktPatchLine(content, "phase-0.4")


### PR DESCRIPTION
## 背景

GaleHarness 已经用 `gale-knowledge` 管理全局公共知识库，但 Gale-managed HKTMemory 仍默认落在项目本地 `memory/`。这会让可迁移的 Markdown 知识和高价值任务记忆分散在两处，清理 checkout 或换机器时容易丢失上下文。

本 PR 将通过 GaleHarness 入口使用的 HKTMemory 默认收敛到：

```text
~/.galeharness/knowledge/<project>/hkt-memory
```

裸 `hkt-memory` 的上游默认语义不变；需要公共 root 时通过 `gale-memory` 或显式 `HKT_MEMORY_DIR` 进入。

## 改动点

- 新增 Gale-managed HKTMemory root resolver，复用 `gale-knowledge` 的 home/project 解析规则，并支持 `--memory-dir`、`HKT_MEMORY_DIR`、config、derived root 的覆盖优先级。
- 新增 copy-first legacy migration：复制本地 `memory/` 中的 Markdown 记忆和必要 manifest，跳过 `.db`、vector cache、session transcript index、`_lifecycle/events.jsonl` 等派生缓存；冲突不覆盖，写入 manifest 和 `MIGRATION_CONFLICTS.md`。
- `gale-memory` 新增 `status`、`resolve-root`、`migrate`，并让 `start/capture/feedback` 统一初始化 root、触发迁移、向 HKTMemory child process 注入 `HKT_MEMORY_DIR`。
- `gale-knowledge init` 扩展 `.gitignore` 并对已有知识库幂等追加规则；`rebuild-index` 改为写入独立可重建索引 root，避免把 `hkt-memory` subtree 递归写回自身。
- setup/install 文案不再默认创建项目本地 `memory/`，改为引导 `gale-memory status`。
- README、插件 README、gh:* 技能中的 raw HKTMemory 调用更新为通过 `gale-memory resolve-root` 注入公共 root。
- 保留 requirements 和 plan 文档作为本次实现依据。

## 测试结果

- `bun test tests/gale-memory-public-root.test.ts tests/gale-memory-migration.test.ts tests/gale-memory-runtime.test.ts tests/knowledge-init.test.ts tests/knowledge-rebuild-index.test.ts tests/hktmemory-public-knowledge-migration.test.ts`：49 pass。
- `bun test tests/hkt-memory-compounding.test.ts tests/x-skill-contract.test.ts`：98 pass。
- `bun test`：1227 pass，3 skip，0 fail。
- `bun run release:validate`：通过，release metadata in sync。
- `git diff --check`：通过。

补充：`bunx tsc --noEmit` 目前仍失败在既有 `src/utils/update.ts` 的 `Bun.execPath` 类型缺口；本 PR 新增/修改的 memory 代码相关类型错误已修复。

## 风险 / 回滚

- 迁移是 copy-first，不删除、不移动项目本地 `memory/`，可通过移除或重命名全局 target root/manifest 后重新运行 `gale-memory migrate` 回滚或重试。
- 如用户已有全局同名 Markdown 且内容不同，本 PR 不覆盖，状态会暴露为 `migration-conflict` 并要求人工处理。
- 公共知识库只应跟踪 Markdown 记忆和必要 manifest；若出现 `.db` 或 index 缓存进入 git，应先修 `.gitignore` 或 skip rules。

## 后续事项

- 后续可补一个显式 cleanup/archive 命令，用于用户确认后清理 legacy 本地 `memory/`。
- 后续可把更多 raw HKTMemory 工作流收敛成结构化 `gale-memory` 子命令，进一步减少技能层 shell 拼接。
