### PR TITLE
feat(workflow): 强化 brainstorm 和 ideate 严谨性护栏

### DIFF
--- a/docs/brainstorms/2026-04-25-upstream-brainstorm-ideate-rigor-sync-requirements.md
+++ b/docs/brainstorms/2026-04-25-upstream-brainstorm-ideate-rigor-sync-requirements.md
@@ -1,0 +1,163 @@
+---
+date: 2026-04-25
+topic: upstream-brainstorm-ideate-rigor-sync
+title: "取长补短融合 upstream brainstorm/ideate 严谨性改进"
+category: brainstorm
+status: active
+---
+
+# 取长补短融合 upstream brainstorm/ideate 严谨性改进
+
+## Problem Frame
+
+GaleHarnessCLI 已经在 PR #66 / commit `a277942` 中融入 Karpathy/工程师提示词 guardrails：需求阶段区分假设、非目标和成功标准，计划阶段要求复杂度有依据，执行阶段形成 execution contract，工作与审查阶段强调 surgical change 和 diff hygiene。这些本地 guardrails 是当前工作流的底座，不能被 upstream prompt 直接覆盖。
+
+upstream `EveryInc/compound-engineering-plugin` 从 `e136d7f` 到 `ea8721e` 的新提交里，有四个 brainstorm/ideate 相关改进值得吸收：
+
+- `494313e fix(ce-brainstorm): enforce Interaction Rules in universal flow (#669)`
+- `304a975 feat(ce-brainstorm): probe rigor gaps with prose before Phase 2 (#677)`
+- `6514b1f feat(ce-ideate): subject gate, surprise-me, and warrant contract (#671)`
+- `f0433d9 fix(ce-ideate): sharpen bug intent, surprise-me dispatch, and drop authoring refs (#672)`
+
+目标不是“同步 upstream 文件”，而是把这些提交中能提高严谨性的语义手工三方融合进 `gh:brainstorm` 和 `gh:ideate`，同时保留 GaleHarnessCLI 的 HKTMemory、Gale knowledge、`gh:` 命名、document-review handoff、Karpathy guardrails、跨平台转换约束。
+
+---
+
+## Actors
+
+- A1. 使用 GaleHarnessCLI 的工程师：希望 brainstorm/ideate 更少发散错题、更能产出可规划的需求或高质量想法。
+- A2. `gh:brainstorm` orchestrator：负责把用户想法转成 requirements doc，不能让 unprobed gaps 或未经确认的实现方案进入计划。
+- A3. `gh:ideate` orchestrator：负责生成并筛选改进想法，必须先明确 ideation subject，再用 warrant 证明 survivor 值得进一步 brainstorm。
+- A4. 后续 planner / worker / reviewer：消费需求与计划，需要继承 Karpathy guardrails，不被 upstream 机械替换破坏。
+
+---
+
+## Key Flows
+
+- F1. Brainstorm universal flow 继承交互规则
+  - **Trigger:** `gh:brainstorm` 把非软件主题路由到 `references/universal-brainstorming.md`。
+  - **Steps:** universal reference 明确父级 Interaction Rules 仍适用，包括 one-question-per-turn、优先 blocking question tool、只有 genuinely open question 才用 prose。
+  - **Outcome:** universal flow 不再绕过主 skill 的交互约束。
+  - **Covered by:** R1, R2, R5, R14-R16
+
+- F2. Brainstorm 在 Phase 2 前探测严谨性缺口
+  - **Trigger:** 用户给出一个新需求或改进方向。
+  - **Steps:** `gh:brainstorm` 在 Phase 1.2 内部扫描 evidence、specificity、counterfactual、attachment；Deep-product 额外扫描 durability。只对实际存在的缺口逐个 prose probe，不把它做成固定问卷。
+  - **Outcome:** requirements doc 记录真实观察、具体受益者、现状 workaround、最小可证明版本、关键假设，而不是让 plan 继承模糊 framing。
+  - **Covered by:** R4, R6-R8, R17
+
+- F3. Ideate 先确认 subject，再决定 mode
+  - **Trigger:** 用户运行 `gh:ideate`，输入为空、过宽、短词、或 “surprise me”。
+  - **Steps:** 先判断 subject 是否 identifiable；对 vague prompt 问一个 scope question；把 “Surprise me” 作为一等模式；对 issue-tracker intent 用更窄触发规则；再做 repo/elsewhere/software/non-software mode classification。
+  - **Outcome:** Phase 1 和 Phase 2 agents 不会在不同主题上发散，surprise-me 也有明确 dispatch 语义。
+  - **Covered by:** R9-R11
+
+- F4. Ideate 用 warrant contract 提高 survivor 质量
+  - **Trigger:** Phase 2 生成候选想法，Phase 3 adversarial filtering 选择 survivors。
+  - **Steps:** 每个 candidate/survivor 携带 warrant，标为 `direct:`、`external:` 或 `reasoned:`；过滤时拒绝无 warrant、warrant 不支撑结论、替换 subject 的想法；默认要求 meeting-test，tactical scope 可放宽。
+  - **Outcome:** ideation artifact 中留下的想法有可检查依据，且下一步应进入 `gh:brainstorm` 而不是直接 plan/work。
+  - **Covered by:** R12, R13
+
+---
+
+## Requirements
+
+### Fusion model
+
+- R1. 必须手工三方融合 upstream 语义，不能机械应用 patch、不能整文件替换 `plugins/galeharness-cli/skills/gh-brainstorm/` 或 `plugins/galeharness-cli/skills/gh-ideate/`。
+- R2. 必须保留本地 PR #66 / commit `a277942` 的 Karpathy guardrails，包括 assumption / non-goals / success criteria separation、complexity justification、execution contract、surgical-change、diff hygiene。
+- R3. 必须保留 Gale/HKT 补丁，包括 HKTMemory retrieve/store、Gale knowledge 输出路径、`gale-task` lifecycle、`gh:` 命名、`galeharness-cli:` agent namespace。
+- R4. 变更必须沿用现有 right-size 原则：明确、轻量任务不被固定问卷拖慢；标准或深度任务必须显式处理真实严谨性缺口。
+
+### Brainstorm rigor
+
+- R5. `gh:brainstorm` 的 universal flow 必须继承父级 Interaction Rules，而不是用 universal reference 放松 one-question-per-turn 或 blocking question tool 规则。
+- R6. `gh:brainstorm` 必须在进入 approaches / Phase 2 前扫描 scope-appropriate rigor gaps：evidence、specificity、counterfactual、attachment；Deep-product 额外包含 durability。
+- R7. Rigor probes 必须是 prose probes，并且只对实际存在的 gap 逐个触发；不能改成固定菜单、批量问题、或所有 brainstorm 强制跑满的问题清单。
+- R8. Rigor probes 的结果必须进入 requirements doc 的 assumptions、non-goals、success criteria、scope boundaries、deferred planning questions 等现有结构，不能新增和本地模板冲突的 parallel taxonomy。
+
+### Ideate rigor
+
+- R9. `gh:ideate` 必须先判断 ideation subject 是否 identifiable，再做 mode classification；repo presence 只能作为 grounding 来源，不能把 vague prompt 默认为“当前 repo improvements”。
+- R10. “Surprise me” 必须作为明确模式处理：在 repo 内可让代码库供应素材；不在 repo 时必须先获得 URL、描述、draft 或 paste 等 substance。
+- R11. Issue-tracker intent 必须收窄到 explicit tracker/report phrasing；`bug in auth`、`top 3 bugs in authentication` 这类 bug focus 不能误触发 issue intelligence。
+- R12. 每个 surviving idea 必须有 articulated warrant，且 filtering 必须拒绝无 warrant、warrant 不支撑结论、或替换 subject 的想法。
+- R13. Ideation artifact 必须能记录 warrant，并保持 “ideate -> brainstorm -> plan” 链路；不允许从 ideation output 直接跳到 implementation plan。
+
+### Compatibility and scope
+
+- R14. 不修改 `test-browser`、`lfg`、release-only 文件或 release-owned version/changelog。
+- R15. 不新增平台专属变量、跨 skill 相对路径、绝对路径、或只在 Claude Code 生效且无 fallback 的指令。
+- R16. 不把 upstream 的 `ce-proof`、Proof-specific authoring refs、Every-specific phrasing机械带入 GaleHarnessCLI；已有 Proof/HITL 语义只在本地已有 reference 中按现状保留。
+- R17. 如果修改 plugin skill 行为，必须补充 prompt contract tests，并运行 `bun test` 与 `bun run release:validate`。
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5.** Given `gh:brainstorm` 检测到非软件 brainstorm，when 它加载 `references/universal-brainstorming.md`，then universal reference 明确父级 Interaction Rules 仍适用，并禁止 silently skipping questions。
+- AE2. **Covers R6-R8.** Given 用户说“给 ideate 加更多 agents 让它更聪明”，when `gh:brainstorm` 进入 Phase 1，then 它应 prose-probe 具体使用者、现状成本、最小可证明版本，而不是直接把“更多 agents”写成 requirement。
+- AE3. **Covers R9-R11.** Given 用户运行 `gh:ideate quick wins`，when subject 不可识别，then workflow 先问要 ideate 什么，并提供 “Surprise me” 选项；不直接 dispatch repo-wide agents。
+- AE4. **Covers R11.** Given 用户运行 `gh:ideate top 3 bugs in authentication`，when 没有 explicit tracker/report phrasing，then 它被视为普通 bug-focused ideation，而不是 issue-tracker analysis。
+- AE5. **Covers R12-R13.** Given Phase 2 产生一个 plausible 但没有 direct/external/reasoned warrant 的想法，when Phase 3 filtering 执行，then 该想法被拒绝或补足 warrant；survivor 文档中展示 warrant 和 rationale。
+- AE6. **Covers R1-R4, R14-R16.** Given upstream diff 想替换 `ce-ideate` 整个 Phase 0-6，when 实现本需求，then 只提取 subject gate、surprise-me、issue intent、warrant contract 等语义并适配到本地 `gh:` / HKT / Gale 结构。
+
+---
+
+## Success Criteria
+
+- `gh:brainstorm` 更稳定地在 plan 前暴露用户问题 framing 的证据、具体性、反事实、依附方案和耐久性风险。
+- `gh:ideate` 不再对 vague prompts 做散射式多 agent 发散，surprise-me 与 issue intent 有明确、可测的 routing。
+- Ideation survivors 带有可检查 warrant，质量高于 naive idea list，且自然进入 `gh:brainstorm`。
+- PR #66 的 Karpathy guardrails 和本地 HKT/Gale 补丁完整保留。
+- 后续实现能通过 contract tests、`bun test`、`bun run release:validate`。
+
+---
+
+## Scope Boundaries
+
+- 不碰 `test-browser`、`lfg`、release-only 变更。
+- 不覆盖本地 Karpathy guardrails，不弱化 assumptions/non-goals/success criteria separation、complexity justification、execution contract、surgical-change、diff hygiene。
+- 不机械替换整文件，不套 upstream patch，不复制 upstream `ce:` 命名或 Every-specific authoring refs。
+- 不新增新的 ideation product surface、Proof integration 重构、issue intelligence agent 重构、web research cache 重构。
+- 不把 upstream 的非本轮文件变更纳入范围，如 demo-reel、proof、root AGENTS authoring wording。
+- 在 brainstorm / plan / document-review 阶段不实现代码、不改技能正文、不 commit/push/PR；进入已审查通过的 work 阶段后，按计划修改 skill 和 tests。
+
+---
+
+## Key Decisions
+
+- **按语义吸收，不按 diff 吸收。** upstream 与本地 guardrails 互补，但文件结构、命名、HKT/Gale patch、测试状态不同，机械 patch 会破坏本地行为。
+- **Brainstorm 只吸收严谨性 probing 和 universal Interaction Rules。** 不改变 PR #66 的 Karpathy structure，只让 pressure test 更有操作性。
+- **Ideate 优先吸收 subject gate、surprise-me、issue intent sharpening、warrant contract。** 这些直接提高 idea quality 和 dispatch correctness；Proof/save/web-cache 等大改不属于本轮。
+- **Plan 必须显式经过 document-review 再 work。** 这是本地 `gh:plan` 当前质量门的一部分，也是后续实现前保护融合质量的关键步骤。
+
+---
+
+## Dependencies / Assumptions
+
+- 假设本轮只关注 `plugins/galeharness-cli/skills/gh-brainstorm/`、`plugins/galeharness-cli/skills/gh-ideate/` 及相关 prompt contract tests。
+- 假设当前 `gh:ideate` 尚未吸收 upstream 的 mode-aware elsewhere/web research/Proof 大结构；本轮只取严谨性核心，不引入更大 workflow 改造。
+- 假设 `document-review` 会在后续 plan handoff 后、`gh:work` 前执行；本阶段计划文档必须保留这个顺序。
+- 假设 upstream commit 的非 brainstorm/ideate 文件改动本轮都不纳入 scope。
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- 无。用户已要求轻量自动决策，不反问。
+
+### Deferred to Planning
+
+- [Technical] Warrant contract 的最小落点应只在 `gh-ideate/SKILL.md` 和 `post-ideation-workflow.md`，还是需要新增/复制 `universal-ideation.md`？
+- [Technical] Contract tests 应放入现有 `tests/pipeline-review-contract.test.ts`，还是拆出 `tests/ideate-skill-contract.test.ts`？
+- [Technical] `gh:brainstorm` rigor probes 如何和 PR #66 的 “Challenge framing before committing” 文案组合，避免重复和过长？
+
+---
+
+## Next Steps
+
+1. `/gh:plan docs/brainstorms/2026-04-25-upstream-brainstorm-ideate-rigor-sync-requirements.md`
+2. 后续执行顺序必须是：plan document-review -> `gh:work`。

--- a/docs/plans/2026-04-25-003-feat-upstream-brainstorm-ideate-rigor-sync-plan.md
+++ b/docs/plans/2026-04-25-003-feat-upstream-brainstorm-ideate-rigor-sync-plan.md
@@ -1,0 +1,308 @@
+---
+title: "feat: 融合 upstream brainstorm/ideate 严谨性改进"
+type: feat
+status: active
+date: 2026-04-25
+origin: docs/brainstorms/2026-04-25-upstream-brainstorm-ideate-rigor-sync-requirements.md
+---
+
+# feat: 融合 upstream brainstorm/ideate 严谨性改进
+
+## Overview
+
+本计划从 upstream `EveryInc/compound-engineering-plugin` 的四个 commit 中吸收 brainstorm/ideate 的严谨性改进，但不机械套 patch。实现应以本地 PR #66 / commit `a277942` 的 Karpathy guardrails 为底座，保留 GaleHarnessCLI 的 HKTMemory、Gale knowledge、`gh:` 命名、document-review handoff、跨平台转换约束。
+
+本轮计划只覆盖 `gh:brainstorm` 和 `gh:ideate` 相关改进。明确排除 `test-browser`、`lfg`、release-only、demo-reel、proof、release version/changelog，以及 upstream 非本轮语义。
+
+后续执行顺序必须是：先对本计划运行 `document-review`，再进入 `gh:work` 实现。不要跳过 document-review。
+
+---
+
+## Problem Frame
+
+当前本地 `gh:brainstorm` 已有 Karpathy guardrails：挑战 framing、区分 explicit assumptions/non-goals/success criteria、避免把 unconfirmed implementation proposal 写成 requirement。`gh:plan`、`gh:work`、`gh:review` 也已有 complexity justification、execution contract、surgical-change、diff hygiene 的 contract tests。
+
+upstream 新增的价值主要在两个方向：
+
+- `ce-brainstorm` 把抽象的 pressure test 变成更可执行的 rigor gap lenses，并修复 universal brainstorming 绕过 Interaction Rules 的问题。
+- `ce-ideate` 明确 subject gate、surprise-me、issue intent、warrant contract，解决 vague prompt 发散和 plausible-but-unsupported idea survivor 的问题。
+
+风险在于 upstream 文件结构、命名、Proof/Every references、agent dispatch、web research 和保存流程与 GaleHarnessCLI 不一致。正确做法是只吸收语义，不替换本地 skill。
+
+---
+
+## Requirements Trace
+
+- R1-R4. 手工融合、保留 PR #66 Karpathy guardrails、保留 Gale/HKT 补丁、保持 right-size。
+- R5-R8. Brainstorm universal flow 继承 Interaction Rules；Phase 2 前扫描并 prose-probe evidence/specificity/counterfactual/attachment/durability gaps；结果落入现有 requirements 结构。
+- R9-R13. Ideate 先 subject gate 再 mode classification；surprise-me 一等模式；issue-tracker intent 收窄；survivors 必须有 articulated warrant；ideation 仍 hand off 到 `gh:brainstorm`。
+- R14-R17. 不碰排除范围，不引入平台专属或跨目录引用，补充 tests，运行 `bun test` 和 `bun run release:validate`。
+
+**Origin:** `docs/brainstorms/2026-04-25-upstream-brainstorm-ideate-rigor-sync-requirements.md`
+
+---
+
+## Scope Boundaries
+
+- 不修改 `test-browser`、`lfg`、release-only、release-owned version/changelog。
+- 不整文件替换 `plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md` 或 `plugins/galeharness-cli/skills/gh-ideate/SKILL.md`。
+- 不引入 upstream `ce:` 命名、Every-specific authoring refs、Proof workflow 重构、demo-reel/proof 非目标改动。
+- 不弱化 PR #66 已有 guardrails 和 tests。
+- 不新增独立 `karpathy` skill，不改变 `ideate -> brainstorm -> plan -> work` 主链路。
+
+---
+
+## Context & Research
+
+### Upstream Semantics to Absorb
+
+- `494313e`:
+  - Parent Interaction Rules apply to universal brainstorming.
+  - Universal reference must not relax one-question-per-turn or blocking question tool rules.
+  - Numbered overflow should preserve free-form input when blocking tool cannot be used.
+
+- `304a975`:
+  - Phase 1.2 should scan for rigor gaps before approaches.
+  - Standard gaps: evidence, specificity, counterfactual, attachment.
+  - Deep-product extra gap: durability.
+  - Probes are agent-internal and selective; only actual gaps fire.
+  - Rigor probes are prose, one gap per probe, before Phase 2.
+  - Attachment probe is final before Phase 2 when attachment gap exists.
+
+- `6514b1f`:
+  - `ce-ideate` adds subject-identification gate before mode classification.
+  - “Surprise me” becomes first-class mode.
+  - Elsewhere context-substance gate prevents no-substance dispatch.
+  - Tactical scope lowers ambition floor.
+  - Warrant contract requires direct/external/reasoned basis.
+  - Survivors must pass meeting-test unless tactical focus waived it.
+  - Artifact template includes warrant and rationale.
+
+- `f0433d9`:
+  - Issue-tracker intent requires explicit tracker/report phrasing.
+  - `bug in auth` / `top 3 bugs in authentication` remain regular ideation focus.
+  - Surprise-me routing is deterministic: repo CWD uses repo-grounded; no-repo uses elsewhere-software and requires substance.
+  - Drops some authoring refs; this reinforces not importing upstream AGENTS/plugin authoring wording mechanically.
+
+### Local Constraints to Preserve
+
+- PR #66 / `a277942`:
+  - `gh:brainstorm` already has `Challenge framing before committing` and `Separate decisions from guesses`.
+  - `requirements-capture.md` already distinguishes confirmed requirements, non-goals, assumptions, success criteria.
+  - `gh:plan` already has `Justify complexity from source material` and `Complexity justification gate`.
+  - `gh:work` and `gh:work-beta` already share execution contract and surgical-change rules.
+  - `gh:review` and reviewers already cover diff hygiene.
+  - Tests in `tests/pipeline-review-contract.test.ts` and `tests/review-skill-contract.test.ts` lock these anchors.
+
+- HKT/Gale patches:
+  - `gh:brainstorm` and `gh:ideate` include `gale-task` lifecycle and HKTMemory retrieve/store sections.
+  - `gh:brainstorm` uses `gale-knowledge resolve-path` and knowledge commit behavior.
+  - Agent references must use `galeharness-cli:<agent-name>`.
+
+- Repo standards:
+  - Skill files must be self-contained; no cross-skill references by relative traversal or absolute path.
+  - File references in generated docs must be repo-relative.
+  - Do not hand-bump release-owned versions or changelog.
+  - Plugin behavior changes require tests and `bun run release:validate`.
+
+---
+
+## Key Technical Decisions
+
+- **D1. Treat upstream as semantic input, not patch source.** Implementation should inspect upstream snippets while editing, but write text in local `gh:` voice and keep local HKT/Gale sections intact.
+- **D2. Brainstorm changes stay narrow.** Add explicit universal Interaction Rules inheritance and refine Phase 1.2 rigor gap lenses; do not restructure Phase 0-4.
+- **D3. Ideate gets a targeted Phase 0 rewrite, not upstream full transplant.** Add subject-identification gate, surprise-me routing, issue-intent sharpening, context-substance gate where needed, and tactical scope detection while preserving local HKT and current simpler repo-grounded flow unless a specific unit expands it.
+- **D4. Warrant contract belongs in both generation and filtering.** `gh-ideate/SKILL.md` should require candidates to carry warrant; `post-ideation-workflow.md` should reject weak warrant and write warrant to artifact.
+- **D5. Tests should lock behavior anchors, not whole prose.** Add stable phrase assertions for subject gate, surprise-me, issue intent, rigor gap probes, warrant contract, and preservation of Karpathy/HKT anchors.
+- **D6. Plan quality gate remains document-review before work.** After this plan, run `document-review` on the plan, address P0/P1 findings, then invoke `gh:work`.
+
+---
+
+## Implementation Units
+
+### U1. Strengthen `gh:brainstorm` Interaction Rules and universal flow
+
+**Goal:** Ensure universal brainstorming follows the same parent Interaction Rules as software brainstorming.
+
+**Requirements:** R1-R5, R14-R16; F1; AE1.
+
+**Files:**
+- Modify: `plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md`
+- Modify: `plugins/galeharness-cli/skills/gh-brainstorm/references/universal-brainstorming.md`
+- Test: `tests/pipeline-review-contract.test.ts`
+
+**Approach:**
+- In `gh-brainstorm/SKILL.md`, add concise wording that Interaction Rules apply to every brainstorm, including universal flow.
+- Adapt upstream's blocking-tool/prose distinction, but keep current platform list and local style.
+- In `universal-brainstorming.md`, state it extends parent rules and does not relax them.
+- Preserve existing HKT, Gale knowledge, document-review handoff, and Karpathy guardrail text.
+
+**Test scenarios:**
+- Assert `gh-brainstorm/SKILL.md` says universal flow still follows Interaction Rules.
+- Assert `universal-brainstorming.md` contains parent-rule inheritance and one-question-per-turn/blocking question anchors.
+- Assert existing PR #66 anchors still exist: `Challenge framing before committing`, `explicit assumptions, non-goals, and success criteria`, `without bulldozing their intent`.
+
+---
+
+### U2. Add brainstorm rigor gap probes before approaches
+
+**Goal:** Make Phase 1.2 pressure testing more actionable without turning brainstorm into a fixed questionnaire.
+
+**Requirements:** R1-R8, R14-R17; F2; AE2.
+
+**Files:**
+- Modify: `plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md`
+- Modify as needed: `plugins/galeharness-cli/skills/gh-brainstorm/references/requirements-capture.md`
+- Test: `tests/pipeline-review-contract.test.ts`
+
+**Approach:**
+- Refine Phase 1.2 to scan for evidence, specificity, counterfactual, attachment; Deep-product adds durability.
+- State that these are agent-internal lenses, not a user-facing checklist.
+- State that probes fire selectively as prose, one gap per probe, before Phase 2.
+- Ensure probe answers map to existing assumptions/non-goals/success criteria/scope/deferred planning structures.
+- Keep the PR #66 separation of confirmed requirements vs unconfirmed implementation proposals.
+
+**Test scenarios:**
+- Assert `gh-brainstorm/SKILL.md` mentions evidence, specificity, counterfactual, attachment, durability.
+- Assert it says probes are selective/prose and before Phase 2.
+- Assert `requirements-capture.md` still requires assumptions/non-goals/success criteria and prevents unconfirmed implementation proposals from becoming requirements.
+
+---
+
+### U3. Add `gh:ideate` subject gate, surprise-me, and issue intent sharpening
+
+**Goal:** Prevent vague ideation prompts from dispatching scattered agents, and make surprise-me / issue analysis routing deterministic.
+
+**Requirements:** R1-R4, R9-R11, R14-R17; F3; AE3, AE4, AE6.
+
+**Files:**
+- Modify: `plugins/galeharness-cli/skills/gh-ideate/SKILL.md`
+- Test: `tests/pipeline-review-contract.test.ts` or new `tests/ideate-skill-contract.test.ts`
+
+**Approach:**
+- Add Phase 0 subject-identification gate before current focus/volume interpretation.
+- Define identifiable vs vague subjects by what the words refer to, not phrase length.
+- Add scope question with “Specify subject”, “Surprise me”, “Cancel”.
+- Make surprise-me deterministic: in repo CWD, repo supplies substance; outside repo, require URL/description/draft/paste before dispatch.
+- Narrow issue-tracker intent to explicit tracker/report phrases and explicitly exclude bug focus prompts.
+- Add tactical scope detection (`quick wins`, `polish`, `typos`, `small fixes`) for later meeting-test waiver.
+- Keep HKTMemory retrieve/store sections and `galeharness-cli:` agent names.
+
+**Test scenarios:**
+- Assert `gh-ideate/SKILL.md` contains subject-identification gate before mode/focus dispatch.
+- Assert it treats “Surprise me” as first-class and deterministic.
+- Assert it excludes `top 3 bugs in authentication` from issue-tracker intent.
+- Assert existing HKTMemory retrieve/store anchors remain.
+
+---
+
+### U4. Add `gh:ideate` warrant contract and artifact support
+
+**Goal:** Ensure surviving ideas are grounded by inspectable warrant and can hand off cleanly to `gh:brainstorm`.
+
+**Requirements:** R1-R4, R12-R17; F4; AE5, AE6.
+
+**Files:**
+- Modify: `plugins/galeharness-cli/skills/gh-ideate/SKILL.md`
+- Modify: `plugins/galeharness-cli/skills/gh-ideate/references/post-ideation-workflow.md`
+- Consider add only if needed: `plugins/galeharness-cli/skills/gh-ideate/references/universal-ideation.md`
+- Test: `tests/pipeline-review-contract.test.ts` or new `tests/ideate-skill-contract.test.ts`
+
+**Approach:**
+- In Phase 2 candidate structure, require warrant tagged `direct:`, `external:`, or `reasoned:`.
+- In filtering, reject candidates with missing warrant, warrant that does not support the move, or subject replacement.
+- Add meeting-test floor by default, waived for tactical scope signals.
+- Update artifact template to include `Warrant` and `Rationale`.
+- Keep post-ideation handoff to `gh:brainstorm`; do not allow direct plan/work.
+
+**Test scenarios:**
+- Assert Phase 2 asks for `direct:`, `external:`, `reasoned:` warrant.
+- Assert filtering rejects unsupported warrant and subject replacement.
+- Assert artifact template includes `**Warrant:**`.
+- Assert `post-ideation-workflow.md` still routes selected ideas to `gh:brainstorm`, not `gh:plan` or `gh:work`.
+
+---
+
+### U5. Validate preservation of local guardrails and plugin consistency
+
+**Goal:** Catch accidental overwrite of PR #66 guardrails or HKT/Gale patches while implementing upstream-derived edits.
+
+**Requirements:** R1-R4, R14-R17; AE6.
+
+**Files:**
+- Modify tests only as needed:
+  - `tests/pipeline-review-contract.test.ts`
+  - `tests/review-skill-contract.test.ts` only if touched by preservation assertions
+
+**Approach:**
+- Add preservation assertions for PR #66 anchors in brainstorm/plan/work/review where current tests already cover them.
+- Add ideate-specific contract tests for HKTMemory anchors and handoff boundaries.
+- Avoid brittle whole-paragraph snapshots.
+
+**Test scenarios:**
+- `bun test tests/pipeline-review-contract.test.ts`
+- `bun test tests/review-skill-contract.test.ts` if touched.
+- Full `bun test`.
+- `bun run release:validate`.
+
+---
+
+## Sequencing
+
+1. Run `document-review` on this plan and address P0/P1 findings before implementation.
+2. Implement U1 and U2 together, because both touch `gh-brainstorm/SKILL.md`.
+3. Implement U3 before U4, because warrant handling depends on subject/mode clarity.
+4. Implement U5 tests throughout, not after all prose edits.
+5. Run focused tests, then full `bun test`, then `bun run release:validate`.
+6. Only after review and tests pass should `gh:work` final output recommend commit/PR.
+
+---
+
+## Testing Strategy
+
+- **Prompt contract tests:** Extend `tests/pipeline-review-contract.test.ts` or create `tests/ideate-skill-contract.test.ts` with stable phrase assertions for the new anchors.
+- **Preservation tests:** Keep existing PR #66 Karpathy tests green; add assertions that HKTMemory retrieve/store and `gh:` / `galeharness-cli:` names remain.
+- **Regression tests:** Run `bun test tests/pipeline-review-contract.test.ts` after skill edits.
+- **Full suite:** Run `bun test` because plugin prompt changes can affect converter/writer expectations.
+- **Plugin consistency:** Run `bun run release:validate` because plugin skill behavior and inventory-adjacent docs may be affected.
+- **No runtime implementation tests needed:** This plan changes workflow prompt contracts, not TypeScript conversion logic, unless implementation discovers converter output changed.
+
+---
+
+## Risks
+
+- **Prompt bloat:** upstream prose is long; copying it directly could make skills harder to follow. Mitigation: keep behavior anchors concise and move only necessary template changes into references.
+- **Guardrail conflict:** new probes could duplicate PR #66 framing guardrails. Mitigation: phrase them as operational lenses under the existing challenge-framing principle.
+- **Over-questioning:** rigor probes and subject gate could slow trivial tasks. Mitigation: selective gaps only, right-size rule preserved, “Surprise me” stays first-class.
+- **Scope creep from upstream ideate:** upstream also changes web research, Proof, elsewhere modes, caches, and AGENTS wording. Mitigation: explicitly exclude non-rigor workflow rewrites from this plan.
+- **Test brittleness:** prompt contract tests can overfit wording. Mitigation: assert short stable anchors, not paragraphs.
+- **HKT/Gale regression:** mechanical merge could delete HKTMemory or Gale knowledge sections. Mitigation: preservation tests plus manual review of HKT/Gale anchors.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should upstream patches be applied mechanically? No. Use semantic, manual three-way fusion only.
+- Should `test-browser`, `lfg`, release-only files be included? No.
+- Should PR #66 Karpathy guardrails be overwritten or reorganized? No; they are constraints to preserve.
+- Should plan flow go directly to work? No; run `document-review` first, then `gh:work`.
+
+### Deferred to Implementation
+
+- Whether `gh:ideate` needs a new `references/universal-ideation.md` now, or whether this round can keep non-software ideation out of scope.
+- Whether ideate tests stay in `tests/pipeline-review-contract.test.ts` or move to a dedicated test file for readability.
+- Exact wording of prose probes and warrant instructions, tuned to surrounding local prompt style.
+
+---
+
+## Handoff
+
+Next required step:
+
+1. Run `document-review docs/plans/2026-04-25-003-feat-upstream-brainstorm-ideate-rigor-sync-plan.md`.
+2. Address any P0/P1 findings.
+3. Then run `gh:work docs/plans/2026-04-25-003-feat-upstream-brainstorm-ideate-rigor-sync-plan.md`.
+
+Do not implement before document-review.

--- a/docs/solutions/workflow-issues/upstream-brainstorm-ideate-rigor-fusion-2026-04-25.md
+++ b/docs/solutions/workflow-issues/upstream-brainstorm-ideate-rigor-fusion-2026-04-25.md
@@ -1,0 +1,104 @@
+---
+title: Upstream brainstorm/ideate rigor changes should be fused semantically
+date: 2026-04-25
+category: workflow-issues
+module: GaleHarnessCLI workflow skills
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - Syncing upstream compound-engineering-plugin workflow prompt changes into GaleHarnessCLI
+  - Upstream prompt improvements overlap with local Karpathy, HKTMemory, or Gale guardrails
+  - Brainstorm or ideate behavior needs stricter routing without replacing local skill structure
+tags: [upstream-sync, brainstorm, ideate, workflow-guardrails, prompt-contract-tests]
+---
+
+# Upstream brainstorm/ideate rigor changes should be fused semantically
+
+## Context
+
+本次同步从 upstream `EveryInc/compound-engineering-plugin` 的 brainstorm/ideate 相关提交中吸收严谨性改进：
+
+- `494313e fix(ce-brainstorm): enforce Interaction Rules in universal flow (#669)`
+- `304a975 feat(ce-brainstorm): probe rigor gaps with prose before Phase 2 (#677)`
+- `6514b1f feat(ce-ideate): subject gate, surprise-me, and warrant contract (#671)`
+- `f0433d9 fix(ce-ideate): sharpen bug intent, surprise-me dispatch, and drop authoring refs (#672)`
+
+GaleHarnessCLI 本地已经有 PR #66 / commit `a277942` 引入的 Karpathy guardrails：brainstorm 要分离 confirmed requirements、explicit assumptions、non-goals、success criteria；plan 要证明复杂度；work 要有 execution contract 和 surgical-change 边界；review 要检查 diff hygiene。同步 upstream 时，目标不是覆盖本地 prompt，而是把 upstream 的有用行为翻译进这些已有阶段。
+
+## Guidance
+
+同步 workflow prompt 时，把 upstream 当作语义输入，而不是 patch source。具体做法：
+
+- 先列出本地不能丢的 guardrails：Karpathy guardrails、HKTMemory retrieve/store、Gale knowledge 输出、`gale-task` lifecycle、`gh:` skill 命名、`galeharness-cli:` agent namespace、跨平台 fallback。
+- 再提取 upstream 的最小行为增量：universal brainstorm 继承 Interaction Rules、rigor gap probes、ideate subject-identification gate、surprise-me routing、issue intent 收窄、warrant contract。
+- 最后把行为落到本地对应阶段，而不是复制 upstream 文件结构、`ce:` 命名、Proof/Every-specific wording 或 authoring references。
+
+本次落点是：
+
+- `gh:brainstorm` 的 Interaction Rules 明确适用于 universal non-software flow；`references/universal-brainstorming.md` 只扩展父规则，不放松 one-question-per-turn 或 blocking question tool fallback。
+- `gh:brainstorm` 的 Phase 1.2 把 pressure test 变成 selective rigor probes：evidence、specificity、counterfactual、attachment，Deep-product 额外 durability。它们是 prose probe，不是固定问卷；只对真实缺口逐个触发。
+- `gh:ideate` 在 focus/volume/mode routing 前增加 subject-identification gate。显式 `surprise me` / `pick for me` / `you decide` 直接进入 surprise-me mode，不重复确认。
+- `gh:ideate` 把 issue-tracker intent 收窄到 explicit tracker/report phrasing，避免 `top 3 bugs in authentication` 这类普通 bug focus 误触发 issue intelligence。
+- `gh:ideate` 要求每个 candidate/survivor 带 warrant，且标为 `direct:`、`external:` 或 `reasoned:`；post-ideation filtering 拒绝无 warrant、unsupported warrant、subject replacement 和低于 meeting-test 的想法。
+
+测试应该保护行为锚点，而不是锁死整段 prose。本次把 assertions 放在 `tests/pipeline-review-contract.test.ts`，覆盖：
+
+- brainstorm universal flow 继承父级 Interaction Rules；
+- brainstorm rigor gap lenses 和 prose/selective/before Phase 2 约束；
+- ideate subject gate、surprise-me、issue intent sharpening；
+- warrant contract、post-ideation artifact 字段和 rejection criteria；
+- 本地 HKT/Gale anchors、PR #66 plan/work/review guardrails 仍存在。
+
+## Why This Matters
+
+Workflow skill 是 agent 的默认行为入口。机械同步 upstream prompt 很容易引入三类回归：
+
+- 本地 guardrail 被覆盖，导致 brainstorm 又把假设写成需求，plan 又把复杂度写成主观判断。
+- 平台或插件身份漂移，例如把 `ce:`、Proof、Every authoring references 带进 GaleHarnessCLI。
+- 新行为缺少测试锚点，后续同步时不知道哪些是刻意融合、哪些只是临时文字。
+
+语义融合能同时得到 upstream 的好处和本地系统的连续性：brainstorm 更会追问真实证据与边界，ideate 更少对 vague prompt 发散，survivor idea 更有可检查依据，同时不破坏 HKTMemory、Gale knowledge 和已有 workflow quality gates。
+
+## When to Apply
+
+- upstream 修改的是 prompt/workflow behavior，而本地已有同类但不同结构的 guardrails。
+- upstream 变更跨多个阶段，不能通过单文件 patch 保持语义正确。
+- 同步对象包含平台特定命名、authoring refs、外部产品 references 或本地没有的 workflow surface。
+- 需要让后续 reviewers 和 tests 能区分“保留本地行为”与“吸收 upstream 行为”。
+
+## Examples
+
+不推荐：
+
+```text
+直接把 upstream ce-brainstorm 或 ce-ideate 的完整 SKILL.md 覆盖到本地 gh-* skill。
+```
+
+这种做法会丢掉 GaleHarnessCLI 的 HKT/Gale sections、`gh:` naming、agent namespace、本地 document-review handoff 和 PR #66 guardrails。
+
+推荐：
+
+```text
+1. 记录 upstream commit 的行为意图。
+2. 标出本地必须保留的 anchors。
+3. 在本地相同决策阶段补最小文字。
+4. 用 prompt contract tests 锁住行为锚点和本地 anchors。
+5. 验证 bun test、release:validate、git diff --check。
+```
+
+## Related
+
+- `docs/brainstorms/2026-04-25-upstream-brainstorm-ideate-rigor-sync-requirements.md`
+- `docs/plans/2026-04-25-003-feat-upstream-brainstorm-ideate-rigor-sync-plan.md`
+- `docs/solutions/workflow-issues/karpathy-guidelines-workflow-guardrails-2026-04-24.md`
+- `plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md`
+- `plugins/galeharness-cli/skills/gh-ideate/SKILL.md`
+- `tests/pipeline-review-contract.test.ts`
+
+## Future Sync Notes
+
+- 继续同步 upstream brainstorm/ideate 时，先检查是否有新的 Proof/web-cache/demo-reel/authoring surface；除非本地已有对应需求，否则不要顺手带入。
+- 对每个 upstream commit 保持“语义、落点、保留本地 anchors、测试锚点”四列表，而不是按文件逐行追 patch。
+- 如果 upstream 后续扩大 surprise-me、elsewhere research 或 issue intelligence 的工作流，本地应先走 brainstorm/plan/document-review，再决定是否引入，不应直接在 ideate 中扩张执行面。
+- Contract tests 应继续检查 HKTMemory、Gale knowledge、`galeharness-cli:` agent namespace 和 PR #66 guardrails，避免下一轮同步把本地底座冲掉。

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -29,10 +29,13 @@ This skill does not implement code. It explores, clarifies, and documents decisi
 
 ## Interaction Rules
 
-1. **Ask one question at a time** - Do not batch several unrelated questions into one message.
+These rules apply to every brainstorm, including the universal non-software flow routed to `references/universal-brainstorming.md`.
+
+1. **Ask one question at a time** - One question per turn, even when related sub-questions feel tempting. Pick the single most useful question and wait for the answer.
 2. **Prefer single-select multiple choice** - Use single-select when choosing one direction, one priority, or one next step.
 3. **Use multi-select rarely and intentionally** - Use it only for compatible sets such as goals, constraints, non-goals, or success criteria that can all coexist. If prioritization matters, follow up by asking which selected item is primary.
-4. **Use the platform's question tool when available** - When asking the user a question, prefer the platform's blocking question tool if one exists (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension)). If the tool is unavailable, do not proceed silently — present numbered options directly in chat and wait for the user's reply before proceeding, and state that the tool is unavailable.
+4. **Default to the platform's blocking question tool** - When asking the user a question, prefer the platform's blocking question tool if one exists (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension)). Use numbered chat options only when no blocking tool exists or the call fails. Do not proceed silently or treat tool inconvenience as permission to skip the question.
+5. **Use prose only for genuinely open probes** - Drop the blocking tool only when the answer is inherently narrative, a menu would leak your priors, or you cannot write distinct plausible options without padding. This includes the rigor probes in Phase 1.3. Rule 1 still applies: one prose probe per turn.
 
 ## Output Guidance
 
@@ -86,7 +89,7 @@ Before proceeding to Phase 0.2, classify whether this is a software task. The ke
 
 **Neither** (respond directly, skip all brainstorming phases) -- the input is a quick-help request, error message, factual question, or single-step task that doesn't need a brainstorm.
 
-**If non-software brainstorming is detected:** Read `references/universal-brainstorming.md` and use those facilitation principles to brainstorm with the user naturally. Do not follow the software brainstorming phases below.
+**If non-software brainstorming is detected:** Read `references/universal-brainstorming.md` and use those facilitation principles. Do not follow the software brainstorming phases below, but the Core Principles and Interaction Rules above still apply unchanged, including one-question-per-turn and the default to the platform's blocking question tool.
 
 #### 0.2 Assess Whether Brainstorming Is Needed
 
@@ -225,16 +228,22 @@ If nothing obvious appears after a short scan, say so and continue. Two rules go
 
 #### 1.2 Product Pressure Test
 
-Before generating approaches, challenge the request to catch misframing. Match depth to scope:
+Before generating approaches, challenge the request to catch misframing and scan the user's opening for rigor gaps. Match depth to scope.
 
-Use this as a thinking checkpoint, not a debate club. The output of the pressure test should sharpen the requirements by separating confirmed user intent from explicit assumptions, non-goals, success criteria, and open questions.
+Use this as a thinking checkpoint, not a debate club or a user-facing checklist. Note which gaps actually exist, then raise only those gaps during Phase 1.3 as short prose probes folded into the normal dialogue. A concrete, well-framed opening may need zero probes; a fuzzy one may need several. The output of the pressure test should sharpen the requirements by separating confirmed user intent from explicit assumptions, non-goals, success criteria, and open questions.
 
 **Lightweight:**
 - Is this solving the real user problem?
 - Are we duplicating something that already covers this?
 - Is there a clearly better framing with near-zero extra cost?
 
-**Standard:**
+**Standard — scan for these rigor gaps:**
+- **Evidence gap.** The opening asserts want or need but does not point to observable behavior, such as time spent, money paid, workarounds built, abandoned tools, or repeated manual effort.
+- **Specificity gap.** The opening describes the beneficiary so broadly that planning would have to silently invent who they are and what changes for them.
+- **Counterfactual gap.** The opening does not show what users do today when the problem appears, or what changes if nothing ships.
+- **Attachment gap.** The opening treats a solution shape as the requirement before the value behind that shape has been tested against smaller forms.
+
+Plus these synthesis questions the agent weighs internally:
 - Is this the right problem, or a proxy for a more important one?
 - What user or business outcome actually matters here?
 - What happens if we do nothing?
@@ -248,6 +257,7 @@ Use this as a thinking checkpoint, not a debate club. The output of the pressure
 - Does this move the product toward that, or is it only a local patch?
 
 **Deep — product** — Deep questions plus:
+- **Durability gap.** The opening's value proposition rests on a current state of the world that may shift within the horizon the user cares about.
 - What's the single sharpest user outcome this earns, and what evidence or assumption supports that outcome?
 - What adjacent product could we accidentally build instead, and why is that the wrong one?
 - What would have to be true in the world for this to fail?
@@ -261,6 +271,7 @@ Follow the Interaction Rules above. Use the platform's blocking question tool wh
 **Guidelines:**
 - Ask what the user is already thinking before offering your own ideas. This surfaces hidden context and prevents fixation on AI-generated framings.
 - Start broad (problem, users, value) then narrow (constraints, exclusions, edge cases)
+- **Probe rigor gaps before Phase 2.** Phase 1 cannot end with unprobed scope-appropriate rigor gaps found in Phase 1.2. Each gap fires selectively as a separate short prose probe, not a menu or fixed questionnaire. Standard brainstorms scan evidence, specificity, counterfactual, and attachment; Deep-product adds durability. Ask only about gaps that are actually present. Examples: evidence — "What's the most concrete thing someone has already done because of this problem?" specificity — "Who have you actually seen hit this, and what changes for them if we solve it?" counterfactual — "What happens today when this comes up, and what does that cost?" attachment — "Before we choose a shape, what's the smallest version that would still prove the bet?" durability — "What near-term shift could make this less valuable, and how does the idea hold up?" If the answer reveals uncertainty, record it as an explicit assumption rather than turning it into a confirmed requirement.
 - Clarify the problem frame, validate assumptions, and ask about success criteria
 - Make requirements concrete enough that planning will not need to invent behavior
 - Surface dependencies or prerequisites only when they materially affect scope

--- a/plugins/galeharness-cli/skills/gh-brainstorm/references/universal-brainstorming.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/references/universal-brainstorming.md
@@ -1,6 +1,6 @@
 # Universal Brainstorming Facilitator
 
-This file is loaded when gh:brainstorm detects a non-software task (Phase 0). It replaces the software-specific brainstorming phases with facilitation principles for any domain. Do not follow the software brainstorming workflow (Phases 0.2 through 4). Instead, absorb these principles and facilitate the brainstorm naturally.
+This file is loaded when gh:brainstorm detects a non-software task (Phase 0). It replaces the software-specific brainstorming phases with facilitation principles for any domain. The Core Principles and Interaction Rules in the parent `gh-brainstorm/SKILL.md` still apply unchanged, including one-question-per-turn and the default to the platform's blocking question tool. This file extends those rules; it does not relax them or permit silently skipping questions.
 
 ---
 
@@ -9,6 +9,12 @@ This file is loaded when gh:brainstorm detects a non-software task (Phase 0). It
 Be a thinking partner, not an answer machine. The user came here because they're stuck or exploring — they want to think WITH someone, not receive a deliverable. Resist the urge to generate a complete solution immediately. A premature answer anchors the conversation and kills exploration.
 
 **Match the tone to the stakes.** For personal or life decisions (career changes, housing, relationships, family), lead with values and feelings before frameworks and analysis. Ask what matters to them, not just what the options are. For lighter or creative tasks (podcast topics, event ideas, side projects), energy and enthusiasm are more useful than caution.
+
+## Asking questions
+
+"Thinking partner" does not mean "all prose." Use the parent skill's Interaction Rules in full: ask one question per turn, prefer the blocking question tool when available, and fall back to numbered chat options only when the tool is unavailable or fails.
+
+Use prose only when the answer is genuinely narrative, when options would bias the user by revealing your priors, or when you cannot write a few distinct plausible options without padding. Even then, keep it to one question and wait for the answer.
 
 ## How to start
 

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -33,7 +33,7 @@ Interpret any provided argument as optional context. It may be:
 - a constraint such as `low-complexity quick wins`
 - a volume hint such as `top 3`, `100 ideas`, or `raise the bar`
 
-If no argument is provided, proceed with open-ended ideation.
+If no argument is provided, treat the subject as unsettled and run the subject-identification gate before any dispatch.
 
 ## Core Principles
 
@@ -81,7 +81,30 @@ If continuing:
 - preserve previous idea statuses
 - update the existing file instead of creating a duplicate
 
-#### 0.2 Interpret Focus and Volume
+#### 0.2 Subject-Identification Gate
+
+Before interpreting focus, volume, or issue-tracker intent, check whether the subject of ideation is identifiable. The repo can ground a settled subject, but being in a repo does not turn vague prompts like `improvements`, `ideas`, `quick wins`, `things to fix`, or an empty prompt into a coherent topic. Downstream agents need to know what they are ideating about before they scan or generate.
+
+**Subject identifiability test:** would a reader, seeing only the prompt, know what subject the agent should ideate on? Judge what the words refer to, not phrase length. `browser sniff` can be identifiable if it names a feature or subsystem; `quick wins` is vague because it only names a quality.
+
+If the prompt explicitly asks the agent to choose the focus, such as `surprise me`, `pick for me`, or `you decide`, mark the run as **surprise-me mode** immediately and use the Surprise me routing below. Do not ask the user to confirm the same choice again.
+
+If the subject is vague, ask one scope question using the blocking question tool when available:
+
+- **Stem:** "What should the agent ideate about?"
+- **Options:**
+  - "Specify a subject the agent should ideate on"
+  - "Surprise me — let the agent decide what to focus on"
+  - "Cancel — let me rephrase"
+
+Routing:
+- **Specify** -> accept the user's follow-up as the subject and re-apply the identifiability test once. If it is still ambiguous, ask once more with "Surprise me" still available. Do not drift into solution direction, audience, success criteria, or constraints; those belong to `gh:brainstorm`.
+- **Surprise me** -> mark the run as **surprise-me mode**. This is a first-class mode, not a fallback. If CWD is inside a git repo, route deterministically to repo-grounded ideation and let the codebase supply the substance. If CWD is not inside a git repo, require at least one piece of substance before dispatching: a URL, a short description, a draft, or pasted material. If the user cannot provide substance outside a repo, end cleanly and ask them to re-run with material.
+- **Cancel** -> exit cleanly so the user can rephrase.
+
+If judgment leaves real doubt in a repo on a short phrase, do one cheap check before asking: search filenames or README/docs for the phrase. If it has repo footprint, treat it as identifiable; otherwise ask the scope question.
+
+#### 0.3 Interpret Focus and Volume
 
 Infer three things from the argument:
 
@@ -89,11 +112,11 @@ Infer three things from the argument:
 - **Volume override** - any hint that changes candidate or survivor counts
 - **Issue-tracker intent** - whether the user wants issue/bug data as an input source
 
-Issue-tracker intent triggers when the argument's primary intent is about analyzing issue patterns: `bugs`, `github issues`, `open issues`, `issue patterns`, `what users are reporting`, `bug reports`, `issue themes`.
+Issue-tracker intent requires explicit tracker/report phrasing. Trigger only when the argument's primary intent is about analyzing issue patterns from an issue tracker: `github issues`, `open issues`, `issue patterns`, `issue themes`, `what users are reporting`, or `bug reports`.
 
-Do NOT trigger on arguments that merely mention bugs as a focus: `bug in auth`, `fix the login issue`, `the signup bug` — these are focus hints, not requests to analyze the issue tracker.
+Do NOT trigger on arguments that merely mention bugs as a focus: `bug in auth`, `fix the login issue`, `the signup bug`, `top 3 bugs in authentication` — these are regular bug-focused ideation prompts, not requests to analyze the issue tracker. A bare `bugs` prompt is vague subject input handled by Phase 0.2, not issue intelligence.
 
-When combined (e.g., `top 3 bugs in authentication`): detect issue-tracker intent first, volume override second, remainder is the focus hint. The focus narrows which issues matter; the volume override controls survivor count.
+When combined with explicit tracker/report wording (e.g., `top 3 issue themes in authentication`, `biggest bug reports about checkout`), detect issue-tracker intent first, volume override second, and treat the remainder as the focus hint. The focus narrows which issues matter; the volume override controls survivor count.
 
 Default volume:
 - each ideation sub-agent generates about 8-10 ideas (yielding ~30 raw ideas across agents, ~20-25 after dedupe)
@@ -104,6 +127,7 @@ Honor clear overrides such as:
 - `100 ideas`
 - `go deep`
 - `raise the bar`
+- tactical scope signals such as `quick wins`, `polish`, `typos`, `small fixes`, or `cleanup`; these lower the Phase 2 meeting-test floor without removing the warrant requirement
 
 Use reasonable interpretation rather than formal parsing.
 
@@ -161,7 +185,7 @@ Run agents in parallel in the **foreground** (do not use background dispatch —
 
 2. **Learnings search** — dispatch `galeharness-cli:learnings-researcher` with a brief summary of the ideation focus.
 
-3. **Issue intelligence** (conditional) — if issue-tracker intent was detected in Phase 0.2, dispatch `galeharness-cli:issue-intelligence-analyst` with the focus hint. If a focus hint is present, pass it so the agent can weight its clustering toward that area. Run this in parallel with agents 1 and 2.
+3. **Issue intelligence** (conditional) — if issue-tracker intent was detected in Phase 0.3, dispatch `galeharness-cli:issue-intelligence-analyst` with the focus hint. If a focus hint is present, pass it so the agent can weight its clustering toward that area. Run this in parallel with agents 1 and 2.
 
    If the agent returns an error (gh not installed, no remote, auth failure), log a warning to the user ("Issue analysis unavailable: {reason}. Proceeding with standard ideation.") and continue with the existing two-agent grounding.
 
@@ -197,11 +221,20 @@ Assign each sub-agent a different ideation frame as a **starting bias, not a con
 - **When issue-tracker intent is active and themes were returned:** Each high/medium-confidence theme becomes a frame. Pad with default frames if fewer than 3 cluster-derived frames. Cap at 4 total.
 - **Default frames (no issue-tracker intent):** (1) user/operator pain and friction, (2) inversion, removal, or automation of a painful step, (3) assumption-breaking or reframing, (4) leverage and compounding effects.
 
-Ask each sub-agent to return a compact structure per idea: title, summary, why_it_matters, evidence/grounding hooks, optional boldness or focus_fit signal.
+Ask each sub-agent to return a compact structure per idea: title, summary, warrant, why_it_matters, meeting_test, optional boldness or focus_fit signal.
+
+**Per-idea warrant contract:** every candidate carries articulated warrant tagged with exactly one of:
+- `direct:` quoted line, specific file, named issue, or explicit user-provided context
+- `external:` named prior art, domain research, or adjacent pattern with source
+- `reasoned:` written-out first-principles argument for why this move likely applies
+
+Warrant is required, not optional. If a sub-agent cannot articulate warrant of at least one type, the idea should not surface. The warrant must support the actual move, not merely decorate it. In surprise-me mode, the warrant may also justify why the agent selected that subject from Phase 1 material.
+
+Apply the meeting-test as a default floor: would this idea warrant team discussion? If not, it should not surface. Waive only the ambition floor for tactical focus signals from Phase 0.3; do not waive grounding or warrant. Stay within the subject's identity. Product expansions, retirements, and architectural pivots are fair game when warrant supports them, but subject-replacement moves are out.
 
 After all sub-agents return:
 1. Merge and dedupe into one master candidate list.
-2. Synthesize cross-cutting combinations -- scan for ideas from different frames that combine into something stronger (expect 3-5 additions at most).
+2. Synthesize cross-cutting combinations -- scan for ideas from different frames that combine into something stronger (expect 3-5 additions at most; in surprise-me mode, spend extra attention on combinations where different frames converged on the same subject).
 3. If a focus was provided, weight the merged list toward it without excluding stronger adjacent ideas.
 4. Spread ideas across multiple dimensions when justified: workflow/DX, reliability, extensibility, missing capabilities, docs/knowledge compounding, quality/maintenance, leverage on future work.
 

--- a/plugins/galeharness-cli/skills/gh-ideate/references/post-ideation-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/references/post-ideation-workflow.md
@@ -18,8 +18,12 @@ Rejection criteria:
 - too expensive relative to likely value
 - already covered by existing workflows or docs
 - interesting but better handled as a brainstorm variant, not a product improvement
+- unjustified — no articulated warrant tagged `direct:`, `external:`, or `reasoned:`
+- unsupported — the stated warrant does not actually support the claimed move
+- subject-replacement — abandons or replaces the subject of ideation rather than operating on it
+- below ambition floor — fails the meeting-test, except when Phase 0.3 detected tactical focus signals
 
-Score survivors using a consistent rubric weighing: groundedness in the current repo, expected value, novelty, pragmatism, leverage on future work, implementation burden, and overlap with stronger ideas.
+Score survivors using a consistent rubric weighing: groundedness in the current repo, warrant strength (`direct:` > `external:` > `reasoned:`, all else equal), expected value, novelty, pragmatism, leverage on future work, implementation burden, and overlap with stronger ideas.
 
 Target output:
 - keep 5-7 survivors by default
@@ -34,6 +38,7 @@ Present only the surviving ideas in structured form:
 
 - title
 - description
+- warrant (`direct:`, `external:`, or `reasoned:`)
 - rationale
 - downsides
 - confidence score
@@ -91,7 +96,8 @@ focus: <optional focus hint>
 
 ### 1. <Idea Title>
 **Description:** [Concrete explanation]
-**Rationale:** [Why this improves the project]
+**Warrant:** [`direct:` / `external:` / `reasoned:` — the actual basis, quoted or cited]
+**Rationale:** [How the warrant connects to the move's significance]
 **Downsides:** [Tradeoffs or costs]
 **Confidence:** [0-100%]
 **Complexity:** [Low / Medium / High]

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -285,6 +285,32 @@ describe("Karpathy workflow guardrails contract", () => {
     expect(capture).toContain("Confirmed requirements, deliberate non-goals, explicit assumptions, success criteria")
   })
 
+  test("gh:brainstorm inherits interaction rules in universal flow and probes rigor gaps selectively", async () => {
+    const content = await readRepoFile("plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md")
+    const universal = await readRepoFile(
+      "plugins/galeharness-cli/skills/gh-brainstorm/references/universal-brainstorming.md",
+    )
+
+    expect(content).toContain("These rules apply to every brainstorm")
+    expect(content).toContain("including the universal non-software flow")
+    expect(content).toContain("one-question-per-turn")
+    expect(content).toContain("default to the platform's blocking question tool")
+    expect(universal).toContain("parent `gh-brainstorm/SKILL.md`")
+    expect(universal).toContain("one-question-per-turn")
+    expect(universal).toContain("does not relax them")
+    expect(universal).toContain("silently skipping questions")
+
+    for (const lens of ["Evidence gap", "Specificity gap", "Counterfactual gap", "Attachment gap", "Durability gap"]) {
+      expect(content).toContain(lens)
+    }
+
+    expect(content).toContain("user-facing checklist")
+    expect(content).toContain("Probe rigor gaps before Phase 2")
+    expect(content).toContain("separate short prose probe")
+    expect(content).toContain("not a menu or fixed questionnaire")
+    expect(content).toContain("record it as an explicit assumption")
+  })
+
   test("gh:plan requires complexity justification and classified uncertainty", async () => {
     const content = await readRepoFile("plugins/galeharness-cli/skills/gh-plan/SKILL.md")
 
@@ -310,6 +336,72 @@ describe("Karpathy workflow guardrails contract", () => {
       expect(content).toContain("Execution note")
       expect(content).toContain("Verification")
     }
+  })
+
+  test("preserves review diff hygiene guardrail outside brainstorm and ideate edits", async () => {
+    const review = await readRepoFile("plugins/galeharness-cli/skills/gh-review/SKILL.md")
+
+    expect(review).toContain("diff-hygiene anchor")
+    expect(review).toContain("Classify diff-hygiene findings")
+    expect(review).toContain("every substantive changed file and behavior change should trace")
+    expect(review).toContain("pre-existing dead code or unrelated quality issues should be reported, not silently fixed")
+  })
+})
+
+describe("gh:ideate rigor contract", () => {
+  test("settles subject before focus dispatch and keeps surprise-me deterministic", async () => {
+    const content = await readRepoFile("plugins/galeharness-cli/skills/gh-ideate/SKILL.md")
+
+    const subjectIdx = content.indexOf("#### 0.2 Subject-Identification Gate")
+    const focusIdx = content.indexOf("#### 0.3 Interpret Focus and Volume")
+    const hktIdx = content.indexOf("#### 0.5 HKTMemory Retrieve")
+    expect(subjectIdx).toBeGreaterThan(0)
+    expect(subjectIdx).toBeLessThan(focusIdx)
+    expect(focusIdx).toBeLessThan(hktIdx)
+
+    expect(content).toContain("being in a repo does not turn vague prompts")
+    expect(content).toContain("What should the agent ideate about?")
+    expect(content).toContain("Surprise me — let the agent decide what to focus on")
+    expect(content).toContain("mark the run as **surprise-me mode** immediately")
+    expect(content).toContain("Do not ask the user to confirm the same choice again")
+    expect(content).toContain("This is a first-class mode")
+    expect(content).toContain("route deterministically to repo-grounded ideation")
+    expect(content).toContain("require at least one piece of substance")
+  })
+
+  test("narrows issue-tracker intent and preserves HKT/Gale anchors", async () => {
+    const content = await readRepoFile("plugins/galeharness-cli/skills/gh-ideate/SKILL.md")
+
+    expect(content).toContain("Issue-tracker intent requires explicit tracker/report phrasing")
+    expect(content).toContain("top 3 bugs in authentication")
+    expect(content).toContain("regular bug-focused ideation prompts")
+    expect(content).toContain("gale-task log skill_started --skill gh:ideate")
+    expect(content).toContain("HKTMemory Retrieve")
+    expect(content).toContain("HKTMemory Store")
+    expect(content).toContain("galeharness-cli:learnings-researcher")
+    expect(content).toContain("galeharness-cli:issue-intelligence-analyst")
+  })
+
+  test("requires warrant on candidates and filters unsupported survivors", async () => {
+    const content = await readRepoFile("plugins/galeharness-cli/skills/gh-ideate/SKILL.md")
+    const post = await readRepoFile(
+      "plugins/galeharness-cli/skills/gh-ideate/references/post-ideation-workflow.md",
+    )
+
+    expect(content).toContain("Per-idea warrant contract")
+    expect(content).toContain("direct:")
+    expect(content).toContain("external:")
+    expect(content).toContain("reasoned:")
+    expect(content).toContain("Warrant is required, not optional")
+    expect(content).toContain("meeting-test")
+    expect(content).toContain("subject-replacement moves are out")
+
+    expect(post).toContain("unjustified — no articulated warrant")
+    expect(post).toContain("unsupported — the stated warrant does not actually support the claimed move")
+    expect(post).toContain("subject-replacement")
+    expect(post).toContain("below ambition floor")
+    expect(post).toContain("**Warrant:**")
+    expect(post).toContain("Do **not** skip brainstorming and go straight to planning")
   })
 })
 


### PR DESCRIPTION
## 背景

本 PR 基于 GaleHarnessCLI 近期工作流 dogfood 中暴露的问题，强化 `gh:brainstorm` 和 `gh:ideate` 的问题澄清、证据约束与候选想法筛选能力。实现以本地已有 Karpathy-style workflow guardrails 为底座，保留 HKTMemory、Gale knowledge、`gh:` 命名、`galeharness-cli:` agent namespace 和跨平台 fallback。

## 主要改动

- `gh:brainstorm`：明确 Interaction Rules 适用于 universal non-software flow，强化 one-question-per-turn 和 blocking question tool fallback。
- `gh:brainstorm`：在 Phase 1.2 增加 selective rigor probes，覆盖 evidence、specificity、counterfactual、attachment，Deep-product 额外覆盖 durability。
- `gh:ideate`：新增 subject-identification gate，显式 `surprise me` / `pick for me` / `you decide` 直接进入 surprise-me mode。
- `gh:ideate`：收窄 issue-tracker intent，避免普通 bug focus 误触发 issue intelligence。
- `gh:ideate`：引入 `direct:` / `external:` / `reasoned:` warrant contract，并在 post-ideation filtering 中拒绝 unsupported 或 subject-replacement ideas。
- 补充 prompt contract tests，保护 brainstorm/ideate 新行为以及 HKT/Gale anchors、既有 workflow guardrails。
- 新增 brainstorm、plan 和 compound solution 文档，记录本次设计决策与未来维护注意事项。

## 验证

- `bun test tests/pipeline-review-contract.test.ts`：37 pass
- `bun test`：1251 pass，3 skip，0 fail
- `bun run release:validate`：通过
- `git diff --check`：通过

## 风险 / 后续

- 这是 prompt/workflow 行为改动，风险主要在 wording 影响 agent routing；已用 contract tests 锁住关键行为锚点。
- 后续如果继续扩展 Proof、web-cache、demo-reel 或 authoring surface，应先走需求/计划/document-review，再按语义评估是否纳入，避免扩大本 PR 的执行面。
- 后续维护 brainstorm/ideate 时，应先列本地 anchors，再评估可吸收语义，并补测试保护。