### PR TITLE
fix(test): 修复 agent 引用 contract 测试的 Windows 路径归一化

### DIFF
--- a/tests/agent-reference-contract.test.ts
+++ b/tests/agent-reference-contract.test.ts
@@ -30,7 +30,7 @@ function collectMarkdownFiles(relativeDir: string): string[] {
         continue
       }
       if (!entry.name.endsWith(".md")) continue
-      results.push(path.relative(repoRoot, absolutePath))
+      results.push(path.relative(repoRoot, absolutePath).split(path.sep).join("/"))
     }
   }
 


### PR DESCRIPTION
## 背景

#72 合入后，Windows CI 暴露出 `tests/agent-reference-contract.test.ts` 在 Windows 下使用反斜杠路径，导致真实 skill `galeharness-cli:gh-plan` 没被识别为已知 skill。

## 改动

- 将 `collectMarkdownFiles()` 返回的 repo-relative path 归一化为 `/` 分隔。
- 保持测试 contract 语义不变。

## 验证

- `bun test tests/agent-reference-contract.test.ts`：4 pass
- `bun run release:validate`：通过