### PR TITLE
ci(install): 增加 release 安装 smoke 门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,36 @@ jobs:
       - name: Run tests
         run: bun test --path-ignore-patterns="**/resolve-base-script*"
 
+      - name: Smoke release archive install
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive_path="$(bun run scripts/release/build.ts --platform linux-x64)"
+          bun run scripts/release/verify-archive.ts "$archive_path"
+
+          install_dir="$(mktemp -d)"
+          home_dir="$(mktemp -d)"
+          old_target="$(mktemp)"
+          printf 'old\n' > "$old_target"
+          ln -s "$old_target" "$install_dir/gale-harness"
+          printf '0.0.0\n' > "$install_dir/VERSION"
+
+          INSTALL_DIR="$install_dir" \
+            HOME="$home_dir" \
+            PATH="$install_dir:$PATH" \
+            GALE_RELEASE_ARCHIVE="$archive_path" \
+            CI=1 \
+            bash scripts/install-release.sh
+
+          test ! -L "$install_dir/gale-harness"
+          test "$(cat "$install_dir/VERSION")" = "$(node -p "require('./package.json').version")"
+
+          PATH="$install_dir:$PATH" gale-harness --version
+          PATH="$install_dir:$PATH" compound-plugin --help
+          PATH="$install_dir:$PATH" gale-knowledge --help
+          PATH="$install_dir:$PATH" gale-memory --help
+
   test-windows:
     runs-on: windows-latest
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 巨风科技研发团队提效工具 —— 基于 Compound Engineering 工作流与 HKTMemory 向量知识库的 AI 驱动开发套件。
 
+## 快速安装 / 新手一键安装
+
+### macOS / Linux
+
+普通用户优先安装 Release 二进制，不需要 clone 仓库：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/install-release.sh | bash
+gale-harness --version
+```
+
+### Windows
+
+Windows release binary installer 尚未进入 P0a 范围。当前不要把 source-mode 的 `scripts/setup.ps1` 当作普通用户默认一键安装；需要在 Windows 上试用或参与开发时，请参考下方“安装方式”里的贡献者源码安装路径。Windows release 安装器会在后续阶段补齐。
+
 ## 目录
 
 - [核心理念](#核心理念)
@@ -430,7 +445,7 @@ gale-knowledge rebuild-index --full  # 全量
 - macOS 11+、Linux（主流发行版）或 Windows 10/11
 - 能联网的终端（macOS: Terminal / iTerm2，Linux: Bash/Zsh，Windows: PowerShell）
 
-> 不需要预先安装任何工具。一键脚本会自动检测并安装缺失的依赖。
+> Release 二进制安装不需要预先安装 Bun。下面的源码安装路径面向贡献者，会自动检测并安装缺失的开发依赖。
 
 ### 一键安装
 
@@ -444,7 +459,7 @@ curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI
 
 脚本会优先安装到当前 `gale-harness` 所在目录，并移除旧的 `bun link` symlink 后写入编译二进制。没有已安装命令时，默认安装到 `~/.local/bin`。Release assets 覆盖 macOS、Linux、Windows 的 arm64/x64 平台。
 
-#### macOS / Linux
+#### macOS / Linux 源码安装（贡献者路径）
 
 ```bash
 git clone https://github.com/wangrenzhu-ola/GaleHarnessCodingCLI.git
@@ -454,7 +469,9 @@ bash scripts/setup.sh
 
 > **Linux 说明：** 脚本会自动检测 `apt`、`dnf`、`yum`、`pacman` 或 `brew` 等包管理器。如果系统未预装 Git 或 Python，请确保有 `sudo` 权限以便自动安装。
 
-#### Windows
+#### Windows 源码安装（贡献者路径）
+
+Windows release binary installer 尚未进入 P0a 范围。以下 `setup.ps1` / `bootstrap.ps1` 路径用于贡献者源码安装或开发环境准备，不是普通用户默认一键 release 安装。
 
 **已有 Git：**
 

--- a/docs/brainstorms/2026-04-25-install-upgrade-ci-requirements.md
+++ b/docs/brainstorms/2026-04-25-install-upgrade-ci-requirements.md
@@ -1,0 +1,114 @@
+---
+date: 2026-04-25
+topic: install-upgrade-ci
+title: "安装与升级 CI 闭环：README 一键入口、PR smoke、release binary 验证"
+category: brainstorms
+---
+
+# 安装与升级 CI 闭环：README 一键入口、PR smoke、release binary 验证
+
+## Problem Frame
+
+GaleHarnessCLI 已经有 release binary 构建、Unix release 安装脚本、source setup 脚本和 `gale-harness update`，但普通用户入口和 CI 验证还没有形成闭环。
+
+当前 README 的安装说明在文档中后段，新同事打开首页时看不到可复制的一键安装命令，容易去找源码安装或 `bun link` 路径。CI 目前主要验证 `bun test`、release metadata 和 Windows `setup.ps1` source-mode，没有在每个 PR 中验证“当前代码能否被打包成 release archive、安装脚本能否从该 archive 安装、安装后的 binary 能否启动”。release asset workflow 也只 build/upload，缺少上传前的 archive 结构和当前平台可执行 smoke。
+
+本次需求的重点不是重新设计发布系统，而是在现有能力前面补最小可靠门禁：README 第一屏给新手安装入口；PR CI 用本地构建产物做安装/升级 smoke，避免依赖真实 GitHub Release 网络；release workflow 在上传前验证每个平台产物；升级路径至少证明现有安装不会被 install/update 相关路径破坏。
+
+## Actors
+
+- A1. 新手使用者：第一次安装 GaleHarnessCLI，希望从 README 第一屏复制一条命令完成安装。
+- A2. 已安装用户：本机可能已有 release binary 或旧 source-mode / `bun link` 安装，希望升级或迁移时不被破坏。
+- A3. 维护者：修改安装脚本、update 命令、release 构建或 README 后，希望 PR 阶段尽早发现安装损坏。
+- A4. CI/CD：在 GitHub Actions 上验证当前代码的安装、升级和 release binary 可用性。
+
+## Goals
+
+- G1. README 首页第一屏提供面向新手的、可复制的一键安装命令，并把源码 setup 明确放到贡献者路径。
+- G2. 每个 PR 至少在 Linux 上验证当前代码能构建 release archive、通过安装脚本安装到临时目录，并运行基础 binary smoke。
+- G3. release workflow 在上传 asset 前验证每个平台 archive 内容符合平台命名和文件集合要求。
+- G4. 安装/升级 smoke 覆盖旧安装存在时不会被破坏：现有 symlink/source-mode 入口应能被 release install 迁移，已有 binary 安装应能被覆盖安装或 update path 安全处理。
+- G5. Windows/macOS/Linux 都纳入设计；MVP 若不能全量执行所有 OS 的完整端到端 smoke，要明确阶段边界。
+
+## Non-Goals
+
+- NG1. 不引入 Homebrew、Scoop、Winget、npm registry、代码签名或自动安装包分发。
+- NG2. 不让 PR CI 依赖真实 GitHub Release 下载链路；网络发布链路可在 release/post-release 阶段补充。
+- NG3. 不重写 `gale-harness update` 的核心下载、备份和 rollback 算法。
+- NG4. 不把 HKTMemory API 服务可用性作为安装 smoke 的成功条件；CI 可以验证 CLI 入口和文件模式诊断。
+- NG5. 不在本阶段实现完整离线安装。
+
+## Requirements
+
+### README 安装入口
+
+- R1. README 第一屏必须出现“新手一键安装”入口，位置在目录和长篇理念之前。
+- R2. macOS/Linux 默认命令使用 release binary 安装脚本。Windows 只有在 release binary PowerShell installer 实现后才能进入第一屏的一键安装；否则第一屏只标注“Windows release binary installer 待补齐，见详细安装章节”，不能把 source-mode `setup.ps1` / `bootstrap.ps1` 当作普通用户一键安装命令。
+- R3. README 第一屏安装块必须少废话、可复制，并包含安装后最小自检命令：`gale-harness --version`。`gale-harness update --check` 可以作为升级检查命令出现在详细安装/升级章节，但不能作为 PR 必跑的安装成功判据。
+- R4. 现有源码安装 / `setup.sh` / `setup.ps1` 说明保留，但定位为“贡献者开发环境”，不能与普通用户默认安装入口竞争。
+
+### PR CI smoke
+
+- R5. 每个 PR 必须构建当前平台 release archive，使用本地 archive 或 mock release asset 验证安装脚本，不依赖真实 GitHub Release。
+- R6. PR smoke 必须使用临时 `INSTALL_DIR`、临时 HOME/PATH，不能写入 runner 的真实用户安装目录。
+- R7. PR smoke 必须验证安装后这些 binary 至少存在且可执行：`gale-harness`、`compound-plugin`、`gale-knowledge`、`gale-memory`。
+- R8. PR smoke 必须运行基础命令：`gale-harness --help` 或 `--version`、`compound-plugin --help` 或 `--version`、`gale-knowledge --help`、`gale-memory --help`。
+- R9. PR smoke 必须覆盖旧安装迁移场景：安装目录中已有 symlink/source-mode 风格入口时，release installer 能替换为普通 binary，且不会留下坏链接。
+- R10. PR smoke 必须覆盖“已有安装升级/覆盖”场景：安装目录中已有旧版本 binary 和 `VERSION` 时，安装当前 archive 后 `VERSION` 和可执行文件状态正确。
+
+### Release binary verification
+
+- R11. release asset workflow 必须在上传前验证每个平台 archive 包含四个 CLI binary 和 `VERSION`。
+- R12. Windows archive 必须验证 `.exe` 文件名；Unix archive 必须验证无 `.exe` 文件名。
+- R13. release workflow 的 MVP 必须对所有 matrix archive 做结构验证；运行时 smoke 应在对应 OS/arch runner 上执行，或作为后续增强明确延期。不能用 macOS runner 上的交叉构建产物替代 Linux/Windows 正式 asset 的运行验证。
+- R14. 如果 build matrix 生成跨平台 asset，平台列表和文件名规则必须复用 `src/utils/release-platforms.ts`，避免 workflow、脚本、测试各自复制映射。
+- R14a. release workflow 必须显式处理发布信任边界：PR workflow 不得拥有发布凭据；release asset 上传只允许 trusted release/tag/protected branch 触发；`workflow_run` 路径必须校验成功结论、同仓库来源和目标 commit/tag。
+- R14b. 发布后 latest release asset 的可见窗口必须被识别：MVP 至少在风险中记录 “release published 但 assets 尚未上传” 的用户 404 风险；后续可改为 draft release 上传完成后再 publish，或增加 post-release 安装验证。
+
+### Upgrade / update path
+
+- R15. `gale-harness update` 的 source-mode/dev-mode 提示必须与 README 一致：说明 update 只支持 release binary，并给出迁移安装命令。
+- R16. CI 中的升级 smoke 优先用本地 archive 验证安装脚本的覆盖/迁移行为；真实 GitHub API `update --check` 不应作为 PR 必跑门禁。
+- R17. 如果要测试 `update` 下载/替换路径，应通过 mock/local asset 或可注入源完成，不能让 PR 因 GitHub Release 网络波动失败。
+
+### Cross-platform boundary
+
+- R18. MVP 必须覆盖 Linux PR smoke，因为现有 CI 主 job 在 Ubuntu。
+- R19. Windows MVP 至少保留并标注 `setup.ps1` source-mode CI；若本阶段新增 PowerShell release installer，则 Windows PR smoke 应安装本地 Windows archive 并运行 `.exe` 基础命令。
+- R20. macOS smoke 可作为 release binary 运行性增强项接入 `macos-latest`；若成本过高，MVP 可先用 Linux PR smoke + release workflow archive 验证，并把 macOS 运行 smoke列为后续。
+
+## Acceptance Examples
+
+- AE1. Given 新同事打开 README，when 第一屏加载完成，then 他无需滚动到长目录后面即可看到已支持平台的一键 release 安装命令和 `gale-harness --version` 自检；如果 Windows release installer 尚未实现，第一屏只显示边界说明，不显示 source-mode 命令。
+- AE2. Given PR 修改 `scripts/install-release.sh`，when CI 运行，then CI 构建当前平台 archive，设置临时 `INSTALL_DIR`，运行安装脚本，并验证四个 binary 能启动。
+- AE3. Given PR 修改 `scripts/release/build.ts` 或 `src/utils/release-platforms.ts`，when CI 运行，then release archive verifier 验证 Linux 和 Windows 文件名集合，缺失 `gale-memory` 或 `.exe` 命名错误会失败。
+- AE4. Given 临时安装目录中已有旧 `gale-harness` symlink，when release installer 安装本地 archive，then `gale-harness` 不再是 symlink，`gale-harness --version` 或 `--help` 可运行。
+- AE5. Given release workflow 构建 `windows-x64` asset，when 上传前验证运行，then archive 中必须包含 `gale-harness.exe`、`compound-plugin.exe`、`gale-knowledge.exe`、`gale-memory.exe` 和 `VERSION`。
+
+## Success Criteria
+
+- README 第一屏能回答“我该怎么安装”，源码安装不再误导新手。
+- PR CI 能在不访问真实 GitHub Release 的情况下发现安装脚本、release archive、binary 启动和旧安装迁移的常见破坏。
+- release workflow 上传前能拦截缺文件、平台命名错误和空 `VERSION`。
+- `gale-harness update` 的边界和 README 安装承诺一致，source-mode 用户获得可执行迁移路径。
+- MVP 保持小而落地：优先 Linux PR smoke + release archive verifier + README 第一屏；Windows/macOS 运行 smoke 按现有脚本成熟度分阶段接入。
+
+## Key Decisions
+
+- PR CI 使用本地 archive/mock asset，不依赖 GitHub Release 网络。这直接降低 flaky 风险，也能验证当前 PR 代码。
+- release workflow 做上传前验证，不等用户下载后才发现 asset 不可用。
+- README 第一屏以普通用户为先，贡献者路径后置。
+- 安装 smoke 验证“能运行”和“不会破坏旧安装”，不把完整 HKTMemory 服务或真实 update 网络链路纳入 MVP。
+
+## Dependencies / Assumptions
+
+- `scripts/release/build.ts` 已能构建 release archive。
+- `src/utils/release-platforms.ts` 是平台和 binary 文件名的权威来源。
+- `scripts/install-release.sh` 当前支持 `INSTALL_DIR`，可扩展为支持本地 archive override。
+- Windows 若需要普通用户 release binary 一键安装，可能需要新增 PowerShell installer；现有 `setup.ps1` 是 source-mode/贡献者路径。
+
+## Deferred to Planning
+
+- PR CI smoke 是直接写在 `.github/workflows/ci.yml`，还是抽成 `scripts/release/smoke-install.ts` / shell 脚本后由 workflow 调用。
+- Windows release installer 是否进入 MVP，还是先把 Windows 边界写清并在后续实现。
+- `update` 下载路径是否需要新增可测试注入点，还是本阶段只验证 dev/source-mode 文案和 install 覆盖升级。

--- a/docs/plans/2026-04-25-004-feat-install-upgrade-ci-plan.md
+++ b/docs/plans/2026-04-25-004-feat-install-upgrade-ci-plan.md
@@ -1,0 +1,305 @@
+---
+title: "feat: 安装与升级 CI 闭环实施计划"
+type: feat
+status: active
+date: 2026-04-25
+origin: docs/brainstorms/2026-04-25-install-upgrade-ci-requirements.md
+---
+
+# feat: 安装与升级 CI 闭环实施计划
+
+## Overview
+
+本计划为 GaleHarnessCLI 补齐安装/升级检测闭环：README 第一屏给新手一键安装入口；PR CI 使用当前代码构建出的本地 release archive 做安装 smoke，避免依赖真实 GitHub Release；release asset workflow 在上传前验证 archive 内容，运行时 smoke 按平台能力分阶段接入；`update` 的 source-mode 提示与 release binary 安装承诺对齐。
+
+MVP 控制在可落地范围：P0a 先覆盖 README 第一屏 macOS/Linux release 安装入口、release archive verifier、Linux PR smoke 和 Unix installer 本地 archive 安装；P0b/P1 再做 `update` source-mode 迁移文案；P1a 把 verifier 接入 release asset workflow 上传前结构验证；P1b 补 release workflow trust gating 和 post-release 可见性门禁定义；P2a 才做 Windows release installer；P2b 做对应 OS/arch runtime smoke。Windows/macOS 运行 smoke 若超出本 PR，必须明确延期，且 README 不能虚假承诺。
+
+## Problem Frame
+
+需求文档 `docs/brainstorms/2026-04-25-install-upgrade-ci-requirements.md` 指出：仓库已有 `.github/workflows/release-assets.yml`、`scripts/install-release.sh`、`scripts/setup.sh`、`scripts/setup.ps1`、`src/utils/update.ts` 和相关测试，但这些能力没有形成“新手入口 -> PR 安装验证 -> release asset 验证 -> 升级边界”的闭环。
+
+当前 `.github/workflows/ci.yml` 在 Ubuntu 跑 `bun test` 和 release metadata，在 Windows 跑 `setup.ps1` CI mode 和部分测试；没有验证当前 PR 能否构建 release archive 并通过 release installer 安装。`.github/workflows/release-assets.yml` 只 build/upload 多平台 tar.gz；没有上传前结构校验和可执行 smoke。README 已有安装章节，但在文档中段之后，不满足“第一屏可复制”的 DevEx 目标。
+
+## Requirements Trace
+
+- R1-R4: README 第一屏安装入口和贡献者路径后置。
+- R5-R10: PR CI 本地 archive 安装 smoke、临时目录、四个 binary、旧 symlink 迁移、已有安装覆盖。
+- R11-R14b: release workflow 上传前 archive verifier、Windows `.exe` 命名、runtime smoke 阶段边界、复用 `src/utils/release-platforms.ts`、release trust gating、published-before-assets 404 风险记录。
+- R15-R17: update source-mode 文案与 README 一致，PR 不依赖真实 GitHub Release 网络。
+- R18-R20: MVP 至少覆盖 Linux；Windows/macOS 阶段边界必须显式。
+
+## Existing Context Checked
+
+- `.github/workflows/ci.yml`: Ubuntu job 跑 `bun install`、`bun run release:validate`、`bun test`；Windows job 跑 `setup.ps1` CI mode 和裁剪后的 tests。没有 release installer smoke。
+- `.github/workflows/release-assets.yml`: release/workflow_dispatch/workflow_run 触发，matrix 构建 `darwin-*`、`linux-*`、`windows-*`，执行 `bun run build:release --version ... --platform ...` 后直接上传。
+- `scripts/release/build.ts`: 已生成四个 binary 和 `VERSION`，archive 命名为 `galeharness-cli-{version}-{platform}.tar.gz`。
+- `src/utils/release-platforms.ts`: 已集中定义 `RELEASE_PLATFORMS`、`RELEASE_BINARY_BASENAMES`、`.exe` 规则和 Bun target，是 verifier 和 CI 的权威映射。
+- `scripts/install-release.sh`: 已支持 `INSTALL_DIR`，可下载 GitHub Release asset，安装四个 binary 和 `VERSION`，会移除目标 symlink；但还不支持本地 archive override，PR CI 不能用当前构建产物验证。
+- `scripts/setup.sh` / `scripts/setup.ps1`: `setup.ps1` 已有 `GHALE_CI=1`；`setup.sh` 是贡献者/source setup，仍可能有交互和真实 HOME/PATH 写入，不应成为普通用户第一屏入口。
+- `src/utils/update.ts` 和 `src/commands/update.ts`: 已区分 compiled binary 与 dev mode；`performUpdate()` dev-mode 提示偏“Build a compiled binary first”，需要改成普通用户迁移指引。
+- `tests/update-command.test.ts`、`tests/skills/gh-update.test.ts`: 已覆盖 update 逻辑和 gh-update skill 部分行为，可扩展文案/边界断言。
+- 主 checkout 脏分支只读参考到一个方向：`verify-archive.ts`、installer 本地 archive override、安装脚本测试和 Windows installer 草案是可行思路，但实现阶段必须重新审查后小步落地，不能直接复制未审查改动。
+
+## Recommended MVP
+
+### P0a. First PR slice
+
+1. 新增 release archive verifier，复用 `src/utils/release-platforms.ts`，验证 archive 的四个 binary、`VERSION`、平台文件名和安全解压规则。P0a 至少要能验证 `linux-x64` PR smoke 产物；Windows `.exe` 命名规则也应通过 fixture 测试覆盖，避免 P1 接入 release matrix 时才发现映射错误。
+2. README 第一屏加入“新手一键安装”块：
+   - macOS/Linux:
+     ```bash
+     curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/install-release.sh | bash
+     gale-harness --version
+     ```
+   - Windows 若无 `install-release.ps1`：第一屏只写“Windows release binary installer 待补齐，见详细安装章节”，不放 `bootstrap.ps1` / `setup.ps1` source-mode 命令。若本 PR 实现 PowerShell release installer，才放 `irm .../scripts/install-release.ps1 | iex`。
+3. 扩展 `scripts/install-release.sh` 支持 CI-gated 本地 archive override，用于 PR CI。该模式必须跳过 GitHub API/tag 解析/download，只安装指定本地 archive。
+4. 在 `.github/workflows/ci.yml` Ubuntu job 增加 release install smoke：
+   - `bun run build:release --version 0.0.0-ci --platform linux-x64`
+   - verifier 检查 archive
+   - 临时 `INSTALL_DIR` 和临时 `HOME` 执行 installer 安装本地 archive，并把临时安装目录 prepend 到 `PATH`
+   - 运行四个 binary 的 `--help` / `--version`
+   - 构造 symlink/旧 VERSION 再安装，验证迁移/覆盖。
+
+### P0b / P1. Update migration copy slice
+
+5. 更新 `src/utils/update.ts` dev/source-mode 文案和 `tests/update-command.test.ts` 断言，让用户知道需要迁移到 release binary。该项重要但不应阻塞 P0a 的安装 CI 闭环；如果实现时改动很小，可以并入同一 PR，否则作为紧随其后的 P0b/P1。
+
+### P1a. Release archive workflow slice
+
+6. 在 `.github/workflows/release-assets.yml` 上传前对 matrix archive 执行 P0a verifier。此切片只做 archive 质量门禁，不同时扩大到发布权限模型。
+
+### P1b. Release trust and public-visibility slice
+
+7. 收紧 release workflow trust gating：发布权限、`workflow_run`、`workflow_dispatch`、tag/ref 绑定和 upload job 条件作为独立门禁处理。
+8. 增加 README 安装入口防漂移测试或 lint：第一屏必须包含 release install 和 `gale-harness --version`，详细安装章节必须包含 tag-pinned/raw trust 说明，第一屏不能出现 `setup.sh`、`setup.ps1`、`bootstrap.ps1` source-mode 命令。
+9. 增加 post-release public installer smoke 的后续门禁定义：release assets 上传完成后用短 retry/backoff 验证 latest asset 可下载且 public installer 不遇到 asset 404。若本 PR 不实现，必须保留为明确 P1/P2 follow-up，而不是只写风险。
+
+### P2a. Windows installer slice
+
+10. 新增 Windows release installer 后，README 第一屏才能加入 Windows PowerShell 一键命令；Windows CI 安装本地 `windows-x64` archive 并运行 `.exe` smoke。
+
+### P2b. Cross-platform runtime smoke slice
+
+11. 对 macOS/Linux/Windows 正式 release asset 的 runtime smoke，优先用对应 OS runner 构建并运行；若继续单 runner 交叉构建，则需把 artifact 传递到对应 OS runner 做 smoke。
+
+## Implementation Units
+
+### U1. Release archive verifier
+
+**Goal:** 建立上传前和 PR smoke 共用的 archive 结构验证。
+
+**Files:**
+- Create: `scripts/release/verify-archive.ts`
+- Modify: `package.json`
+- Test: `tests/release-archive.test.ts`
+
+**Approach:**
+- 导出 `verifyReleaseArchive({ archivePath, platform })`，CLI 支持 `--archive` 和 `--platform`。
+- 复用 `getReleaseBinaryFileNames()` 和 `getReleasePlatformConfig()`。
+- 安全解压到 OS temp：解压前或解压过程中枚举 tar entries，拒绝绝对路径、`..`、symlink、hardlink、设备文件、重复条目和未知顶层文件；只接受预期普通文件。
+- 检查四个 binary 和 `VERSION`，校验 `VERSION` 非空。
+- 不在 verifier 中运行 binary；运行 smoke 由 CI 当前平台负责。
+
+**Test Scenarios:**
+- `linux-x64` archive 包含四个无 `.exe` binary 和 `VERSION` 时通过。
+- `windows-x64` archive 包含四个 `.exe` 和 `VERSION` 时通过。
+- 缺 `gale-memory`、空 `VERSION`、不支持的平台时失败且错误信息可定位。
+- 恶意 archive 包含 path traversal、symlink binary、重复 entry 或未知顶层文件时失败。
+
+### U2. Unix installer 本地 archive smoke 能力
+
+**Goal:** 让 `scripts/install-release.sh` 可安装当前 PR 构建出的本地 archive。
+
+**Files:**
+- Modify: `scripts/install-release.sh`
+- Test: `tests/install-release-sh.test.ts`
+
+**Approach:**
+- 保留现有 GitHub Release 下载路径。
+- 增加 CI-gated 本地 archive override，例如 `GALE_RELEASE_ARCHIVE=/tmp/archive.tar.gz`，但只有 `CI=1` 或显式 `GALE_INSTALL_ALLOW_LOCAL_ARCHIVE=1` 时启用；日志必须打印 archive source。
+- 本地 archive 模式控制流必须先校验文件存在，然后跳过 `resolve_tag`、tag prefix 校验、GitHub API 和 `curl` 下载；version 从解压后的 `VERSION` 读取或仅用于日志。
+- 平台默认自动检测。若确需平台 override，仅作为未文档化 CI-only 变量，并校验与当前 OS/arch 或测试 fixture 兼容，不能作为普通用户配置面。
+- CI 在调用 installer 前运行 TS verifier；Bash installer 不能依赖用户机器已有 Bun/TypeScript 工具链。
+- Installer 自身做 bash-native 最小防护：解压到 temp、只复制预期文件名、拒绝从解压目录复制 symlink 或非 regular file、复制后固定权限、失败时不能输出 “Installed to”。
+- 对目标 symlink 先删除再安装普通文件；普通文件覆盖安装。
+- 从解压目录复制时再次检查源是 regular file，固定权限写入目标，避免把 symlink 当 binary 安装。
+
+**Test Scenarios:**
+- 临时 `INSTALL_DIR` 安装本地 archive 后四个 binary 和 `VERSION` 存在。
+- 旧 `gale-harness` symlink 被替换为普通文件。
+- 旧 `VERSION` 被新 archive 覆盖。
+- archive 缺文件或平台 override 不支持时失败。
+- 本地 archive 模式不访问 GitHub API、不生成 release URL、不调用 `curl` 下载。
+- `tests/install-release-sh.test.ts` 在 `process.platform === "win32"` 时 skip；Windows release installer 用独立 PowerShell 测试覆盖。
+
+### U3. PR CI release install smoke
+
+**Goal:** 每个 PR 尽早发现当前代码无法打包、安装或启动。
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Approach:**
+- 在 Ubuntu `test` job 现有 `bun test` 之后或之前增加一个独立步骤，构建 `linux-x64` CI archive。
+- 执行 `bun run scripts/release/verify-archive.ts --archive ... --platform linux-x64`。
+- 用 `mktemp -d` 创建安装目录和临时 HOME，设置 `CI=1`、`GALE_RELEASE_ARCHIVE`、`INSTALL_DIR`、`HOME` 运行 `scripts/install-release.sh`；除非测试必须，不设置平台 override。
+- 将临时安装目录 prepend 到 PATH，使用同一个临时 `HOME` 运行：
+  - `gale-harness --version` 或 `gale-harness --help`
+  - `compound-plugin --help`
+  - `gale-knowledge --help`
+  - `gale-memory --help`
+- 同一 job 增加小型迁移 smoke：先创建旧 symlink/旧 `VERSION`，再安装同一 archive，验证不再是 symlink 且 `VERSION` 更新。
+- 明确断言 smoke 没有使用 `$HOME/.local/bin` 或 runner 真实用户安装目录。
+
+**Test Scenarios:**
+- GitHub Release 不可用时 PR smoke 仍能通过，因为只使用本地 archive。
+- install script 改坏目标文件名、权限、symlink 替换或 VERSION 时 CI 失败。
+
+### U4. Release asset workflow 上传前验证与 trust gating
+
+**Goal:** release 包上传前确认每个平台 asset 结构正确，并收紧 release asset 上传的信任边界。
+
+**Files:**
+- Modify: `.github/workflows/release-assets.yml`
+
+**Approach:**
+- `Build release binaries` 后立即运行 verifier。
+- 对 matrix 平台都做 archive 结构验证。
+- MVP 不把 macOS runtime smoke 作为必做；所有平台先做结构验证。
+- runtime smoke 必须在对应 OS/arch runner 上执行，或作为 U8 后续：Linux asset 用 `ubuntu-latest` 构建/运行，macOS asset 用 `macos-latest`，Windows asset 用 `windows-latest`，或将单 runner 交叉构建产物传递到对应 OS runner 再运行。
+- 收紧触发和权限：workflow 顶层默认 `permissions: contents: read`；build job 只用读权限；upload job 单独使用 `contents: write` 并依赖 trust gate 输出；`workflow_run` 路径必须校验指定 workflow 名称、`conclusion == success`、`head_repository.full_name == github.repository`、head sha 匹配目标 release commit/tag；`workflow_dispatch` 必须校验 tag prefix，且 release target 属于当前仓库默认分支或受保护 ref；release/tag 来源必须和要上传 asset 的版本/tag 可验证绑定；非 trusted 分支/tag 的 `workflow_run` 必须跳过 upload job，而不是只在脚本中失败。PR workflow 不授予发布凭据。
+- 记录发布可见窗口风险：当前 release 已 published 后再上传 assets，用户可能短暂遇到 404。MVP 不重构 release-please 时序；后续应评估 draft release 上传完成后 publish，或增加 post-release installer 验证。
+
+**Test Scenarios:**
+- matrix 中任一平台 archive 缺文件时该 matrix job 失败，不上传坏 asset。
+- Windows archive 使用非 `.exe` 文件名时 verifier 失败。
+- 非 trusted `workflow_run` 不会获得上传权限或执行 upload。
+- `workflow_run` 来自 fork、错误 workflow 名称、失败 conclusion、非目标 sha/tag 时，upload job 被 GitHub Actions 条件跳过。
+
+### U5. update source-mode 迁移提示
+
+**Goal:** 让 update 边界对新手可执行，而不是只给开发者编译提示。
+
+**Files:**
+- Modify: `src/utils/update.ts`
+- Test: `tests/update-command.test.ts`
+
+**Approach:**
+- 保持 `isCompiledBinary()` 的硬边界。
+- 修改 `performUpdate()` 非 compiled binary 分支文案：
+  - 说明当前是 source/development install。
+  - 说明 `gale-harness update` 只支持 release binary。
+  - 给出 macOS/Linux release install 命令。
+  - 如果 U7 实现 Windows installer，则给出 PowerShell 命令；否则指向 README Windows 安装边界。
+- `gale-harness update --check` 不作为 README 第一屏安装成功的必需自检。若要把它纳入 CI，先给 release metadata 源增加 mock/local fixture 注入点，再跑 release-binary 路径测试；真实 GitHub API 不进 PR 必跑门禁。
+- 更新 CLI integration test 对文案的断言，避免只匹配 “development mode”。
+
+**Test Scenarios:**
+- `bun run src/index.ts update` 非 0 退出，输出包含 release binary、install-release 和迁移建议。
+- `update --check --rollback` 冲突行为保持不变。
+
+### U6. README 第一屏安装入口
+
+**Goal:** 新同事打开 README 即可复制安装命令。
+
+**Files:**
+- Modify: `README.md`
+
+**Approach:**
+- 在标题和一句产品说明后、目录前新增“快速安装”短块。
+- 块内只放普通用户安装和自检；避免把工作流理念、架构和贡献者 setup 放在前面。
+- 现有“安装方式”章节保留，但调整为详细说明：release binary 是普通用户推荐；source setup 是贡献者路径。
+- Windows 文案必须与实现一致：没有 release installer 就在第一屏写清楚边界并链接详细章节，不能放 `bootstrap.ps1` / `setup.ps1` source-mode 命令；实现了 U7 才放 PowerShell release installer 为默认。
+- 一键命令使用 `raw.githubusercontent.com/main` 属于信任 GitHub raw 的便利入口。README 详细安装章节应说明团队/生产安装可改用 tag 固定脚本或 release asset 校验；checksum/signature 是后续 release hardening，不阻塞本 MVP。
+- 增加 README 文本测试或 lint 防漂移：第一屏必须包含 release installer 命令和 `gale-harness --version`；第一屏不得包含 `setup.sh`、`setup.ps1`、`bootstrap.ps1`；详细安装章节必须保留 GitHub raw 信任边界和 tag-pinned 备选说明。
+
+**Acceptance:**
+- README 第一屏能看到安装命令，不需要滚动到目录后。
+- 复制的 macOS/Linux 命令与 `scripts/install-release.sh` 实际入口一致。
+- README 防漂移测试能阻止 source-mode 命令重新进入普通用户第一屏。
+
+### U7. Windows release installer（MVP+，可延期但需标注）
+
+**Goal:** 让 Windows 普通用户也有 release binary 一键安装，而不只依赖 source-mode `setup.ps1`。
+
+**Files:**
+- Create: `scripts/install-release.ps1`
+- Test: `tests/install-release-ps1.test.ts`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `README.md`
+
+**Approach:**
+- PowerShell 原生下载/解压 `windows-x64` 或 `windows-arm64` archive，安装四个 `.exe` 和 `VERSION`。
+- 支持本地 archive override 和临时安装目录，供 Windows CI 使用。
+- 复用 `setup.ps1` 的 CI mode、PATH 和 PowerShell 5.1 兼容经验。
+- 不依赖 Git Bash/WSL；优先使用 Windows 自带 `tar.exe`，缺失时清晰失败。
+
+**Phase Boundary:**
+- 若本 PR 不实现 U7，README 第一屏不能声称 Windows release binary 一键安装已可用，也不能放 source-mode 命令；只给边界说明和详细章节链接，把 U7 作为后续。
+
+### U8. 对应 OS/arch runtime smoke（后续增强）
+
+**Goal:** 证明正式 release workflow 产出的各平台 binary 不只是结构正确，而是在对应 OS 上可启动。
+
+**Files:**
+- Modify: `.github/workflows/release-assets.yml`
+
+**Approach:**
+- Linux asset 在 `ubuntu-latest` 构建并运行 smoke，Windows asset 在 `windows-latest` 运行 `.exe --help`，macOS asset 在 `macos-latest` 运行 smoke。
+- 如果保留单 runner 交叉构建，则把 archive 上传为 workflow artifact，再由对应 OS runner 下载运行 smoke，通过后才 release upload。
+- 该单元不属于 P0；如果 release workflow 当前成本敏感，可以先结构验证并记录 residual risk。
+
+## CI Strategy
+
+**Every PR should run:**
+- Existing `bun run release:validate` and `bun test`.
+- New Linux release install smoke in `.github/workflows/ci.yml`:
+  - build local `linux-x64` archive;
+  - verify archive;
+  - install into temp `INSTALL_DIR` with temp `HOME` and temp PATH prepend;
+  - run four CLI binaries with the same temp `HOME`;
+  - verify symlink migration and existing install overwrite behavior.
+- Existing Windows `setup.ps1` CI remains contributor/source-mode coverage.
+- If U7 lands, Windows CI also installs local `windows-x64` archive with `install-release.ps1` and runs `.exe` help/version smoke.
+
+**Release workflow should run:**
+- For every matrix platform in `.github/workflows/release-assets.yml`: build archive, run verifier, only then upload.
+- Trust gating before upload: trusted release/tag/protected branch only, same-repo successful workflow_run only, minimal permissions.
+- Runtime smoke on corresponding OS/arch is P2 unless implemented with low workflow complexity in the same PR.
+- Do not require downloading from the just-published GitHub Release in PR CI. Post-release public installer verification is a follow-up release hardening item.
+
+**Local developer verification before PR:**
+- `bun test`
+- `bun run release:validate`
+- `bun run build:release --version 0.0.0-ci --platform $(current platform)`
+- `bun run scripts/release/verify-archive.ts --archive <archive> --platform <platform>`
+- temp `INSTALL_DIR` install smoke via `scripts/install-release.sh`
+
+## Risks
+
+- **Bun compile cross-platform mismatch:** archive structure can be verified everywhere, but binary runtime can only be smoke-tested on compatible OS/arch. MVP mitigates PR risk with Linux smoke; release asset runtime smoke across OS/arch remains P2 unless implemented.
+- **Installer test flakiness from network:** PR smoke uses local archive, not GitHub Release.
+- **Windows gap:** existing Windows CI validates `setup.ps1` source-mode, not release binary install. If U7 is deferred, README must be honest and the risk remains visible.
+- **README drift:** install commands must stay aligned with script names and update source-mode guidance; tests should assert key text where practical, but review discipline remains important.
+- **Partial install on script failure:** installer should validate archive before copying and fail before success messaging; tests must cover missing files.
+- **Installer trust boundary:** `curl | bash` / `irm | iex` is a convenience path that trusts GitHub raw. MVP should document this plainly; checksum/signature verification can be follow-up hardening.
+- **Release published before assets uploaded:** existing release event timing can expose a short 404 window. MVP records the risk; later work should move toward draft-before-publish or post-release public installer verification.
+
+## Document Review Decisions / Risks
+
+- **Decision: promote verifier into P0a.** P0a PR smoke and local-archive installer safety both depend on archive validation, so the verifier cannot wait for P1. P1a now means "wire the P0a verifier into release-assets workflow," not "create verifier for the first time"; P1b separately handles release trust gating.
+- **Decision: keep Windows release installer in P2 for this PR.** README first screen must remain honest: macOS/Linux get the release installer command; Windows gets an explicit release-installer gap until `install-release.ps1` exists and is covered by Windows CI.
+- **Decision: do not put real `gale-harness update --check` in PR CI.** Current PR coverage should use local archive install/overwrite smoke. Mockable release metadata or post-release public installer verification can be added later without making PRs depend on GitHub Release network timing.
+- **Decision: make README guidance testable.** README changes should include a lightweight text test/lint so the first screen remains a release-binary path and source-mode commands stay in the contributor path.
+- **Risk: PR smoke must isolate HOME as well as INSTALL_DIR/PATH.** The implementation should use temp `HOME`, temp `INSTALL_DIR`, and temp PATH prepend so installer/update paths cannot mutate the runner user's real config or installation state.
+- **Risk: release asset runtime smoke is not a P0/P1 promise.** P1 validates structure and upload trust boundaries for every matrix archive. Actual binary startup on macOS/Windows/Linux release assets remains P2 unless the implementation adds corresponding OS runners in the same change.
+- **Risk: latest asset 404 remains until public installer smoke exists.** P1 should define or implement a post-release public installer check with short retry/backoff after assets upload; P0 may ship with this as a tracked follow-up.
+
+## Open Questions
+
+- Should P1 include a fixture for the latest public release archive to test installer backward compatibility, or should that remain a post-release/network verification job?
+- Should `gale-harness update --check` get a mockable release metadata source in this PR, or stay as unit-tested logic plus release/post-release verification?
+
+## Document Review Gate
+
+Before `/gh:work`, run `document-review` on this plan and apply high-confidence fixes or record remaining items in `Open Questions`. Implementation should not start until the remaining issues are explicitly accepted.

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -5,6 +5,9 @@
 #
 # Environment:
 #   INSTALL_DIR=/path/to/bin   Override install directory
+#   GALE_RELEASE_ARCHIVE=/path/to/archive.tar.gz
+#                             Install from a local archive, only when CI=1 or
+#                             GALE_INSTALL_ALLOW_LOCAL_ARCHIVE=1
 
 set -euo pipefail
 
@@ -76,23 +79,13 @@ resolve_install_dir() {
   printf '%s\n' "$HOME/.local/bin"
 }
 
-need curl
 need tar
 
-tag="$(resolve_tag "${1:-}")"
-if [[ "$tag" != "$TAG_PREFIX"* ]]; then
-  err "release tag must start with $TAG_PREFIX: $tag"
-  exit 1
-fi
-
-version="${tag#$TAG_PREFIX}"
 platform="$(detect_platform)"
 exe=""
 if [[ "$platform" == windows-* ]]; then
   exe=".exe"
 fi
-asset="galeharness-cli-$version-$platform.tar.gz"
-url="https://github.com/$REPO/releases/download/$tag/$asset"
 tmpdir="$(mktemp -d -t galeharness-install-XXXXXX)"
 install_dir="$(resolve_install_dir)"
 
@@ -101,18 +94,117 @@ cleanup() {
 }
 trap cleanup EXIT
 
-printf 'Installing GaleHarnessCLI %s (%s)\n' "$version" "$platform"
-printf 'Download: %s\n' "$url"
+expected_files() {
+  printf '%s\n' \
+    "gale-harness$exe" \
+    "compound-plugin$exe" \
+    "gale-knowledge$exe" \
+    "gale-memory$exe" \
+    "VERSION"
+}
 
-curl -fL "$url" -o "$tmpdir/$asset"
-tar -xzf "$tmpdir/$asset" -C "$tmpdir"
+is_expected_file() {
+  local entry="$1"
+  case "$entry" in
+    "gale-harness$exe" | "compound-plugin$exe" | "gale-knowledge$exe" | "gale-memory$exe" | "VERSION")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+validate_archive_listing() {
+  local archive="$1"
+  local list_file="$tmpdir/archive-files.txt"
+  local detail_file="$tmpdir/archive-details.txt"
+
+  if [ ! -f "$archive" ] || [ -L "$archive" ]; then
+    err "release archive must be a regular file: $archive"
+    exit 1
+  fi
+
+  tar -tzf "$archive" > "$list_file"
+  tar -tvzf "$archive" > "$detail_file"
+
+  while IFS= read -r entry; do
+    [ "$entry" != "" ] || continue
+    case "$entry" in
+      /* | *"/../"* | "../"* | *"/.." | *"/"* | *"\\.."* | "\\"*)
+        err "unsafe archive path: $entry"
+        exit 1
+        ;;
+    esac
+    if ! is_expected_file "$entry"; then
+      err "unexpected archive file: $entry"
+      exit 1
+    fi
+  done < "$list_file"
+
+  while IFS= read -r expected; do
+    if ! grep -Fx "$expected" "$list_file" >/dev/null; then
+      err "archive missing expected file: $expected"
+      exit 1
+    fi
+  done < <(expected_files)
+
+  if [ "$(sort "$list_file" | uniq -d | wc -l | tr -d ' ')" != "0" ]; then
+    err "archive contains duplicate entries"
+    exit 1
+  fi
+
+  if grep -v '^-' "$detail_file" >/dev/null; then
+    err "archive contains non-regular files"
+    exit 1
+  fi
+}
+
+if [ "${GALE_RELEASE_ARCHIVE:-}" != "" ]; then
+  if [ "${CI:-}" != "1" ] && [ "${GALE_INSTALL_ALLOW_LOCAL_ARCHIVE:-}" != "1" ]; then
+    err "GALE_RELEASE_ARCHIVE is only allowed when CI=1 or GALE_INSTALL_ALLOW_LOCAL_ARCHIVE=1"
+    exit 1
+  fi
+  archive_path="$GALE_RELEASE_ARCHIVE"
+  printf 'Installing GaleHarnessCLI from local archive (%s)\n' "$platform"
+  printf 'Archive: %s\n' "$archive_path"
+else
+  need curl
+  tag="$(resolve_tag "${1:-}")"
+  if [[ "$tag" != "$TAG_PREFIX"* ]]; then
+    err "release tag must start with $TAG_PREFIX: $tag"
+    exit 1
+  fi
+
+  version="${tag#$TAG_PREFIX}"
+  asset="galeharness-cli-$version-$platform.tar.gz"
+  url="https://github.com/$REPO/releases/download/$tag/$asset"
+  archive_path="$tmpdir/$asset"
+
+  printf 'Installing GaleHarnessCLI %s (%s)\n' "$version" "$platform"
+  printf 'Download: %s\n' "$url"
+  curl -fL "$url" -o "$archive_path"
+fi
+
+validate_archive_listing "$archive_path"
+tar -xzf "$archive_path" -C "$tmpdir"
+
+for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
+  src="$tmpdir/$bin$exe"
+  if [ ! -f "$src" ] || [ -L "$src" ]; then
+    err "archive entry is not a regular file: $bin$exe"
+    exit 1
+  fi
+done
+
+if [ ! -f "$tmpdir/VERSION" ] || [ -L "$tmpdir/VERSION" ]; then
+  err "archive entry is not a regular file: VERSION"
+  exit 1
+fi
 
 mkdir -p "$install_dir"
 for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
   src="$tmpdir/$bin$exe"
-  if [ ! -f "$src" ]; then
-    continue
-  fi
   dest="$install_dir/$bin$exe"
   if [ -L "$dest" ]; then
     rm "$dest"

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -83,7 +83,7 @@ execFileSync(
   ],
   {
     cwd: repoRoot,
-    stdio: "inherit",
+    stdio: ["ignore", "ignore", "inherit"],
   },
 )
 
@@ -111,7 +111,7 @@ for (const [basename, entrypoint] of [
     ],
     {
       cwd: repoRoot,
-      stdio: "inherit",
+      stdio: ["ignore", "ignore", "inherit"],
     },
   )
 }

--- a/scripts/release/verify-archive.ts
+++ b/scripts/release/verify-archive.ts
@@ -1,0 +1,131 @@
+/**
+ * Verify a GaleHarnessCLI release archive without executing its binaries.
+ *
+ * Usage:
+ *   bun run scripts/release/verify-archive.ts <archive.tar.gz>
+ */
+
+import { execFileSync } from "node:child_process"
+import fs from "node:fs"
+import path from "node:path"
+import {
+  RELEASE_PLATFORMS,
+  getReleaseBinaryFileNames,
+  getReleasePlatformConfig,
+  isReleasePlatform,
+} from "../../src/utils/release-platforms"
+
+function fail(message: string): never {
+  throw new Error(message)
+}
+
+function parseArchiveName(archivePath: string): { version: string; platform: string } {
+  const basename = path.basename(archivePath)
+  for (const platform of RELEASE_PLATFORMS) {
+    const suffix = `-${platform}.tar.gz`
+    if (basename.startsWith("galeharness-cli-") && basename.endsWith(suffix)) {
+      const version = basename.slice("galeharness-cli-".length, -suffix.length)
+      if (!version) fail(`Archive name is missing version: ${basename}`)
+      return { version, platform }
+    }
+  }
+
+  fail(
+    `Archive name must match galeharness-cli-<version>-<platform>.tar.gz. Supported platforms: ${RELEASE_PLATFORMS.join(", ")}`,
+  )
+}
+
+function assertSafeRelativeFileName(entry: string): void {
+  if (!entry) fail("Archive contains an empty entry name")
+  if (path.posix.isAbsolute(entry) || entry.startsWith("\\")) {
+    fail(`Archive contains an absolute path: ${entry}`)
+  }
+
+  const parts = entry.split("/")
+  if (parts.includes("..")) fail(`Archive contains path traversal: ${entry}`)
+  if (parts.length !== 1) fail(`Archive contains nested path: ${entry}`)
+}
+
+function listArchiveNames(archivePath: string): string[] {
+  return execFileSync("tar", ["-tzf", archivePath], { encoding: "utf-8" })
+    .split(/\r?\n/)
+    .filter(Boolean)
+}
+
+function listArchiveDetails(archivePath: string): string[] {
+  return execFileSync("tar", ["-tvzf", archivePath], { encoding: "utf-8" })
+    .split(/\r?\n/)
+    .filter(Boolean)
+}
+
+export function verifyReleaseArchive(archivePath: string): void {
+  const resolvedArchivePath = path.resolve(archivePath)
+  if (!fs.existsSync(resolvedArchivePath)) fail(`Archive does not exist: ${archivePath}`)
+  if (!fs.statSync(resolvedArchivePath).isFile()) fail(`Archive is not a regular file: ${archivePath}`)
+
+  const { version, platform } = parseArchiveName(resolvedArchivePath)
+  const platformConfig = getReleasePlatformConfig(platform)
+  if (!isReleasePlatform(platformConfig.platform)) fail(`Unsupported release platform: ${platform}`)
+
+  const expectedFiles = new Set([...getReleaseBinaryFileNames(platform), "VERSION"])
+  const names = listArchiveNames(resolvedArchivePath)
+  if (names.length !== expectedFiles.size) {
+    fail(`Archive must contain exactly ${expectedFiles.size} files, found ${names.length}`)
+  }
+
+  const seen = new Set<string>()
+  for (const name of names) {
+    assertSafeRelativeFileName(name)
+    if (seen.has(name)) fail(`Archive contains duplicate entry: ${name}`)
+    seen.add(name)
+    if (!expectedFiles.has(name)) fail(`Archive contains unexpected file: ${name}`)
+  }
+
+  for (const expectedFile of expectedFiles) {
+    if (!seen.has(expectedFile)) fail(`Archive is missing expected file: ${expectedFile}`)
+  }
+
+  for (const detail of listArchiveDetails(resolvedArchivePath)) {
+    const type = detail[0]
+    if (type !== "-") {
+      fail(`Archive entry is not a regular file: ${detail}`)
+    }
+  }
+
+  const extractDir = fs.mkdtempSync(path.join(path.dirname(resolvedArchivePath), ".verify-archive-"))
+  try {
+    execFileSync("tar", ["-xzf", resolvedArchivePath, "-C", extractDir], { stdio: "pipe" })
+    const versionFile = path.join(extractDir, "VERSION")
+    if (!fs.statSync(versionFile).isFile()) fail("VERSION is not a regular file")
+    const archiveVersion = fs.readFileSync(versionFile, "utf-8").trim()
+    if (archiveVersion !== version) {
+      fail(`VERSION content '${archiveVersion}' does not match archive version '${version}'`)
+    }
+
+    for (const fileName of expectedFiles) {
+      const filePath = path.join(extractDir, fileName)
+      const stat = fs.lstatSync(filePath)
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        fail(`Extracted entry is not a regular file: ${fileName}`)
+      }
+    }
+  } finally {
+    fs.rmSync(extractDir, { recursive: true, force: true })
+  }
+}
+
+if (import.meta.main) {
+  const archivePath = process.argv[2]
+  if (!archivePath) {
+    console.error("usage: bun run scripts/release/verify-archive.ts <archive.tar.gz>")
+    process.exit(2)
+  }
+
+  try {
+    verifyReleaseArchive(archivePath)
+    console.log(`Verified ${archivePath}`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/tests/install-release-sh.test.ts
+++ b/tests/install-release-sh.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { detectReleasePlatform, getReleaseBinaryFileNames } from "../src/utils/release-platforms"
+import { createTarGz, type TarFixtureEntry } from "./tar-fixtures"
+
+const repoRoot = path.resolve(import.meta.dir, "..")
+const installerPath = path.join(repoRoot, "scripts", "install-release.sh")
+
+async function writeLocalArchive(version = "9.8.7"): Promise<{ archivePath: string; platform: string }> {
+  const platform = detectReleasePlatform()
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-archive-"))
+  const archivePath = path.join(dir, `galeharness-cli-${version}-${platform}.tar.gz`)
+  const entries: TarFixtureEntry[] = [
+    ...getReleaseBinaryFileNames(platform).map((name) => ({
+      name,
+      content: `#!/usr/bin/env sh\necho ${name} ${version}\n`,
+    })),
+    { name: "VERSION", content: `${version}\n` },
+  ]
+  await fs.writeFile(archivePath, createTarGz(entries))
+  return { archivePath, platform }
+}
+
+async function runInstaller(env: Record<string, string>): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bash", installerPath], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+const describeIfUnix = process.platform === "win32" ? describe.skip : describe
+
+describeIfUnix("install-release.sh local archive mode", () => {
+  test("requires CI or explicit opt-in for local archives", async () => {
+    const { archivePath } = await writeLocalArchive()
+    const installDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-bin-"))
+
+    const result = await runInstaller({
+      GALE_RELEASE_ARCHIVE: archivePath,
+      INSTALL_DIR: installDir,
+      CI: "",
+      GALE_INSTALL_ALLOW_LOCAL_ARCHIVE: "",
+    })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain("GALE_RELEASE_ARCHIVE is only allowed")
+  })
+
+  test("installs a local archive without calling curl and replaces old symlinks plus VERSION", async () => {
+    const { archivePath, platform } = await writeLocalArchive()
+    const installDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-bin-"))
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-path-"))
+    const oldTargetDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-old-"))
+    const oldTarget = path.join(oldTargetDir, "gale-harness-old")
+
+    await fs.writeFile(oldTarget, "old\n")
+    await fs.symlink(oldTarget, path.join(installDir, getReleaseBinaryFileNames(platform)[0]))
+    await fs.writeFile(path.join(installDir, "VERSION"), "0.0.1\n")
+    await fs.writeFile(path.join(fakeBinDir, "curl"), "#!/usr/bin/env sh\necho curl should not run >&2\nexit 42\n")
+    await fs.chmod(path.join(fakeBinDir, "curl"), 0o755)
+
+    const result = await runInstaller({
+      GALE_RELEASE_ARCHIVE: archivePath,
+      INSTALL_DIR: installDir,
+      CI: "1",
+      PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("Installing GaleHarnessCLI from local archive")
+    expect(result.stderr).not.toContain("curl should not run")
+
+    for (const fileName of getReleaseBinaryFileNames(platform)) {
+      const filePath = path.join(installDir, fileName)
+      const stat = await fs.lstat(filePath)
+      expect(stat.isFile()).toBe(true)
+      expect(stat.isSymbolicLink()).toBe(false)
+    }
+    expect(await fs.readFile(path.join(installDir, "VERSION"), "utf-8")).toBe("9.8.7\n")
+  })
+
+  test("rejects local archives with symlink entries before install", async () => {
+    const platform = detectReleasePlatform()
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-bad-"))
+    const archivePath = path.join(dir, `galeharness-cli-9.8.7-${platform}.tar.gz`)
+    await fs.writeFile(
+      archivePath,
+      createTarGz([
+        { name: getReleaseBinaryFileNames(platform)[0], type: "symlink", linkName: "/tmp/bad" },
+        ...getReleaseBinaryFileNames(platform)
+          .slice(1)
+          .map((name) => ({ name, content: `#!/usr/bin/env sh\necho ${name}\n` })),
+        { name: "VERSION", content: "9.8.7\n" },
+      ]),
+    )
+
+    const installDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-release-bin-"))
+    const result = await runInstaller({
+      GALE_RELEASE_ARCHIVE: archivePath,
+      INSTALL_DIR: installDir,
+      CI: "1",
+    })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain("non-regular")
+  })
+})

--- a/tests/readme-install.test.ts
+++ b/tests/readme-install.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "node:fs"
+import path from "node:path"
+
+const readmePath = path.resolve(import.meta.dir, "..", "README.md")
+
+describe("README install guidance", () => {
+  test("keeps release binary installer in the first screen", async () => {
+    const readme = await fs.readFile(readmePath, "utf-8")
+    const firstScreen = readme.slice(0, readme.indexOf("## 目录"))
+
+    expect(firstScreen).toContain("## 快速安装 / 新手一键安装")
+    expect(firstScreen).toContain(
+      "curl -fsSL https://raw.githubusercontent.com/wangrenzhu-ola/GaleHarnessCodingCLI/main/scripts/install-release.sh | bash",
+    )
+    expect(firstScreen).toContain("gale-harness --version")
+  })
+
+  test("states the Windows release installer boundary before source-mode setup", async () => {
+    const readme = await fs.readFile(readmePath, "utf-8")
+    const firstScreen = readme.slice(0, readme.indexOf("## 目录"))
+
+    expect(firstScreen).toContain("Windows release binary installer 尚未进入 P0a 范围")
+    expect(firstScreen).toContain("不要把 source-mode")
+    expect(firstScreen).toContain("普通用户默认一键安装")
+    expect(firstScreen).not.toContain(".\\scripts\\setup.ps1")
+    expect(firstScreen).not.toContain("bootstrap.ps1 | iex")
+  })
+})

--- a/tests/release-archive.test.ts
+++ b/tests/release-archive.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { verifyReleaseArchive } from "../scripts/release/verify-archive"
+import { getReleaseBinaryFileNames } from "../src/utils/release-platforms"
+import { createTarGz, type TarFixtureEntry } from "./tar-fixtures"
+
+async function writeArchive(name: string, entries: TarFixtureEntry[]): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "release-archive-test-"))
+  const archivePath = path.join(dir, name)
+  await fs.writeFile(archivePath, createTarGz(entries))
+  return archivePath
+}
+
+function validEntries(platform: string, version = "9.8.7"): TarFixtureEntry[] {
+  return [
+    ...getReleaseBinaryFileNames(platform).map((name) => ({
+      name,
+      content: `#!/bin/sh\necho ${name}\n`,
+    })),
+    { name: "VERSION", content: `${version}\n` },
+  ]
+}
+
+describe("release archive verifier", () => {
+  test("accepts a linux archive with all four CLI binaries and VERSION", async () => {
+    const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", validEntries("linux-x64"))
+
+    expect(() => verifyReleaseArchive(archive)).not.toThrow()
+  })
+
+  test("accepts Windows .exe binary names", async () => {
+    const archive = await writeArchive("galeharness-cli-9.8.7-windows-x64.tar.gz", validEntries("windows-x64"))
+
+    expect(() => verifyReleaseArchive(archive)).not.toThrow()
+  })
+
+  test("rejects missing expected binaries", async () => {
+    const entries = validEntries("linux-x64").filter((entry) => entry.name !== "gale-memory")
+    const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", entries)
+
+    expect(() => verifyReleaseArchive(archive)).toThrow(/exactly|missing/)
+  })
+
+  test("rejects unknown top-level files", async () => {
+    const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", [
+      ...validEntries("linux-x64"),
+      { name: "README.md", content: "extra\n" },
+    ])
+
+    expect(() => verifyReleaseArchive(archive)).toThrow(/exactly|unexpected/)
+  })
+
+  test("rejects unsafe paths and non-regular entries", async () => {
+    for (const entry of [
+      { name: "../gale-harness", content: "bad\n" },
+      { name: "/gale-harness", content: "bad\n" },
+      { name: "nested/gale-harness", content: "bad\n" },
+      { name: "gale-harness", type: "symlink" as const, linkName: "/tmp/gale-harness" },
+      { name: "gale-harness", type: "hardlink" as const, linkName: "compound-plugin" },
+      { name: "gale-harness", type: "character-device" as const },
+    ]) {
+      const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", [
+        entry,
+        ...validEntries("linux-x64").filter((candidate) => candidate.name !== "gale-harness"),
+      ])
+
+      expect(() => verifyReleaseArchive(archive)).toThrow()
+    }
+  })
+
+  test("rejects duplicate entries", async () => {
+    const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", [
+      ...validEntries("linux-x64"),
+      { name: "VERSION", content: "9.8.7\n" },
+    ])
+
+    expect(() => verifyReleaseArchive(archive)).toThrow(/duplicate|exactly/)
+  })
+
+  test("rejects VERSION content that does not match archive version", async () => {
+    const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", validEntries("linux-x64", "1.2.3"))
+
+    expect(() => verifyReleaseArchive(archive)).toThrow(/VERSION/)
+  })
+})

--- a/tests/tar-fixtures.ts
+++ b/tests/tar-fixtures.ts
@@ -1,0 +1,67 @@
+import { gzipSync } from "node:zlib"
+
+export interface TarFixtureEntry {
+  name: string
+  content?: string
+  type?: "file" | "symlink" | "hardlink" | "directory" | "character-device"
+  linkName?: string
+}
+
+function writeString(buffer: Buffer, offset: number, length: number, value: string): void {
+  buffer.write(value.slice(0, length), offset, length, "utf-8")
+}
+
+function writeOctal(buffer: Buffer, offset: number, length: number, value: number): void {
+  const encoded = value.toString(8).padStart(length - 1, "0")
+  writeString(buffer, offset, length, `${encoded}\0`)
+}
+
+function padToBlock(buffer: Buffer): Buffer {
+  const remainder = buffer.length % 512
+  if (remainder === 0) return buffer
+  return Buffer.concat([buffer, Buffer.alloc(512 - remainder)])
+}
+
+function tarHeader(entry: TarFixtureEntry, size: number): Buffer {
+  const header = Buffer.alloc(512)
+  const typeflag =
+    entry.type === "symlink"
+      ? "2"
+      : entry.type === "hardlink"
+        ? "1"
+        : entry.type === "directory"
+          ? "5"
+          : entry.type === "character-device"
+            ? "3"
+            : "0"
+
+  writeString(header, 0, 100, entry.name)
+  writeOctal(header, 100, 8, entry.type === "directory" ? 0o755 : 0o644)
+  writeOctal(header, 108, 8, 0)
+  writeOctal(header, 116, 8, 0)
+  writeOctal(header, 124, 12, typeflag === "0" ? size : 0)
+  writeOctal(header, 136, 12, 0)
+  header.fill(0x20, 148, 156)
+  writeString(header, 156, 1, typeflag)
+  if (entry.linkName) writeString(header, 157, 100, entry.linkName)
+  writeString(header, 257, 6, "ustar")
+  writeString(header, 263, 2, "00")
+
+  let checksum = 0
+  for (const byte of header) checksum += byte
+  writeString(header, 148, 8, checksum.toString(8).padStart(6, "0") + "\0 ")
+  return header
+}
+
+export function createTarGz(entries: TarFixtureEntry[]): Buffer {
+  const blocks: Buffer[] = []
+  for (const entry of entries) {
+    const content = Buffer.from(entry.content ?? "", "utf-8")
+    blocks.push(tarHeader(entry, content.length))
+    if ((entry.type ?? "file") === "file") {
+      blocks.push(padToBlock(content))
+    }
+  }
+  blocks.push(Buffer.alloc(1024))
+  return gzipSync(Buffer.concat(blocks))
+}


### PR DESCRIPTION
## 背景

公司内部新同学反复询问 GaleHarnessCLI 如何安装，README 第一屏缺少可复制的一键安装入口；同时 PR CI 还没有验证当前代码能否打包成 release archive、通过安装脚本安装、并让 release binary 基础启动。

本 PR 先落地 P0a：把“安装是否可用”从文档提示推进到可执行门禁，同时保持范围克制，不混入 Windows installer、release trust gating 或跨 OS runtime smoke。

## 改动摘要

- README 第一屏新增 macOS/Linux release binary 一键安装命令和 `gale-harness --version` 自检。
- Windows 在第一屏诚实标注 release binary installer 尚未进入本轮，不把 `setup.ps1` / source-mode 当作普通用户默认安装路径。
- 新增 `scripts/release/verify-archive.ts`：复用 `src/utils/release-platforms.ts` 校验 release archive 结构。
- `scripts/install-release.sh` 新增 CI-gated 本地 archive 模式：`GALE_RELEASE_ARCHIVE=...`，仅允许 `CI=1` 或 `GALE_INSTALL_ALLOW_LOCAL_ARCHIVE=1`。
- Ubuntu PR CI 增加 release archive build -> verifier -> 本地 installer -> 四个 binary smoke。
- 补充 release archive、installer、本地 README 安装入口防漂移测试。
- 调整 release build stdout，避免 `bun build` 进度污染 CI 捕获的 archive path。

## 验证

- `bun test tests/release-archive.test.ts tests/install-release-sh.test.ts tests/readme-install.test.ts`：12 pass
- `bun run release:validate`：pass
- `bun test`：1263 pass / 3 skip / 0 fail
- `git diff --check`：pass
- `bun run scripts/release/build.ts --platform linux-x64`：生成成功
- `bun run scripts/release/verify-archive.ts galeharness-cli-2.5.0-linux-x64.tar.gz`：pass

## 范围边界

本 PR 不做：

- `gale-harness update` source-mode 文案调整；
- release-assets workflow 上传前接入；
- release trust gating；
- Windows release installer；
- macOS/Windows runtime smoke。

这些已在计划文档里拆为后续 P0b/P1/P2。