### PR TITLE
fix(windows-scan): 修复 Windows 兼容性扫描脚本的导入副作用

### DIFF
--- a/docs/brainstorms/2026-04-25-windows-compat-scan-side-effect-free-requirements.md
+++ b/docs/brainstorms/2026-04-25-windows-compat-scan-side-effect-free-requirements.md
@@ -1,0 +1,44 @@
+# Windows 兼容扫描只读运行需求
+
+Created: 2026-04-25
+Mode: Lightweight
+
+## 背景
+
+`scripts/windows-compat-scan.ts` 负责扫描仓库中的 Windows 兼容性风险。当前扫描器在被测试导入时会执行主流程，并默认写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`，导致 `bun test` 产生文档污染。同时默认排除规则不完整，历史上曾扫描到 `.worktrees/review-pr-68/vendor/...`，带来大量与当前分支无关的噪声。
+
+## 目标
+
+- 让扫描器支持在 CI 和测试中只读运行，不写仓库报告。
+- 保持人工运行 `bun run scripts/windows-compat-scan.ts` 时仍生成既有默认报告。
+- 默认排除 `.worktrees/**` 和 `vendor/**`，避免扫描其他工作树或 vendored 依赖。
+- 增加测试覆盖，确保只读、显式输出和默认报告生成语义清晰。
+
+## 范围
+
+本次只改 Windows 兼容扫描器、配置和相关测试。不做大规模重构，不改 release binary 主线，不改变扫描规则的核心匹配语义。
+
+## 需求
+
+- R1: 导入 `scripts/windows-compat-scan.ts` 不应触发扫描或写文件。
+- R2: CLI 应支持等价只读模式，例如 `--no-write` 或 `--dry-run`，该模式打印报告但不写默认报告文件。
+- R3: CLI 应支持显式输出路径，例如 `--output <path>`，用于测试或 CI 将报告写到临时目录。
+- R4: 无参数人工运行仍写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。
+- R5: 默认排除应包含 `.worktrees/**` 与 `vendor/**`，配置额外排除仍可叠加。
+- R6: 测试不得污染 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。
+
+## 验收标准
+
+- AE1: `bun test tests/windows-compat-scan.test.ts` 不修改 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。
+- AE2: 针对临时仓库结构的测试证明 `.worktrees/.../vendor/...` 不会被扫描。
+- AE3: 只读模式运行扫描后不会创建默认报告文件。
+- AE4: 显式 `--output` 或等价 API 可将报告写入临时路径。
+- AE5: 默认写报告路径仍可用，保持既有人工运行体验。
+
+## 非目标
+
+- 不新增 Windows 兼容规则。
+- 不改变现有报告内容结构，除非为路径或 CLI 输出说明做最小调整。
+- 不接入新的 CI workflow。
+- 不处理 release binary 或发布流程。
+

--- a/docs/plans/2026-04-25-001-fix-windows-compat-scan-side-effect-free-plan.md
+++ b/docs/plans/2026-04-25-001-fix-windows-compat-scan-side-effect-free-plan.md
@@ -1,0 +1,82 @@
+---
+title: Windows 兼容扫描只读运行实现计划
+status: active
+origin: docs/brainstorms/2026-04-25-windows-compat-scan-side-effect-free-requirements.md
+created: 2026-04-25
+---
+
+# Windows 兼容扫描只读运行实现计划
+
+## 问题框架
+
+当前 `scripts/windows-compat-scan.ts` 同时承担库函数和 CLI 的角色，但文件末尾无条件执行 `main()`。这使 `tests/windows-compat-scan.test.ts` 导入函数时触发全仓扫描并写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。另外默认排除规则缺少 `.worktrees/**`，历史上会扫到其他工作树中的 vendored 文件，降低信号质量。
+
+## 范围边界
+
+- 修改 `scripts/windows-compat-scan.ts`，提供只读/输出路径能力，并避免导入副作用。
+- 修改 `scripts/windows-compat-scan-config.json`，补齐默认或配置排除。
+- 修改 `tests/windows-compat-scan.test.ts`，覆盖只读、输出路径、默认排除和默认报告写入。
+- 不新增扫描规则，不改 release binary，不改 CI 主线。
+
+## 设计决策
+
+- 将扫描主流程拆成可导出的 `runScan` / `renderReport` 形态，测试直接调用 API，避免启动子进程和污染仓库。
+- CLI 参数采用简单显式选项：`--no-write`、`--dry-run`、`--output <path>`、`--config <path>`。`--dry-run` 作为 `--no-write` 别名，降低使用成本。
+- 默认写入路径保持 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`，只在直接执行脚本且未传 `--no-write` 时发生。
+- 默认排除放在代码常量中包含 `.worktrees` 和 `vendor`，配置文件保留 `vendor/**` 兼容现有意图。
+
+## 实施单元
+
+### U1: 拆分扫描器执行入口
+
+Files:
+- Modify: `scripts/windows-compat-scan.ts`
+- Test: `tests/windows-compat-scan.test.ts`
+
+Approach:
+- 导出扫描结果类型、默认报告路径、`walkFiles` 或 `scanWorkspace` 等可测试函数。
+- 使用直接运行检测保护 `main()`，确保模块导入无副作用。
+- 允许扫描根目录作为参数，避免测试依赖真实仓库根。
+
+Test scenarios:
+- 导入模块不会创建或改写默认报告。
+- 临时目录扫描可以发现普通 `.sh` 文件。
+
+### U2: 增加 CLI 只读和输出路径
+
+Files:
+- Modify: `scripts/windows-compat-scan.ts`
+- Test: `tests/windows-compat-scan.test.ts`
+
+Approach:
+- 添加轻量参数解析，支持 `--no-write` / `--dry-run` / `--output <path>` / `--config <path>`。
+- `--output` 写到显式路径；`--no-write` 不写任何报告文件；无参数保持默认报告写入。
+
+Test scenarios:
+- 只读模式不写默认报告。
+- 显式 output 写入临时路径。
+- 默认配置仍写入默认报告路径。
+
+### U3: 补齐默认排除并覆盖噪声场景
+
+Files:
+- Modify: `scripts/windows-compat-scan.ts`
+- Modify: `scripts/windows-compat-scan-config.json`
+- Test: `tests/windows-compat-scan.test.ts`
+
+Approach:
+- 默认排除加入 `.worktrees`、`.worktrees/**`、`vendor`、`vendor/**`。
+- 继续合并配置中的额外排除，不破坏现有配置。
+
+Test scenarios:
+- `.worktrees/review-pr-68/vendor/noisy.sh` 不出现在扫描结果。
+- `vendor/noisy.sh` 不出现在扫描结果。
+- 普通目录下的 `.sh` 仍会被扫描。
+
+## 验证
+
+- `bun test tests/windows-compat-scan.test.ts`
+- 如时间可承受，运行 `bun test`
+- `bun run release:validate`
+- `git status --short` 确认没有非预期污染 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`
+

--- a/docs/solutions/developer-experience/windows-compat-scan-side-effect-free-cli-2026-04-25.md
+++ b/docs/solutions/developer-experience/windows-compat-scan-side-effect-free-cli-2026-04-25.md
@@ -1,0 +1,101 @@
+---
+title: "Windows compatibility scan should be import-safe and side-effect-free"
+date: 2026-04-25
+category: developer-experience
+module: developer-tooling
+problem_type: developer_experience
+component: tooling
+severity: medium
+applies_when:
+  - "脚本既要能作为 CLI 执行，也要能被测试或其他工具导入复用"
+  - "扫描或报告生成工具默认会写入仓库文件"
+  - "工作区包含 .worktrees/ 或 vendor/ 这类会放大扫描噪音的目录"
+tags:
+  - windows-compat
+  - side-effects
+  - cli
+  - testing
+  - developer-experience
+---
+
+# Windows compatibility scan should be import-safe and side-effect-free
+
+## Context
+
+`scripts/windows-compat-scan.ts` 原本在模块顶层直接执行扫描并写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。这让它可以直接作为脚本运行，但也让任何测试导入、工具复用或类型检查都可能触发写报告的副作用。
+
+这类脚本在开发流程里很常见：同一份逻辑既需要 CLI 入口，也需要可测试的纯函数。关键约束是默认命令行为不能破坏既有工作流，但导入模块和 dry-run 必须不写文件。
+
+## Guidance
+
+把扫描脚本拆成三层：
+
+- **纯扫描层**：`runScan` 只读取文件并返回 `{ findings, shFiles }`。
+- **渲染层**：`renderReport` 只把扫描结果转成 Markdown 字符串。
+- **CLI 层**：`runCli` 负责解析参数、决定是否写文件，并只在 `import.meta.main` 时执行。
+
+CLI 仍保留无参数默认行为：写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。新增显式的无写入路径用于测试和人工检查：
+
+```bash
+bun run scripts/windows-compat-scan.ts --no-write
+bun run scripts/windows-compat-scan.ts --dry-run
+bun run scripts/windows-compat-scan.ts --output tmp/windows-report.md
+bun run scripts/windows-compat-scan.ts --config scripts/windows-compat-scan-config.json
+```
+
+目录排除要用路径语义，而不是简单字符串前缀。默认排除 `.worktrees/**` 和 `vendor/**`，同时要保证仓库根目录下的普通文件名如 `vendor.sh` 不会被误排除。
+
+## Why This Matters
+
+导入即执行的脚本会让测试变脆：只要测试文件 import 了被测函数，就可能改写真实报告文件。它还会污染 review diff，让开发者难以区分真正的代码改动和扫描时间戳造成的报告 churn。
+
+把副作用限制在 CLI 入口后，脚本可以同时满足三个场景：
+
+- 作为日常命令运行时，继续生成默认报告。
+- 作为库导入时，不写任何文件。
+- 作为验证步骤运行时，可以用 `--no-write` 检查扫描逻辑而不制造 diff。
+
+## When to Apply
+
+- CLI 脚本需要被测试直接导入函数时。
+- 报告生成脚本默认会写入仓库内的 Markdown、JSON 或缓存文件时。
+- 扫描工具需要在 worktree、vendored dependency 或 release workspace 中运行时。
+- 需要保留旧的默认命令行为，但新增 side-effect-free 验证入口时。
+
+## Examples
+
+推荐结构：
+
+```ts
+export async function runScan(options: RunScanOptions = {}): Promise<ScanResult> {
+  // 只负责扫描和返回结构化结果
+}
+
+export function renderReport(result: ScanResult): string {
+  // 只负责渲染字符串
+}
+
+export async function runCli(args = process.argv.slice(2)): Promise<ScanResult> {
+  // 只在这里决定是否 writeFile
+}
+
+if (import.meta.main) {
+  runCli().catch((err) => {
+    console.error("Scan failed:", err)
+    process.exit(1)
+  })
+}
+```
+
+对应测试应该覆盖：
+
+- `await import(scriptPath)` 不会创建默认报告。
+- `--no-write` 和 `--dry-run` 不会写报告。
+- `--output <path>` 写到指定路径，不写默认路径。
+- 无参数仍写默认报告，保护旧工作流。
+- `.worktrees/` 和 `vendor/` 目录被排除，但 `vendor.sh` 这类普通文件仍会被扫描。
+
+## Related
+
+- [docs/solutions/integrations/windows-gbk-emoji-and-file-mode-fix-2026-04-23.md](../integrations/windows-gbk-emoji-and-file-mode-fix-2026-04-23.md)
+- [docs/solutions/agent-friendly-cli-principles.md](../agent-friendly-cli-principles.md)

--- a/scripts/windows-compat-scan-config.json
+++ b/scripts/windows-compat-scan-config.json
@@ -6,6 +6,7 @@
   },
   "exclude": [
     "scripts/release/**",
+    ".worktrees/**",
     "vendor/**"
   ]
 }

--- a/scripts/windows-compat-scan.ts
+++ b/scripts/windows-compat-scan.ts
@@ -12,7 +12,7 @@
  * Run: bun run scripts/windows-compat-scan.ts
  */
 
-import { readdir, readFile } from "fs/promises"
+import { mkdir, readdir, readFile, writeFile } from "fs/promises"
 import path from "path"
 
 export interface Finding {
@@ -36,13 +36,41 @@ export interface Config {
   exclude?: string[]
 }
 
-const DEFAULT_EXCLUDE_DIRS = [
+export interface ScanResult {
+  findings: Finding[]
+  shFiles: string[]
+}
+
+export interface RunScanOptions {
+  rootDir?: string
+  configPath?: string
+  config?: Config
+}
+
+export interface CliOptions {
+  noWrite: boolean
+  outputPath?: string
+  configPath?: string
+}
+
+export interface RunCliOptions {
+  rootDir?: string
+  stdout?: Pick<typeof console, "log" | "error">
+}
+
+export const DEFAULT_REPORT_PATH = path.join("docs", "async-progress", "WINDOWS_COMPAT_SCAN_REPORT.md")
+
+const DEFAULT_EXCLUDE_PATTERNS = [
   "node_modules",
   ".git",
   "__pycache__",
   ".venv",
   "memory",
   "docs/async-progress",
+  ".worktrees",
+  ".worktrees/**",
+  "vendor",
+  "vendor/**",
 ]
 
 const DEFAULT_RULES: Rule[] = [
@@ -129,22 +157,28 @@ export function buildRules(config?: Config): Rule[] {
 }
 
 function minimatchLike(filePath: string, pattern: string): boolean {
+  if (!pattern.includes("*")) {
+    return filePath === pattern || filePath.startsWith(`${pattern}/`)
+  }
+
   const regexPattern = pattern
     .replace(/\./g, "\\.")
     .replace(/\*\*/g, "{{GLOBSTAR}}")
     .replace(/\*/g, "[^/]*")
     .replace(/{{GLOBSTAR}}/g, ".*")
-  const re = new RegExp(`^${regexPattern}`)
+  const re = new RegExp(`^${regexPattern}$`)
   return re.test(filePath)
 }
 
 export function getExclusions(config?: Config): string[] {
   const extras = config?.exclude ?? []
-  return [...DEFAULT_EXCLUDE_DIRS, ...extras]
+  return [...DEFAULT_EXCLUDE_PATTERNS, ...extras]
 }
 
-export async function loadConfig(configPath?: string): Promise<Config | undefined> {
-  const target = configPath ?? path.join(process.cwd(), "scripts", "windows-compat-scan-config.json")
+export async function loadConfig(configPath?: string, rootDir = process.cwd()): Promise<Config | undefined> {
+  const target = configPath
+    ? path.resolve(rootDir, configPath)
+    : path.join(rootDir, "scripts", "windows-compat-scan-config.json")
   try {
     const raw = await readFile(target, "utf8")
     return JSON.parse(raw) as Config
@@ -153,14 +187,18 @@ export async function loadConfig(configPath?: string): Promise<Config | undefine
   }
 }
 
-async function* walkFiles(dir: string, exclusions: string[]): AsyncGenerator<string> {
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join("/").replace(/\\/g, "/")
+}
+
+export async function* walkFiles(dir: string, exclusions: string[], rootDir = dir): AsyncGenerator<string> {
   const entries = await readdir(dir, { withFileTypes: true })
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name)
-    const relPath = path.relative(process.cwd(), fullPath)
+    const relPath = toPosixPath(path.relative(rootDir, fullPath))
     if (entry.isDirectory()) {
       if (exclusions.some((e) => minimatchLike(relPath, e) || minimatchLike(entry.name, e))) continue
-      yield* walkFiles(fullPath, exclusions)
+      yield* walkFiles(fullPath, exclusions, rootDir)
     } else if (entry.isFile()) {
       if (exclusions.some((e) => minimatchLike(relPath, e))) continue
       yield fullPath
@@ -200,7 +238,7 @@ export function scanContent(lines: string[], rules: Rule[], ext: string): Findin
   return findings
 }
 
-export async function scanFile(filePath: string, rules?: Rule[]): Promise<Finding[]> {
+export async function scanFile(filePath: string, rules?: Rule[], rootDir = process.cwd()): Promise<Finding[]> {
   const activeRules = rules ?? buildRules(await loadConfig())
   const ext = path.extname(filePath)
   const content = await readFile(filePath, "utf8")
@@ -208,27 +246,32 @@ export async function scanFile(filePath: string, rules?: Rule[]): Promise<Findin
   const findings = scanContent(lines, activeRules, ext)
   return findings.map((f) => ({
     ...f,
-    file: path.relative(process.cwd(), filePath),
+    file: toPosixPath(path.relative(rootDir, filePath)),
   }))
 }
 
-async function main() {
-  console.log("[SCAN] Windows Compatibility Scan\n")
-
-  const config = await loadConfig()
+export async function runScan(options: RunScanOptions = {}): Promise<ScanResult> {
+  const rootDir = options.rootDir ?? process.cwd()
+  const config = options.config ?? await loadConfig(options.configPath, rootDir)
   const rules = buildRules(config)
   const exclusions = getExclusions(config)
 
   const findings: Finding[] = []
   const shFiles: string[] = []
 
-  for await (const file of walkFiles(process.cwd(), exclusions)) {
+  for await (const file of walkFiles(rootDir, exclusions, rootDir)) {
     if (file.endsWith(".sh") || file.endsWith(".bash")) {
-      shFiles.push(path.relative(process.cwd(), file))
+      shFiles.push(toPosixPath(path.relative(rootDir, file)))
     }
-    const fileFindings = await scanFile(file, rules)
+    const fileFindings = await scanFile(file, rules, rootDir)
     findings.push(...fileFindings)
   }
+
+  return { findings, shFiles }
+}
+
+export function renderReport(result: ScanResult, generatedAt = new Date()): string {
+  const { findings, shFiles } = result
 
   // Group by severity
   const errors = findings.filter((f) => f.severity === "error")
@@ -239,7 +282,7 @@ async function main() {
   const reportLines: string[] = []
   reportLines.push("# Windows Compatibility Scan Report")
   reportLines.push("")
-  reportLines.push(`Generated: ${new Date().toISOString()}`)
+  reportLines.push(`Generated: ${generatedAt.toISOString()}`)
   reportLines.push("")
   reportLines.push("## Summary")
   reportLines.push("")
@@ -298,16 +341,69 @@ async function main() {
   reportLines.push("---")
   reportLines.push("*Run this scan anytime with: `bun run scripts/windows-compat-scan.ts`*")
 
-  const report = reportLines.join("\n")
-  await Bun.write("docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md", report)
-
-  console.log(report)
-  console.log(`\n[OK] Report written to docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`)
-  console.log(`   Errors: ${errors.length}, Warnings: ${warnings.length}, Info: ${infos.length}`)
-  console.log(`   Bash scripts: ${shFiles.length}`)
+  return reportLines.join("\n")
 }
 
-main().catch((err) => {
-  console.error("Scan failed:", err)
-  process.exit(1)
-})
+export function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = { noWrite: false }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === "--no-write" || arg === "--dry-run") {
+      options.noWrite = true
+    } else if (arg === "--output") {
+      const value = args[++i]
+      if (!value) throw new Error("--output requires a path")
+      options.outputPath = value
+    } else if (arg === "--config") {
+      const value = args[++i]
+      if (!value) throw new Error("--config requires a path")
+      options.configPath = value
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+export async function runCli(args = process.argv.slice(2), options: RunCliOptions = {}): Promise<ScanResult> {
+  const rootDir = options.rootDir ?? process.cwd()
+  const output = options.stdout ?? console
+  const cliOptions = parseCliArgs(args)
+
+  output.log("[SCAN] Windows Compatibility Scan\n")
+
+  const result = await runScan({ rootDir, configPath: cliOptions.configPath })
+  const report = renderReport(result)
+  const errors = result.findings.filter((f) => f.severity === "error")
+  const warnings = result.findings.filter((f) => f.severity === "warn")
+  const infos = result.findings.filter((f) => f.severity === "info")
+
+  const reportPath = cliOptions.outputPath
+    ? path.resolve(rootDir, cliOptions.outputPath)
+    : path.join(rootDir, DEFAULT_REPORT_PATH)
+
+  if (!cliOptions.noWrite) {
+    await mkdir(path.dirname(reportPath), { recursive: true })
+    await writeFile(reportPath, report)
+  }
+
+  output.log(report)
+  if (cliOptions.noWrite) {
+    output.log("\n[OK] Report generated without writing a file")
+  } else {
+    output.log(`\n[OK] Report written to ${toPosixPath(path.relative(rootDir, reportPath))}`)
+  }
+  output.log(`   Errors: ${errors.length}, Warnings: ${warnings.length}, Info: ${infos.length}`)
+  output.log(`   Bash scripts: ${result.shFiles.length}`)
+
+  return result
+}
+
+if (import.meta.main) {
+  runCli().catch((err) => {
+    console.error("Scan failed:", err)
+    process.exit(1)
+  })
+}

--- a/tests/windows-compat-scan.test.ts
+++ b/tests/windows-compat-scan.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, test } from "bun:test"
-import { buildRules, getExclusions, loadConfig, scanContent } from "../scripts/windows-compat-scan"
+import { existsSync } from "fs"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import {
+  buildRules,
+  DEFAULT_REPORT_PATH,
+  getExclusions,
+  loadConfig,
+  runCli,
+  runScan,
+  scanContent,
+} from "../scripts/windows-compat-scan"
+
+async function withTempWorkspace(run: (rootDir: string) => Promise<void>) {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "windows-compat-scan-"))
+  try {
+    await run(rootDir)
+  } finally {
+    await rm(rootDir, { recursive: true, force: true })
+  }
+}
+
+const quietStdout = {
+  log() {},
+  error() {},
+}
 
 describe("windows-compat-scan", () => {
   describe("rules", () => {
@@ -136,6 +162,8 @@ describe("windows-compat-scan", () => {
     test("getExclusions merges defaults and extras", () => {
       const exclusions = getExclusions({ exclude: ["custom/**"] })
       expect(exclusions).toContain("node_modules")
+      expect(exclusions).toContain(".worktrees/**")
+      expect(exclusions).toContain("vendor/**")
       expect(exclusions).toContain("custom/**")
     })
 
@@ -143,11 +171,97 @@ describe("windows-compat-scan", () => {
       const exclusions = getExclusions()
       expect(exclusions).toContain("node_modules")
       expect(exclusions).toContain(".git")
+      expect(exclusions).toContain(".worktrees")
+      expect(exclusions).toContain("vendor")
     })
 
     test("loadConfig returns undefined for missing file", async () => {
       const config = await loadConfig("/nonexistent/path/config.json")
       expect(config).toBeUndefined()
+    })
+  })
+
+  describe("scan execution", () => {
+    test("importing the module does not write the default report", async () => {
+      await withTempWorkspace(async (rootDir) => {
+        const scriptPath = path.resolve(import.meta.dir, "../scripts/windows-compat-scan.ts")
+        const proc = Bun.spawn({
+          cmd: ["bun", "-e", `await import(${JSON.stringify(scriptPath)})`],
+          cwd: rootDir,
+          stdout: "ignore",
+          stderr: "pipe",
+        })
+
+        const exitCode = await proc.exited
+        const stderr = await new Response(proc.stderr).text()
+        expect(stderr).toBe("")
+        expect(exitCode).toBe(0)
+        expect(existsSync(path.join(rootDir, DEFAULT_REPORT_PATH))).toBe(false)
+      })
+    })
+
+    test("--no-write does not write the default report", async () => {
+      await withTempWorkspace(async (rootDir) => {
+        await writeFile(path.join(rootDir, "script.sh"), "#!/bin/bash\n")
+
+        await runCli(["--no-write"], { rootDir, stdout: quietStdout })
+
+        expect(existsSync(path.join(rootDir, DEFAULT_REPORT_PATH))).toBe(false)
+      })
+    })
+
+    test("--dry-run is an alias for --no-write", async () => {
+      await withTempWorkspace(async (rootDir) => {
+        await writeFile(path.join(rootDir, "script.sh"), "#!/bin/bash\n")
+
+        await runCli(["--dry-run"], { rootDir, stdout: quietStdout })
+
+        expect(existsSync(path.join(rootDir, DEFAULT_REPORT_PATH))).toBe(false)
+      })
+    })
+
+    test("--output writes to the requested path", async () => {
+      await withTempWorkspace(async (rootDir) => {
+        await writeFile(path.join(rootDir, "script.sh"), "#!/bin/bash\n")
+
+        await runCli(["--output", "tmp/report.md"], { rootDir, stdout: quietStdout })
+
+        const reportPath = path.join(rootDir, "tmp/report.md")
+        expect(existsSync(reportPath)).toBe(true)
+        expect(await readFile(reportPath, "utf8")).toContain("# Windows Compatibility Scan Report")
+        expect(existsSync(path.join(rootDir, DEFAULT_REPORT_PATH))).toBe(false)
+      })
+    })
+
+    test("default run writes the default report", async () => {
+      await withTempWorkspace(async (rootDir) => {
+        await writeFile(path.join(rootDir, "script.sh"), "#!/bin/bash\n")
+
+        await runCli([], { rootDir, stdout: quietStdout })
+
+        const reportPath = path.join(rootDir, DEFAULT_REPORT_PATH)
+        expect(existsSync(reportPath)).toBe(true)
+        expect(await readFile(reportPath, "utf8")).toContain("script.sh")
+      })
+    })
+
+    test("default exclusions skip .worktrees and vendor", async () => {
+      await withTempWorkspace(async (rootDir) => {
+        await writeFile(path.join(rootDir, "regular.sh"), "#!/bin/bash\n")
+        await writeFile(path.join(rootDir, "vendor.sh"), "#!/bin/bash\n")
+        await mkdir(path.join(rootDir, ".worktrees/review-pr-68/vendor"), { recursive: true })
+        await mkdir(path.join(rootDir, "vendor"), { recursive: true })
+        await writeFile(path.join(rootDir, ".worktrees/review-pr-68/vendor/noisy.sh"), "#!/bin/bash\n")
+        await writeFile(path.join(rootDir, "vendor/noisy.sh"), "#!/bin/bash\n")
+
+        const result = await runScan({ rootDir })
+
+        expect(result.shFiles).toContain("regular.sh")
+        expect(result.shFiles).toContain("vendor.sh")
+        expect(result.shFiles).not.toContain(".worktrees/review-pr-68/vendor/noisy.sh")
+        expect(result.shFiles).not.toContain("vendor/noisy.sh")
+        expect(result.findings.map((finding) => finding.file)).toContain("regular.sh")
+      })
     })
   })
 })


### PR DESCRIPTION
## 背景

`跑前端复杂度评估` 会触发 `scripts/windows-compat-scan.ts`，该脚本原本在模块顶层直接执行扫描并写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。这导致测试或其他工具只要导入扫描函数，就可能产生报告文件写入副作用和无关 diff。

## 主要改动

- 将 Windows 兼容性扫描拆分为可复用的 `runScan`、`renderReport`、`runCli`，并通过 `import.meta.main` 限制 CLI 执行入口。
- 新增 CLI 参数：`--no-write`、`--dry-run`、`--output <path>`、`--config <path>`。
- 保留无参数默认行为：继续写入 `docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`。
- 默认排除 `.worktrees/**` 与 `vendor/**`，同时避免误排根目录普通文件如 `vendor.sh`。
- 增加导入无副作用、dry-run/no-write、指定 output、默认写报告、排除规则等测试覆盖。
- 补充本次需求、计划与 compound solution 文档。

## 验证结果

- `bun test tests/windows-compat-scan.test.ts`：36 pass
- `bun run release:validate`：通过
- `bun run scripts/windows-compat-scan.ts --no-write`：通过，未写报告
- `git diff -- docs/async-progress/WINDOWS_COMPAT_SCAN_REPORT.md`：无 diff

## 已知风险/后续

- `--output --dry-run` 目前会把 `--dry-run` 当作路径值；当前语义声明为 `--output <path>`，本 PR 不阻塞。后续可增强参数解析，拒绝以 `--` 开头的路径值或增加更明确的错误信息。
- 全量 `bun test` 在当前环境因缺少 `js-yaml`、`citty` 等依赖失败；本次相关测试文件和 release validation 已通过。
