### PR TITLE
test(skills): 固化 GaleHarnessCLI agent 引用命名空间约束

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,11 +144,12 @@ Only add a provider when the target format is stable, documented, and has a clea
 
 ## Agent References in Skills
 
-When referencing agents from within skill SKILL.md files (e.g., via the `Agent` or `Task` tool), always use the **fully-qualified namespace**: `galeharness-cli:<category>:<agent-name>`. Never use the short agent name alone.
+When referencing agents from within skill SKILL.md files (e.g., via the `Agent` or `Task` tool), always use the two-segment plugin namespace: `galeharness-cli:<agent-name>`. The `<agent-name>` must match a real file in `plugins/galeharness-cli/agents/<agent-name>.md`. Never use the short agent name alone, and do not add a category segment.
 
 Example:
-- `galeharness-cli:research:learnings-researcher` (correct)
+- `galeharness-cli:learnings-researcher` (correct)
 - `learnings-researcher` (wrong — will fail to resolve at runtime)
+- `galeharness-cli:<category>:<agent-name>` (wrong — GaleHarnessCLI agents are currently flat)
 
 This prevents resolution failures when the plugin is installed alongside other plugins that may define agents with the same short name.
 

--- a/docs/brainstorms/2026-04-25-agent-reference-lint-requirements.md
+++ b/docs/brainstorms/2026-04-25-agent-reference-lint-requirements.md
@@ -1,0 +1,111 @@
+---
+date: 2026-04-25
+topic: agent-reference-lint
+---
+
+# Agent Reference Lint
+
+## Problem Frame
+
+GaleHarnessCLI 技能文档会调度插件内置 agents。根 `AGENTS.md` 当前要求 agent 引用使用 `galeharness-cli:<category>:<agent-name>`，但仓库真实结构和 converter 行为已经围绕扁平 agent 名称工作：`plugins/galeharness-cli/agents` 下的 agent 文件是扁平的，converter 测试也覆盖了二段 `galeharness-cli:<agent-name>` 被转换成目标平台可解析的本地 agent 名。
+
+这种“规范与实际内容不一致”会让维护者误判应该修三段引用还是二段引用，也会让技能文档里新增的 agent dispatch 逃过约束。需要一个小而闭环的 lint/contract test，把当前真实标准固化下来，并同步修正过时规范。
+
+---
+
+## Actors
+
+- A1. 技能维护者：修改 `plugins/galeharness-cli/skills/**` 和 agent 文档时，需要知道哪种 agent 引用形态是有效的。
+- A2. Converter 维护者：维护 `src/converters/**` 和目标平台 writer 时，需要确保技能文档引用不会破坏转换后的 agent dispatch。
+- A3. 下游执行 agent：运行技能文档中的调度说明时，需要获得可解析、无歧义的 agent 名称。
+
+---
+
+## Key Flows
+
+- F1. 维护者新增或修改技能文档中的 agent 调度引用
+  - **Trigger:** 技能文档出现新的 `galeharness-cli:*` agent 引用。
+  - **Actors:** A1, A2
+  - **Steps:** 维护者编辑技能文档；测试扫描技能文档和 agent 文档中的插件内 agent 引用；测试确认每个引用匹配允许形态并指向真实 agent 或真实 skill。
+  - **Outcome:** 错误引用在 PR 测试阶段失败，而不是发布后才被某个平台调度失败暴露。
+  - **Covered by:** R1, R2, R3, R5
+
+- F2. 维护者查阅项目规范
+  - **Trigger:** 维护者阅读 `AGENTS.md` 或 `plugins/galeharness-cli/AGENTS.md` 决定引用格式。
+  - **Actors:** A1
+  - **Steps:** 维护者看到与当前仓库结构一致的规则；规则说明 agent 引用使用二段 `galeharness-cli:<agent-name>`；规则区分 skill 引用、slash command 和非 agent colon 字符串。
+  - **Outcome:** 新文档按真实标准书写，避免继续引入三段示例或不存在的 category。
+  - **Covered by:** R1, R4
+
+---
+
+## Requirements
+
+**Reference standard**
+- R1. GaleHarnessCLI 技能文档中的插件内 agent 引用标准应明确为二段 `galeharness-cli:<agent-name>`，其中 `<agent-name>` 必须对应 `plugins/galeharness-cli/agents/<agent-name>.md` 的真实 agent 名。
+- R2. 三段 `galeharness-cli:<category>:<agent-name>` 不应作为当前 GaleHarnessCLI 技能文档的标准，因为当前 agent 文件和 converter 处理都不保留 category 作为可解析命名空间。
+- R3. lint/contract test 应扫描 `AGENTS.md`、`plugins/galeharness-cli/AGENTS.md`、`plugins/galeharness-cli/skills/**`、`plugins/galeharness-cli/agents/**` 中的 `galeharness-cli:*` 引用，并区分 agent 引用、skill 引用、slash command、路径或普通 prose。
+
+**Documentation alignment**
+- R4. 根 `AGENTS.md` 和 `plugins/galeharness-cli/AGENTS.md` 中与 agent 分类目录或三段引用相矛盾的说明应改成当前真实标准；如果仍保留历史说明，必须明确它不是当前可执行规范。
+
+**Validation behavior**
+- R5. 测试失败信息应指出具体文件、引用文本、失败原因，以及可用的正确形态，便于维护者直接修正文档。
+- R6. 测试不应要求大型 agent resolver 重构，也不应改变 converter 的现有扁平化行为。
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R5.** Given 技能文档包含 `galeharness-cli:repo-research-analyst`，when 运行 contract test，then 测试通过，因为 `plugins/galeharness-cli/agents/repo-research-analyst.md` 存在。
+- AE2. **Covers R2, R4, R5.** Given 文档包含 `galeharness-cli:research:learnings-researcher` 作为当前 agent 引用规范，when 运行 contract test，then 测试失败并提示当前标准是 `galeharness-cli:learnings-researcher`。
+- AE3. **Covers R3, R6.** Given 文档包含 `/galeharness-cli:agent-native-architecture` 或 `galeharness-cli:gh-plan` 这类非 agent 引用，when 运行 contract test，then 测试不会把它们误判为 agent dispatch 错误。
+
+---
+
+## Success Criteria
+
+- `bun test` 能覆盖 GaleHarnessCLI agent reference contract，新增错误引用会稳定失败。
+- 维护者阅读项目说明后能明确知道当前最终标准是二段 `galeharness-cli:<agent-name>`，不是三段 category 命名空间。
+- 计划阶段无需重新决定是否重构 agent 目录、resolver 或 converter；本轮范围保持为文档标准对齐和测试约束。
+
+---
+
+## Scope Boundaries
+
+- 不做大型 agent resolver 重构。
+- 不把 `plugins/galeharness-cli/agents` 迁移成分类目录。
+- 不改变 converter 对二段或三段引用的目标平台扁平化策略，除非测试暴露当前行为与文档标准冲突且需要最小修正。
+- 不处理其他插件的 agent 引用规则；本轮只约束 GaleHarnessCLI 自己的技能和 agent 文档。
+- 不提交、推送或开 PR。
+
+---
+
+## Key Decisions
+
+- 最终标准采用二段 `galeharness-cli:<agent-name>`：这是当前仓库 agent 文件结构、converter 注释和现有测试共同支持的真实标准。三段标准需要分类目录或 resolver 语义配套，否则只会把不可解析规范写进文档。
+- 用 contract test 固化标准，而不是只做一次性 grep 修文档：问题本质是规范漂移，测试能防止后续技能继续引入错误形态。
+- 扫描范围包括根说明、插件说明、skills 和 agents：根说明是当前矛盾来源之一，agent 文档也可能给出示例或检查标准。
+
+---
+
+## Dependencies / Assumptions
+
+- 当前 `plugins/galeharness-cli/agents` 是扁平文件目录，未发现分类子目录。
+- 当前 converter 目标会把 agent 引用转换成目标平台本地可解析的扁平 agent 名。
+- `galeharness-cli:<skill-name>` 和 slash command 可能合法存在，lint 需要通过真实 agent 列表和技能列表避免误报。
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R3][Technical] 测试应放在现有哪个 test 文件，还是新增专门的 contract test 文件？
+- [Affects R3, R5][Technical] 扫描规则应使用现有 parser/frontmatter 工具，还是简单文件读取加正则就足够？
+
+---
+
+## Next Steps
+
+-> `/gh:plan` for structured implementation planning

--- a/docs/plans/2026-04-25-002-fix-agent-reference-lint-plan.md
+++ b/docs/plans/2026-04-25-002-fix-agent-reference-lint-plan.md
@@ -1,0 +1,241 @@
+---
+title: fix: Add GaleHarnessCLI agent reference lint
+type: fix
+status: active
+date: 2026-04-25
+origin: docs/brainstorms/2026-04-25-agent-reference-lint-requirements.md
+---
+
+# fix: Add GaleHarnessCLI agent reference lint
+
+## Overview
+
+本计划把 GaleHarnessCLI 内部 agent 引用标准固化为可测试 contract：当前最终标准是二段 `galeharness-cli:<agent-name>`，其中 `<agent-name>` 对应 `plugins/galeharness-cli/agents/<agent-name>.md` 的真实 agent。三段 `galeharness-cli:<category>:<agent-name>` 是当前文档规范漂移，不作为本轮目标标准。
+
+实现范围保持小闭环：新增一个 contract test 扫描项目说明、技能文档和 agent 文档中的 `galeharness-cli:*` 引用；修正根说明、插件说明和现有三段示例；不做 agent resolver、目录结构或 converter 行为重构。
+
+---
+
+## Problem Frame
+
+需求文档指出，根 `AGENTS.md` 要求三段 agent 引用，但仓库实际 agent 文件是扁平结构，converter 也会把二段或三段引用压平成目标平台本地 agent 名。继续保留三段规范会让维护者把不可解析的 category 语义写进技能文档，且没有测试防止漂移继续发生。计划以需求文档为源，修复“规范与实际内容不一致”的问题。(see origin: `docs/brainstorms/2026-04-25-agent-reference-lint-requirements.md`)
+
+---
+
+## Requirements Trace
+
+- R1. GaleHarnessCLI 技能文档中的插件内 agent 引用标准是二段 `galeharness-cli:<agent-name>`。
+- R2. 三段 `galeharness-cli:<category>:<agent-name>` 不作为当前标准。
+- R3. contract test 扫描 `AGENTS.md`、`plugins/galeharness-cli/AGENTS.md`、`plugins/galeharness-cli/skills/**`、`plugins/galeharness-cli/agents/**`，并区分 agent、skill、slash command 和普通 prose。
+- R4. 根 `AGENTS.md` 和 `plugins/galeharness-cli/AGENTS.md` 中过时的分类目录或三段规范要对齐当前真实标准。
+- R5. 测试失败信息要给出文件、引用文本、失败原因和推荐修正形态。
+- R6. 不做大型 resolver 重构，不改变 converter 现有扁平化行为。
+
+**Origin actors:** A1 技能维护者, A2 Converter 维护者, A3 下游执行 agent
+**Origin flows:** F1 新增或修改技能文档中的 agent 调度引用, F2 查阅项目规范
+**Origin acceptance examples:** AE1 二段真实 agent 引用通过, AE2 三段 agent 引用失败并建议二段, AE3 非 agent 引用不误报
+
+---
+
+## Scope Boundaries
+
+- 不迁移 `plugins/galeharness-cli/agents` 到分类目录。
+- 不修改 agent dispatch resolver 或目标平台 writer 的转换策略。
+- 不要求其他插件采用 GaleHarnessCLI 的引用标准。
+- 不改 release-owned 版本、release notes 或 marketplace manifest。
+- 不在本阶段实现、提交、推送或开 PR。
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `plugins/galeharness-cli/agents/*.md`：当前 agent 源文件是扁平目录，frontmatter `name` 也是扁平名称。
+- `src/parsers/claude.ts`：Claude plugin parser 递归收集 agent Markdown 文件，并以 frontmatter `name` 或文件 basename 作为 agent 名。
+- `src/converters/claude-to-opencode.ts`：现有注释和实现会把三段和二段 agent 引用压平成目标平台本地 agent 名，并避免误改 skill 引用。
+- `tests/pipeline-review-contract.test.ts`、`tests/review-skill-contract.test.ts`：现有 contract tests 使用 repo-relative 文件读取和 `bun:test`，适合新增同类文档约束测试。
+- `tests/frontmatter.test.ts`：已有递归遍历 Markdown/frontmatter 的简单本地工具模式，可复用思路但不需要抽共享 helper。
+
+### Institutional Learnings
+
+- HKTMemory 检索没有返回直接相关的 agent reference lint 方案；返回内容主要是 Windows、platform capability manifest、Karpathy guardrails 等相邻主题。
+- `docs/solutions/integrations/colon-namespaced-names-break-windows-paths-2026-03-26.md` 是相邻风险提醒：colon 命名空间跨平台有历史坑，当前计划只扫描 Markdown 文本，不新增路径命名空间。
+
+### External References
+
+- 未使用外部研究。该变更是仓库内部 contract/test 与文档标准对齐，外部资料不会改变标准选择。
+
+---
+
+## Key Technical Decisions
+
+- 最终标准选择二段 `galeharness-cli:<agent-name>`：这是当前 agent 文件结构、converter 注释和现有测试支持的真实标准，能保留插件命名空间并避免引入不存在的 category 语义。
+- 新增专门的 `tests/agent-reference-contract.test.ts`，而不是塞进 converter test：该测试约束的是源文档 contract，不是某个目标转换器行为。
+- 扫描用文件系统读取和正则分类即可：需要检查 Markdown 文本里的引用形态，不需要解析完整 Markdown AST。分类必须由真实 agent 名集合和真实 skill 名集合驱动，避免误报 `galeharness-cli:gh-plan` 这类 skill 引用。
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- 测试位置：新增 `tests/agent-reference-contract.test.ts`，保持职责清晰。
+- 扫描规则：使用简单文件读取、递归遍历和正则提取 `galeharness-cli:*` token；用 agent/skill 集合判断 token 语义，避免过度工程。
+
+### Deferred to Implementation
+
+- 具体错误消息格式：实现时可按 `bun:test` 的断言输出调整，但必须包含文件、引用文本、原因和推荐形态。
+- 是否需要修正额外引用：以 contract test 首次失败列表为准，除已知的 `AGENTS.md`、`plugins/galeharness-cli/AGENTS.md` 和 `plugins/galeharness-cli/agents/project-standards-reviewer.md` 外，不预先枚举所有可能文本改动。
+
+---
+
+## Implementation Units
+
+- [ ] U1. **Add agent reference contract test**
+
+**Goal:** 新增测试扫描 GaleHarnessCLI 源文档中的 agent 引用，禁止当前标准之外的三段 agent 引用和未知二段 agent 引用。
+
+**Requirements:** R1, R2, R3, R5, R6; covers F1; covers AE1, AE2, AE3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `tests/agent-reference-contract.test.ts`
+- Read patterns: `plugins/galeharness-cli/agents/**/*.md`, `plugins/galeharness-cli/skills/**/*.md`, `AGENTS.md`, `plugins/galeharness-cli/AGENTS.md`
+
+**Approach:**
+- Build an allowed agent set from `plugins/galeharness-cli/agents/**/*.md`, using frontmatter `name` when present and filename basename as fallback.
+- Build a skill set from `plugins/galeharness-cli/skills/*/SKILL.md`, using frontmatter `name` or directory basename.
+- Scan target Markdown files for `galeharness-cli:` colon tokens.
+- Treat `/galeharness-cli:*` slash-command-like references and known skill references as non-agent references.
+- Pass two-segment `galeharness-cli:<agent-name>` when `<agent-name>` exists in the agent set.
+- Fail three-segment `galeharness-cli:<category>:<agent-name>` when `<agent-name>` exists in the agent set, with recommendation `galeharness-cli:<agent-name>`.
+- Fail unknown `galeharness-cli:*` references unless they are classified as known skills or slash commands.
+
+**Execution note:** Add the test first and confirm it catches the existing three-segment documentation drift before fixing docs.
+
+**Patterns to follow:**
+- `tests/pipeline-review-contract.test.ts` for repo-relative `readRepoFile` style and readable contract assertions.
+- `tests/frontmatter.test.ts` for shallow recursive Markdown collection patterns.
+
+**Test scenarios:**
+- Happy path: existing `galeharness-cli:repo-research-analyst` in skill docs maps to an agent file and passes.
+- Error path: existing `galeharness-cli:research:learnings-researcher` in standards text is reported as invalid for current GaleHarnessCLI agent references.
+- Edge case: `/galeharness-cli:agent-native-architecture` is not treated as an agent dispatch failure.
+- Edge case: `galeharness-cli:gh-plan` or another real skill reference is not treated as an agent dispatch failure.
+- Error path: an unknown two-segment `galeharness-cli:not-real-agent` would fail with a missing-agent reason.
+
+**Verification:**
+- The new targeted test fails before documentation alignment and passes after U2.
+- Failure output is specific enough for a maintainer to locate and fix the reference without rerunning exploratory scans.
+
+---
+
+- [ ] U2. **Align project and plugin documentation with the two-segment standard**
+
+**Goal:** 修正当前已知的规范漂移，让说明文档与 contract test 的最终标准一致。
+
+**Requirements:** R1, R2, R4, R5; covers F2; covers AE2
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `plugins/galeharness-cli/AGENTS.md`
+- Modify: `plugins/galeharness-cli/agents/project-standards-reviewer.md`
+- Test: `tests/agent-reference-contract.test.ts`
+
+**Approach:**
+- 在根 `AGENTS.md` 的 “Agent References in Skills” 中把当前规范改为二段 `galeharness-cli:<agent-name>`，并更新示例为 `galeharness-cli:learnings-researcher`。
+- 在 `plugins/galeharness-cli/AGENTS.md` 中修正过时的 agent 目录结构说明：当前 agent 源目录是扁平的；如果保留类别概念，只描述为 README/维护分组语义，而不是路径或引用命名空间。
+- 在 `project-standards-reviewer.md` 中把 broken-reference 示例从三段推荐改为二段推荐。
+- 不批量改写所有二段引用；它们是目标标准。
+
+**Patterns to follow:**
+- 保持 `AGENTS.md` 现有指令式、短段落风格。
+- 保持 `plugins/galeharness-cli/AGENTS.md` checklist 风格，不引入大段历史解释。
+
+**Test scenarios:**
+- Happy path: contract test 不再发现三段 agent 引用作为当前标准。
+- Integration: 根说明、插件说明和 standards reviewer 文档都通过同一套扫描规则。
+- Regression: 现有二段 agent 引用仍保留，不被改成三段。
+
+**Verification:**
+- 维护者阅读根说明和插件说明时看到同一个二段标准。
+- `plugins/galeharness-cli/agents/project-standards-reviewer.md` 不再鼓励三段引用。
+
+---
+
+- [ ] U3. **Validate targeted and full test impact**
+
+**Goal:** 确认新 contract 不破坏现有 converter/writer 语义，并满足仓库测试要求。
+
+**Requirements:** R5, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Test: `tests/agent-reference-contract.test.ts`
+- Existing related tests: `tests/converter.test.ts`, `tests/codex-converter.test.ts`, `tests/review-skill-contract.test.ts`, `tests/pipeline-review-contract.test.ts`
+
+**Approach:**
+- 先验证新增 contract test 的失败到通过路径。
+- 再运行相关 contract/converter tests，确认文档标准调整没有改变目标平台转换行为。
+- 最后按仓库 `AGENTS.md` 对解析、转换或输出相关变更的要求运行完整 `bun test`。
+
+**Patterns to follow:**
+- 不把测试结果写入实现文件；验证结果只在执行阶段汇报。
+
+**Test scenarios:**
+- Integration: contract test 和现有 converter tests 同时通过，说明源文档标准与目标平台扁平化行为并存。
+- Regression: OpenCode/Codex 等目标仍能处理既有二段 agent 引用。
+- Documentation: standards 文档检查不再与真实 agent layout 冲突。
+
+**Verification:**
+- 新增 targeted test 通过。
+- 相关 converter/contract tests 通过。
+- 完整 `bun test` 通过，或执行阶段明确记录非本次变更导致的失败。
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** 影响技能文档维护、project standards reviewer 的检查建议，以及测试阶段对 agent 引用的约束；不改变运行时 dispatch。
+- **Error propagation:** 错误引用从运行时调度失败前移到测试失败。
+- **State lifecycle risks:** 无持久状态或迁移风险。
+- **API surface parity:** 不改变 CLI、converter 输出路径或目标平台安装结构。
+- **Integration coverage:** 通过新增 contract test 加现有 converter tests 证明源文档标准和转换器扁平化行为一致。
+- **Unchanged invariants:** agent 源文件仍位于 `plugins/galeharness-cli/agents/*.md`；二段引用仍是技能文档中的标准；target writer 仍可按各平台规则压平 agent 名。
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| 正则扫描误把 skill 引用或 slash command 当成 agent 引用 | 用真实 agent set、skill set 和 slash 前缀分类，新增 AE3 对应测试场景 |
+| 文档仍存在过时分类目录说明 | U2 明确修改 `plugins/galeharness-cli/AGENTS.md` 的目录结构描述 |
+| 未来真的引入分类 agent 目录时本测试阻止三段引用 | 这是有意约束；未来分类化应先更新需求、resolver/converter 语义和 contract test |
+| 新测试过于宽松，只检查当前已知文件 | 扫描 root/plugin AGENTS、所有 skills、所有 agents，覆盖新增文档引用 |
+
+---
+
+## Documentation / Operational Notes
+
+- 这是测试和规范对齐变更，不需要 release-owned version bump。
+- 不需要更新 README 组件数量，因为不新增 skill、agent 或 command。
+- 若实现阶段修改 `plugins/galeharness-cli/AGENTS.md` 的目录布局说明，保持它与真实文件树一致即可，不扩展成 agent inventory 重写。
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-25-agent-reference-lint-requirements.md`
+- Root standard source: `AGENTS.md`
+- Plugin maintenance source: `plugins/galeharness-cli/AGENTS.md`
+- Existing agent docs: `plugins/galeharness-cli/agents`
+- Existing skill docs: `plugins/galeharness-cli/skills`
+- Converter behavior reference: `src/converters/claude-to-opencode.ts`
+- Parser behavior reference: `src/parsers/claude.ts`
+- Test style references: `tests/pipeline-review-contract.test.ts`, `tests/review-skill-contract.test.ts`, `tests/frontmatter.test.ts`

--- a/docs/solutions/developer-experience/agent-reference-namespace-contract-2026-04-25.md
+++ b/docs/solutions/developer-experience/agent-reference-namespace-contract-2026-04-25.md
@@ -1,0 +1,121 @@
+---
+title: "GaleHarnessCLI agent references need a source-level namespace contract"
+date: 2026-04-25
+category: developer-experience
+module: galeharness-cli
+problem_type: developer_experience
+component: testing_framework
+severity: medium
+applies_when:
+  - "技能文档会调度同一插件内的 agents"
+  - "项目说明、真实目录结构和 converter 行为对引用格式产生漂移"
+  - "文档中的 agent 引用需要在发布前被测试约束"
+tags:
+  - agent-references
+  - contract-tests
+  - galeharness-cli
+  - skills
+  - developer-experience
+---
+
+# GaleHarnessCLI agent references need a source-level namespace contract
+
+## Context
+
+GaleHarnessCLI 的技能文档会通过 `galeharness-cli:*` 引用插件内置 agents。问题是项目说明一度要求三段 `galeharness-cli:<category>:<agent-name>`，但真实源码结构是扁平的：agents 位于 `plugins/galeharness-cli/agents/*.md`，converter 和现有内容也围绕二段 `galeharness-cli:<agent-name>` 工作。
+
+这类漂移不能只靠一次性 grep 修正。维护者会继续从 `AGENTS.md`、插件说明或 reviewer agent 的检查清单里学习当前规范；如果规范与运行时可解析结构不一致，错误引用会在技能执行或目标平台转换后才暴露。
+
+## Guidance
+
+把当前标准明确为二段插件命名空间：
+
+```text
+galeharness-cli:<agent-name>
+```
+
+其中 `<agent-name>` 必须对应 `plugins/galeharness-cli/agents/<agent-name>.md` 的真实 agent 名。三段 `galeharness-cli:<category>:<agent-name>` 不作为当前 GaleHarnessCLI 源文档标准，因为仓库没有分类 agent 目录，也没有 category-aware resolver 语义。
+
+用源级 contract test 固化这个规则，而不是改 converter 或迁移目录结构。测试应扫描会承载维护规范或调度示例的 Markdown：
+
+- `AGENTS.md`
+- `plugins/galeharness-cli/AGENTS.md`
+- `plugins/galeharness-cli/skills/**/*.md`，包括 `references/*.md`
+- `plugins/galeharness-cli/agents/**/*.md`
+
+测试逻辑需要先从真实文件系统构建 agent 集合和 skill 集合，再分类 `galeharness-cli:*` token：
+
+- 二段真实 agent 引用通过。
+- 三段且末段是真实 agent 的引用失败，并建议改成二段。
+- 未知二段引用失败，并提示必须指向真实 agent 或真实 skill。
+- slash command 形式如 `/galeharness-cli:...` 不作为 agent dispatch 失败。
+- 真实 skill 引用不误报为 agent 失败。
+
+本轮落地为 `tests/agent-reference-contract.test.ts`，并同步更新了根 `AGENTS.md`、`plugins/galeharness-cli/AGENTS.md` 和 `plugins/galeharness-cli/agents/project-standards-reviewer.md` 中的过时说明或示例。
+
+## Why This Matters
+
+agent 引用格式是技能文档、项目标准、converter 和目标平台执行之间的接口。只改说明文档无法防止后续新增技能再次引入三段示例；只改 converter 又会把一个文档规范问题扩大成运行时 resolver 重构。
+
+contract test 把失败前移到 PR 阶段，并给维护者具体文件、引用文本、失败原因和推荐修正形态。这样新技能或 reviewer 文档一旦写入不可解析的 agent 引用，就会在 `bun test` 中直接失败。
+
+## When to Apply
+
+- 插件内技能需要调度同一插件的 agents。
+- agent 文件结构是扁平目录，但文档出现了 category 命名空间。
+- converter 对引用格式有兼容行为，但源文档需要更严格的 authoring contract。
+- 规范文本本身也需要被测试覆盖，避免 reviewer 或 AGENTS 指令继续传播旧标准。
+
+## Examples
+
+当前正确引用：
+
+```markdown
+Dispatch `galeharness-cli:learnings-researcher` to search prior solutions.
+```
+
+当前应失败的三段引用：
+
+```markdown
+Dispatch `galeharness-cli:research:learnings-researcher`.
+```
+
+测试失败时应推荐：
+
+```text
+Use galeharness-cli:learnings-researcher.
+```
+
+真实 skill 引用和 slash command 不是 agent dispatch 错误：
+
+```markdown
+/galeharness-cli:agent-native-architecture
+galeharness-cli:gh:plan
+```
+
+## Validation
+
+本轮验证过：
+
+- `bun test tests/agent-reference-contract.test.ts`：4 pass
+- `bun run release:validate`：通过
+- `bun test`：在执行 `bun install --frozen-lockfile` 后通过，1246 pass，3 skip，0 fail
+
+收尾提交前仍应至少重跑 targeted contract test 和 `bun run release:validate`，确认新增 compound 文档和最终 diff 没有引入副作用。
+
+## Future Extension
+
+如果未来确实要支持三段 `galeharness-cli:<category>:<agent-name>`，不要只放宽测试。应先补齐这些前置条件：
+
+- agent 源目录、frontmatter 或 manifest 中有稳定 category 语义。
+- 技能执行端和 converter 都知道 category 是否参与解析，还是仅用于作者分组。
+- 目标平台输出中同名不同 category agent 的冲突策略明确。
+- contract test 更新为新的真实标准，并覆盖二段兼容策略或迁移失败提示。
+
+在这些语义补齐前，三段引用会制造一种看似更精确、实际不可解析的规范。
+
+## Related
+
+- `docs/brainstorms/2026-04-25-agent-reference-lint-requirements.md`
+- `docs/plans/2026-04-25-002-fix-agent-reference-lint-plan.md`
+- `tests/agent-reference-contract.test.ts`

--- a/plugins/galeharness-cli/AGENTS.md
+++ b/plugins/galeharness-cli/AGENTS.md
@@ -33,11 +33,7 @@ Before committing ANY changes:
 
 ```
 agents/
-├── review/           # Code review agents
-├── document-review/  # Plan and requirements document review agents
-├── research/         # Research and analysis agents
-├── design/           # Design and UI agents
-└── docs/             # Documentation agents
+└── <agent-name>.md   # Flat agent files; reference as galeharness-cli:<agent-name>
 
 skills/
 ├── ce-*/          # Core workflow skills (gh:plan, gh:review, etc.)
@@ -208,7 +204,7 @@ grep -E '^description:' skills/*/SKILL.md
 ## Adding Components
 
 - **New skill:** Create `skills/<name>/SKILL.md` with required YAML frontmatter (`name`, `description`). Reference files go in `skills/<name>/references/`. Add the skill to the appropriate category table in `README.md` and update the skill count.
-- **New agent:** Create `agents/<category>/<name>.md` with frontmatter. Categories: `review`, `document-review`, `research`, `design`, `docs`, `workflow`. Add the agent to `README.md` and update the agent count.
+- **New agent:** Create `agents/<name>.md` with frontmatter. Reference it from skills as `galeharness-cli:<name>`. Add the agent to `README.md` and update the agent count.
 
 ## Beta Skills
 

--- a/plugins/galeharness-cli/agents/project-standards-reviewer.md
+++ b/plugins/galeharness-cli/agents/project-standards-reviewer.md
@@ -29,7 +29,7 @@ In either case, identify which sections apply to the file types in the diff. A s
 
 - **Reference file inclusion mistakes** -- markdown links (`[file](./references/file.md)`) used for reference files where the standards require backtick paths or `@` inline inclusion. Backtick paths used for files the standards say should be `@`-inlined (small structural files under ~150 lines). `@` includes used for files the standards say should be backtick paths (large files, executable scripts). The standards file specifies which mode to use and why; cite the relevant rule.
 
-- **Broken cross-references** -- agent names that are not fully qualified (e.g., `learnings-researcher` instead of `galeharness-cli:research:learnings-researcher`). Skill-to-skill references using slash syntax inside a SKILL.md where the standards say to use semantic wording. References to tools by platform-specific names without naming the capability class.
+- **Broken cross-references** -- agent names that are not fully qualified (e.g., `learnings-researcher` instead of `galeharness-cli:learnings-researcher`) or that use a non-existent category segment. Skill-to-skill references using slash syntax inside a SKILL.md where the standards say to use semantic wording. References to tools by platform-specific names without naming the capability class.
 
 - **Cross-platform portability violations** -- platform-specific tool names used without equivalents (e.g., `TodoWrite` instead of `TaskCreate`/`TaskUpdate`/`TaskList`). Slash references in pass-through SKILL.md files that won't be remapped. Assumptions about tool availability that break on other platforms.
 

--- a/tests/agent-reference-contract.test.ts
+++ b/tests/agent-reference-contract.test.ts
@@ -1,0 +1,207 @@
+import { readdirSync, readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const repoRoot = process.cwd()
+const pluginRoot = "plugins/galeharness-cli"
+const agentRoot = `${pluginRoot}/agents`
+const skillRoot = `${pluginRoot}/skills`
+
+type ReferenceFailure = {
+  file: string
+  reference: string
+  reason: string
+  recommendation: string
+}
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function collectMarkdownFiles(relativeDir: string): string[] {
+  const results: string[] = []
+  const absoluteDir = path.join(repoRoot, relativeDir)
+
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const absolutePath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(absolutePath)
+        continue
+      }
+      if (!entry.name.endsWith(".md")) continue
+      results.push(path.relative(repoRoot, absolutePath))
+    }
+  }
+
+  walk(absoluteDir)
+  return results.sort()
+}
+
+function frontmatterName(relativePath: string): string | undefined {
+  const raw = readRepoFile(relativePath)
+  const lines = raw.split(/\r?\n/)
+  if (lines[0]?.trim() !== "---") return undefined
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() === "---") return undefined
+    const match = line.match(/^name:\s*(.+?)\s*$/)
+    if (!match) continue
+    return match[1].replace(/^["']|["']$/g, "")
+  }
+
+  return undefined
+}
+
+function buildAgentNames(): Set<string> {
+  return new Set(
+    collectMarkdownFiles(agentRoot).map((file) => {
+      return frontmatterName(file) ?? path.basename(file, ".md")
+    }),
+  )
+}
+
+function buildSkillNames(): Set<string> {
+  const names = new Set<string>()
+  for (const skillFile of collectMarkdownFiles(skillRoot).filter((file) => file.endsWith("/SKILL.md"))) {
+    const directoryName = path.basename(path.dirname(skillFile))
+    names.add(directoryName)
+    const name = frontmatterName(skillFile)
+    if (name) names.add(name)
+  }
+  return names
+}
+
+function scanReferenceFailures(files: string[], agentNames: Set<string>, skillNames: Set<string>): ReferenceFailure[] {
+  return scanReferenceEntries(
+    files.map((file) => ({ file, content: readRepoFile(file) })),
+    agentNames,
+    skillNames,
+  )
+}
+
+function scanReferenceEntries(
+  entries: { file: string; content: string }[],
+  agentNames: Set<string>,
+  skillNames: Set<string>,
+): ReferenceFailure[] {
+  const failures: ReferenceFailure[] = []
+  const referencePattern = /galeharness-cli:[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*/g
+
+  for (const { file, content } of entries) {
+    for (const match of content.matchAll(referencePattern)) {
+      const reference = match[0]
+      const before = content[match.index - 1]
+      if (before === "/") continue
+
+      const parts = reference.split(":")
+      const pluginLocalName = reference.slice("galeharness-cli:".length)
+      const localName = parts.at(-1) ?? ""
+
+      if (skillNames.has(pluginLocalName)) continue
+
+      if (parts.length === 2) {
+        if (agentNames.has(localName) || skillNames.has(localName)) continue
+
+        failures.push({
+          file,
+          reference,
+          reason: `Unknown GaleHarnessCLI reference "${localName}". It is not a real agent or skill.`,
+          recommendation: "Use galeharness-cli:<agent-name> where <agent-name> exists under plugins/galeharness-cli/agents/*.md, or use a real skill name.",
+        })
+        continue
+      }
+
+      if (parts.length === 3 && agentNames.has(localName)) {
+        failures.push({
+          file,
+          reference,
+          reason: "Three-segment agent references are not the current GaleHarnessCLI standard.",
+          recommendation: `Use galeharness-cli:${localName}.`,
+        })
+        continue
+      }
+
+      failures.push({
+        file,
+        reference,
+        reason: "Only two-segment GaleHarnessCLI agent references are supported in source docs.",
+        recommendation: "Use galeharness-cli:<agent-name> for agents, or a real two-segment skill reference.",
+      })
+    }
+  }
+
+  return failures
+}
+
+describe("GaleHarnessCLI agent reference contract", () => {
+  test("uses two-segment references for real plugin agents", () => {
+    const agentNames = buildAgentNames()
+    const skillNames = buildSkillNames()
+    const files = [
+      "AGENTS.md",
+      `${pluginRoot}/AGENTS.md`,
+      ...collectMarkdownFiles(skillRoot),
+      ...collectMarkdownFiles(agentRoot),
+    ]
+
+    const failures = scanReferenceFailures(files, agentNames, skillNames)
+
+    expect(
+      failures,
+      failures.map((failure) => [
+        `${failure.file}: ${failure.reference}`,
+        `reason: ${failure.reason}`,
+        `fix: ${failure.recommendation}`,
+      ].join("\n")).join("\n\n"),
+    ).toEqual([])
+  })
+
+  test("rejects three-segment references to real agents", () => {
+    const failures = scanReferenceEntries(
+      [{ file: "inline.md", content: "Task galeharness-cli:research:learnings-researcher" }],
+      new Set(["learnings-researcher"]),
+      new Set(),
+    )
+
+    expect(failures).toEqual([
+      {
+        file: "inline.md",
+        reference: "galeharness-cli:research:learnings-researcher",
+        reason: "Three-segment agent references are not the current GaleHarnessCLI standard.",
+        recommendation: "Use galeharness-cli:learnings-researcher.",
+      },
+    ])
+  })
+
+  test("rejects unknown two-segment references", () => {
+    const failures = scanReferenceEntries(
+      [{ file: "inline.md", content: "Task galeharness-cli:not-real-agent" }],
+      new Set(["repo-research-analyst"]),
+      new Set(["gh:plan"]),
+    )
+
+    expect(failures).toEqual([
+      {
+        file: "inline.md",
+        reference: "galeharness-cli:not-real-agent",
+        reason: 'Unknown GaleHarnessCLI reference "not-real-agent". It is not a real agent or skill.',
+        recommendation: "Use galeharness-cli:<agent-name> where <agent-name> exists under plugins/galeharness-cli/agents/*.md, or use a real skill name.",
+      },
+    ])
+  })
+
+  test("does not treat slash commands or known skills as agent failures", () => {
+    const failures = scanReferenceEntries(
+      [{
+        file: "inline.md",
+        content: "/galeharness-cli:agent-native-architecture and galeharness-cli:gh:plan",
+      }],
+      new Set(["repo-research-analyst"]),
+      new Set(["gh:plan", "agent-native-architecture"]),
+    )
+
+    expect(failures).toEqual([])
+  })
+})


### PR DESCRIPTION
## 背景

GaleHarnessCLI 的技能文档会通过 `galeharness-cli:*` 引用插件内置 agents。此前根说明要求三段 `galeharness-cli:<category>:<agent-name>`，但真实 agent 源目录是扁平结构，现有 converter 和技能内容也围绕二段 `galeharness-cli:<agent-name>` 工作。这个 PR 将当前真实标准固化为可测试 contract，避免规范漂移继续进入技能文档。

## 主要改动

- 新增 `tests/agent-reference-contract.test.ts`，扫描 root/plugin AGENTS、GaleHarnessCLI skills、references 和 agents 中的 `galeharness-cli:*` 引用。
- 将真实 agent 引用标准明确为二段 `galeharness-cli:<agent-name>`，并对三段真实 agent 引用、未知二段引用给出失败信息和修正建议。
- 避免误报 slash command 和真实 skill 引用。
- 更新 `AGENTS.md`、`plugins/galeharness-cli/AGENTS.md` 和 `project-standards-reviewer` 中过时的三段/分类目录说明。
- 新增 brainstorm、plan 和 compound solution 文档，记录二段标准决策、contract test 方案和未来三段扩展前置条件。

## 验证结果

- `bun test tests/agent-reference-contract.test.ts`：4 pass
- `bun run release:validate`：通过
- `bun test`：此前在本分支执行 `bun install --frozen-lockfile` 后通过，1246 pass，3 skip，0 fail；本次最终收尾未重复全量运行。
- `/gh:review` verdict：APPROVE

## 风险/后续

- 当前 PR 不改 resolver、converter 或 agent 目录结构，只约束源文档 authoring contract。
- 如果未来要支持三段 `galeharness-cli:<category>:<agent-name>`，需要先补齐 category-aware 目录/manifest/resolver/converter 语义，再更新 contract test。
- 新测试会让未来新增的未知 agent 引用在 PR 阶段失败，这是预期约束。