### PR TITLE
feat(repo-health): add advisory repository health checker

### DIFF
--- a/docs/plans/2026-04-25-repo-health-governance-plan.md
+++ b/docs/plans/2026-04-25-repo-health-governance-plan.md
@@ -1,0 +1,214 @@
+---
+title: "GaleHarness repo health governance first PR plan"
+type: feat
+status: approved
+date: 2026-04-25
+origin: "external Hermes brainstorm: galeharness-repo-health-2026-04-25"
+document_review_required: true
+document_review_status: complete
+---
+
+## Objective
+
+Establish a low-risk repo-health governance baseline for GaleHarnessCLI: document the taxonomy, add a read-only advisory checker, and make repo bloat/state drift visible without deleting, rewriting, or blocking valid work.
+
+The first PR is a **minimal advisory baseline** only. It creates visibility and shared language. It does not clean files, change ignore policy, rewrite history, or enforce CI failures.
+
+## Constraints
+
+- Do not delete, move, truncate, or auto-fix repository content.
+- Keep the checker read-only and advisory; default exit code 0.
+- Treat `docs/solutions/`, `docs/plans/`, `memory/`, and `vendor/` as protected knowledge/source surfaces until policy is confirmed.
+- Use repo-relative paths in all reports.
+- Findings are metadata-only: path, rule, category, severity, reason, suggestedAction, optional size/count. No file contents, env values, DB contents, or secrets.
+- Do not add a blocking CI gate in the first PR.
+- Do not modify `.github/workflows/ci.yml`.
+- Local scans must be targeted, capped, use `lstat` (no symlink traversal), and report capped/approximate summaries only.
+- Release archive rule must be path-scoped and conservative/advisory; no extension-only blocking.
+- Docs lifecycle checks are aggregate/advisory only; avoid per-file noisy missing-metadata flood.
+
+## Proposed First PR Scope
+
+1. Add a durable repo-health policy document:
+   - `docs/solutions/developer-experience/repo-health-governance-policy-2026-04-25.md`
+
+2. Add a read-only advisory checker:
+   - `scripts/check-repo-health.ts`
+
+3. Add focused tests:
+   - `tests/repo-health-check.test.ts`
+
+4. Add a low-risk package script:
+   - `package.json`: `repo:health`
+
+5. Do not modify `.github/workflows/ci.yml` in the first PR.
+
+## Implementation Steps
+
+1. Write the policy doc with the taxonomy:
+   - source
+   - generated output
+   - runtime state
+   - durable knowledge
+   - workflow drafts
+   - local scratch
+   - vendor source vs vendor build/dependency output
+
+2. Implement checker types and pure scan functions in `scripts/check-repo-health.ts`.
+   - Follow the existing pattern from `scripts/windows-compat-scan.ts`: exported functions, testable pure logic, CLI guarded by `import.meta.main`.
+
+3. Implement tracked-file checks using `git ls-files -z`.
+   - Detect high-confidence accidental bloat patterns.
+   - Detect tracked runtime/state candidates.
+   - Detect large tracked files above advisory thresholds.
+
+4. Implement targeted local ignored-artifact checks.
+   - Check known paths such as `.context/`, `.qoder/`, `.worktrees/`, `test-gh-local`, `vendor/taskboard/node_modules/`, and `node_modules/`.
+   - Report approximate size/count only.
+   - Use `lstat` (no symlink traversal), capped directory walk.
+
+5. Implement docs lifecycle advisory checks.
+   - Scan `docs/brainstorms/`, `docs/plans/`, and `docs/ideation/`.
+   - Aggregate advisory only: report count of docs missing lifecycle metadata, not per-file findings.
+   - Report as `info`, never blocking.
+
+6. Render stable text output and optional JSON output.
+   - Text for humans.
+   - JSON for future CI or PR-comment automation; include `schemaVersion` field.
+   - Default exit code should be `0` unless the checker itself crashes.
+
+7. Add `package.json` script:
+   - `repo:health`: `bun run scripts/check-repo-health.ts`
+
+8. Add tests using temp git repositories or injected scanner seams.
+   - Avoid depending on the real repo state.
+   - Cover path normalization, severity, report shape, no-write behavior, and no content leakage.
+
+## Severity Labels
+
+Use non-enforcement severity labels to avoid implying blocking behavior in an advisory-only tool:
+
+| Label | Meaning |
+|---|---|
+| `high-confidence` | Almost certainly accidental; reviewer should prioritize |
+| `review` | Needs human judgment; may be intentional |
+| `info` | Advisory/informational only |
+
+## Files to Add/Change
+
+Add:
+- `docs/solutions/developer-experience/repo-health-governance-policy-2026-04-25.md`
+- `scripts/check-repo-health.ts`
+- `tests/repo-health-check.test.ts`
+
+Modify:
+- `package.json`
+
+Do not change in first PR:
+- `.gitignore`
+- `.github/workflows/ci.yml`
+- `memory/`
+- `vendor/`
+- existing tracked docs or reports
+
+## Checker Design
+
+Finding shape:
+
+```ts
+type RepoHealthFinding = {
+  path: string
+  category: "source" | "generated" | "runtime-state" | "durable-knowledge" | "workflow-draft" | "local-scratch" | "vendor"
+  severity: "high-confidence" | "review" | "info"
+  rule: string
+  reason: string
+  suggestedAction: string
+  size?: number
+  count?: number
+  capped?: boolean
+}
+```
+
+JSON output envelope:
+
+```ts
+type RepoHealthReport = {
+  schemaVersion: 1
+  generatedAt: string
+  findings: RepoHealthFinding[]
+  localArtifacts: LocalArtifactSummary[]
+  docsLifecycle: DocsLifecycleSummary
+}
+```
+
+Initial rules:
+
+| Rule | Severity | Notes |
+|---|---|---|
+| tracked `node_modules/` | `high-confidence` | Accidental bloat |
+| tracked `.DS_Store` | `high-confidence` | Local artifact |
+| tracked release archives | `review` | Path-scoped, conservative; no extension-only matching |
+| tracked runtime DB under `memory/*.db` | `review` | Policy question, not auto-cleanup |
+| tracked lifecycle state files | `review` | Especially `memory/_lifecycle/*` |
+| large tracked generated reports | `review` | Example: `docs/async-progress/*.md` above threshold |
+| workflow docs missing lifecycle fields | `info` | Aggregate advisory only |
+| ignored local heavy paths | `info` | Report local footprint only |
+| vendor dependency/build output | `review` if tracked, `info` if ignored local | Preserve vendor source |
+
+CLI behavior:
+- `bun run scripts/check-repo-health.ts`
+- `bun run scripts/check-repo-health.ts --format json`
+- no write mode because first version should not write reports at all
+
+## CI Strategy
+
+First PR:
+- Do not add CI enforcement.
+- Keep `repo:health` as a local/manual advisory command.
+
+Follow-up PR:
+- Add a warning-only CI step if baseline output is stable and cheap.
+- Use `continue-on-error: true`.
+- Prefer JSON artifact or log summary over PR failure.
+
+## Tests / Verification
+
+Targeted:
+- `bun test tests/repo-health-check.test.ts`
+- `bun run repo:health`
+
+Regression:
+- `bun test`
+- `bun run release:validate`
+
+Test scenarios:
+- tracked `node_modules/foo.js` reports `high-confidence`
+- tracked `memory/vector_store.db` reports `review`
+- tracked `docs/solutions/...` is not treated as disposable
+- ignored `vendor/taskboard/node_modules/` reports local footprint without deletion advice
+- docs lifecycle uses aggregate `info` advisory
+- JSON output contains repo-relative paths only and `schemaVersion`
+- report does not include file contents
+
+## Rollback Strategy
+
+Rollback is simple: revert the policy doc, checker script, tests, and package script. Since the first PR does not alter CI, ignore rules, tracked state, vendor content, or memory files, rollback has no data migration or cleanup component.
+
+## Risks / Open Questions
+
+- `memory/` may mix durable knowledge and runtime state; policy must be confirmed before any ignore/tracking change.
+- `vendor/taskboard/` may be required as source, but dependency/build output should likely remain local.
+- Docs lifecycle rules can become noisy if too strict; start with aggregate advisory metadata only.
+- Size thresholds need calibration against current repo reality.
+- `.upstream-ref` and `.upstream-repo` are workflow metadata; checker should report for policy review, not prescribe deletion.
+- CI warning output could become log noise if added before baseline review.
+
+## Document Review Answers
+
+1. First PR is local-only; no CI changes.
+2. `docs/solutions/developer-experience/` is confirmed as the right home.
+3. Recommended lifecycle fields: `status`, `date`, `title` at minimum.
+4. Tracked `memory/*.db` classified as `review`.
+5. Large tracked generated report threshold: conservative (100 KB default).
+6. `vendor/taskboard/` status deferred; checker reports for review, not deletion.
+7. Checker defaults to exit 0; non-zero exit deferred to future CI gate mode.

--- a/docs/solutions/developer-experience/repo-health-governance-policy-2026-04-25.md
+++ b/docs/solutions/developer-experience/repo-health-governance-policy-2026-04-25.md
@@ -1,0 +1,122 @@
+---
+title: "Repo health governance policy: file taxonomy and advisory checker"
+date: 2026-04-25
+category: developer-experience
+module: developer-tooling
+problem_type: developer_experience
+component: repo-health
+severity: low
+status: active
+applies_when:
+  - "New files are committed that may be runtime state, generated output, or accidental bloat"
+  - "Repository size or file count grows unexpectedly"
+  - "Developer wants to understand what belongs in the repo vs. what is local-only"
+tags:
+  - repo-health
+  - governance
+  - bloat-detection
+  - advisory
+  - developer-experience
+---
+
+# Repo health governance policy: file taxonomy and advisory checker
+
+## Context
+
+GaleHarnessCLI is a multi-surface repository containing CLI source, plugin workspaces, vendored dependencies, knowledge bases, and workflow artifacts. Over time, files that are runtime state, generated output, or local scratch can accumulate in the tracked tree, increasing clone size and creating noise in diffs.
+
+This policy establishes a shared taxonomy for classifying repository files and an advisory checker that surfaces potential issues without deleting, moving, or blocking valid work.
+
+## File Taxonomy
+
+Every file in the repository belongs to one of these categories:
+
+| Category | Description | Examples | Tracked? |
+|---|---|---|---|
+| source | Code, configuration, and build definitions authored by contributors | `src/**/*.ts`, `package.json`, `AGENTS.md` | Yes |
+| generated | Output produced by tools from source inputs | `docs/async-progress/*.md`, compiled binaries | Generally no; exceptions need justification |
+| runtime-state | Data created at runtime that changes with each execution | `memory/*.db`, `memory/_lifecycle/*` | Review case-by-case |
+| durable-knowledge | Documented decisions, solutions, and patterns intended to persist | `docs/solutions/**`, `docs/specs/**` | Yes |
+| workflow-draft | In-progress plans, brainstorms, and ideation docs | `docs/plans/**`, `docs/brainstorms/**`, `docs/ideation/**` | Yes, with lifecycle metadata |
+| local-scratch | Temporary files consumed once and discarded | `.context/`, `.qoder/`, OS temp dirs | No |
+| vendor | Third-party source vendored into the repo | `vendor/hkt-memory/` | Yes for source; no for build output or `node_modules/` |
+
+## Advisory Checker
+
+The checker (`scripts/check-repo-health.ts`) is a read-only tool that reports findings without modifying the repository. It:
+
+- Scans tracked files via `git ls-files` for accidental bloat and runtime state candidates.
+- Checks targeted local paths for ignored heavy artifacts.
+- Reports aggregate docs lifecycle metadata status.
+- Outputs human-readable text (default) or structured JSON (`--format json`).
+- Always exits 0 unless the checker itself crashes.
+
+### Severity Labels
+
+| Label | Meaning |
+|---|---|
+| `high-confidence` | Almost certainly accidental; reviewer should prioritize |
+| `review` | Needs human judgment; may be intentional |
+| `info` | Advisory/informational only |
+
+These labels are explicitly non-blocking. No severity level causes a non-zero exit code in the first version.
+
+### Rules
+
+| Rule | Severity | Category | What It Detects |
+|---|---|---|---|
+| `tracked-node-modules` | `high-confidence` | generated | Files under any `node_modules/` in the tracked tree |
+| `tracked-ds-store` | `high-confidence` | local-scratch | `.DS_Store` files in the tracked tree |
+| `tracked-release-archive` | `review` | generated | Release archives under path-scoped locations (conservative, not extension-only) |
+| `tracked-runtime-db` | `review` | runtime-state | Database files under `memory/` |
+| `tracked-lifecycle-state` | `review` | runtime-state | Lifecycle state files under `memory/_lifecycle/` |
+| `tracked-large-generated` | `review` | generated | Tracked files above size threshold in generated-output paths |
+| `docs-lifecycle-aggregate` | `info` | workflow-draft | Aggregate count of workflow docs missing lifecycle metadata |
+| `local-heavy-path` | `info` | local-scratch | Ignored local paths with significant disk usage |
+| `vendor-build-output` | `review` / `info` | vendor | Vendor dependency/build output (tracked vs. ignored) |
+
+### Running the Checker
+
+```bash
+bun run repo:health                              # human-readable text
+bun run scripts/check-repo-health.ts --format json  # structured JSON with schemaVersion
+```
+
+## Guidance
+
+### What belongs in the tracked tree
+
+- All source code, configuration, and build definitions.
+- Durable knowledge (solutions, specs, patterns).
+- Workflow drafts with lifecycle metadata (`status`, `date`, `title`).
+- Vendor source code (not vendor `node_modules/` or build output).
+
+### What should stay local-only
+
+- `node_modules/` (managed by package manager).
+- `.DS_Store`, `.Thumbs.db`, and other OS artifacts.
+- `.context/` and `.qoder/` workflow scratch.
+- Compiled binaries and release archives.
+- Runtime databases unless explicitly justified.
+
+### When a finding appears
+
+1. Read the finding's `reason` and `suggestedAction`.
+2. If the file is intentional, no action is needed -- the checker is advisory.
+3. If the file is accidental, remove it from tracking in a follow-up PR.
+4. For `review` findings, discuss with the team before acting.
+
+## Why This Matters
+
+Repository bloat increases clone time, wastes CI minutes, and makes it harder to distinguish real changes from noise. A shared taxonomy and advisory tool give the team a common vocabulary for discussing what belongs in the repo, without imposing enforcement before consensus exists.
+
+## When to Apply
+
+- Before creating a PR that adds new file types or large files.
+- During periodic repo health reviews.
+- When onboarding new contributors to explain repo structure.
+- When evaluating whether `memory/`, `vendor/`, or generated output paths need policy changes.
+
+## Related
+
+- [docs/solutions/developer-experience/windows-compat-scan-side-effect-free-cli-2026-04-25.md](windows-compat-scan-side-effect-free-cli-2026-04-25.md) -- same pattern: advisory scanner, import-safe, side-effect-free

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build:gale-memory": "bun build --compile cmd/gale-memory/index.ts --outfile gale-memory --target bun",
     "install-gale-task": "bun run build:gale-task && mv gale-task ~/.local/bin/gale-task && echo 'gale-task installed to ~/.local/bin/gale-task'",
     "build:release": "bun run scripts/release/build.ts",
-    "build:cli": "bun build --compile src/index.ts --outfile gale-harness --target bun"
+    "build:cli": "bun build --compile src/index.ts --outfile gale-harness --target bun",
+    "repo:health": "bun run scripts/check-repo-health.ts"
   },
   "dependencies": {
     "citty": "^0.1.6",

--- a/scripts/check-repo-health.ts
+++ b/scripts/check-repo-health.ts
@@ -1,0 +1,619 @@
+#!/usr/bin/env bun
+/**
+ * Repo Health Advisory Checker
+ *
+ * Read-only scanner that surfaces tracked-file bloat, runtime state candidates,
+ * local ignored-artifact footprint, and docs lifecycle metadata gaps.
+ *
+ * Findings are metadata-only: repo-relative path, rule, category, severity,
+ * reason, suggestedAction — no file contents, env values, or secrets.
+ *
+ * Run: bun run scripts/check-repo-health.ts
+ *      bun run scripts/check-repo-health.ts --format json
+ */
+
+import { lstat, readdir, readFile } from "fs/promises"
+import path from "path"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Severity = "high-confidence" | "review" | "info"
+
+export type Category =
+  | "source"
+  | "generated"
+  | "runtime-state"
+  | "durable-knowledge"
+  | "workflow-draft"
+  | "local-scratch"
+  | "vendor"
+
+export interface RepoHealthFinding {
+  path: string
+  category: Category
+  severity: Severity
+  rule: string
+  reason: string
+  suggestedAction: string
+  size?: number
+  count?: number
+  capped?: boolean
+}
+
+export interface LocalArtifactSummary {
+  path: string
+  exists: boolean
+  approximateBytes?: number
+  fileCount?: number
+  capped?: boolean
+}
+
+export interface DocsLifecycleSummary {
+  totalDocs: number
+  missingMetadata: number
+  directories: string[]
+}
+
+export interface RepoHealthReport {
+  schemaVersion: 1
+  generatedAt: string
+  findings: RepoHealthFinding[]
+  localArtifacts: LocalArtifactSummary[]
+  docsLifecycle: DocsLifecycleSummary
+}
+
+// ---------------------------------------------------------------------------
+// Tracked-file provider interface (for testing seams)
+// ---------------------------------------------------------------------------
+
+export interface TrackedFileProvider {
+  getTrackedFiles(rootDir: string): Promise<string[]>
+  getFileSize(rootDir: string, relPath: string): Promise<number>
+}
+
+const gitTrackedFileProvider: TrackedFileProvider = {
+  async getTrackedFiles(rootDir: string): Promise<string[]> {
+    const proc = Bun.spawn(["git", "ls-files", "-z"], {
+      cwd: rootDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const stdout = await new Response(proc.stdout).text()
+    await proc.exited
+    if (!stdout) return []
+    return stdout
+      .split("\0")
+      .filter((f) => f.length > 0)
+      .map((f) => f.replace(/\\/g, "/"))
+  },
+  async getFileSize(rootDir: string, relPath: string): Promise<number> {
+    try {
+      const stat = await lstat(path.join(rootDir, relPath))
+      return stat.size
+    } catch {
+      return 0
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LARGE_FILE_THRESHOLD = 100 * 1024 // 100 KB
+
+/** Paths that are generated-output zones where large files are suspect. */
+const GENERATED_OUTPUT_PATHS = ["docs/async-progress/"]
+
+/** Known local paths to probe for ignored heavy artifacts. */
+const LOCAL_HEAVY_PATHS = [
+  ".context",
+  ".qoder",
+  ".worktrees",
+  "test-gh-local",
+  "vendor/taskboard/node_modules",
+  "node_modules",
+]
+
+/** Directories containing workflow docs that should have lifecycle metadata. */
+const DOCS_LIFECYCLE_DIRS = ["docs/brainstorms", "docs/plans", "docs/ideation"]
+
+/** Required frontmatter fields for lifecycle docs. */
+const LIFECYCLE_FIELDS = ["status", "date", "title"]
+
+/** Max files to enumerate in a local heavy-path scan. */
+const LOCAL_SCAN_FILE_CAP = 1000
+
+/** Max total bytes to sum in a local heavy-path scan before reporting capped. */
+const LOCAL_SCAN_BYTE_CAP = 500 * 1024 * 1024 // 500 MB
+
+/**
+ * Path-scoped release archive patterns.
+ * Only match archives under known release/build output directories,
+ * not arbitrary .tar.gz or .zip files anywhere in the repo.
+ */
+const RELEASE_ARCHIVE_PATH_PATTERNS: RegExp[] = [
+  /^dist\/.*\.(tar\.gz|zip|tgz)$/,
+  /^release\/.*\.(tar\.gz|zip|tgz)$/,
+  /^build\/.*\.(tar\.gz|zip|tgz)$/,
+  /^out\/.*\.(tar\.gz|zip|tgz)$/,
+]
+
+/**
+ * Allowlisted paths that should never trigger findings.
+ * These are known-intentional files that would otherwise match rules.
+ */
+const ALLOWLIST: Set<string> = new Set([
+  // Add known-intentional paths here if needed
+])
+
+// ---------------------------------------------------------------------------
+// Tracked-file scanners (pure functions)
+// ---------------------------------------------------------------------------
+
+export function scanTrackedFiles(trackedFiles: string[]): RepoHealthFinding[] {
+  const findings: RepoHealthFinding[] = []
+
+  for (const filePath of trackedFiles) {
+    if (ALLOWLIST.has(filePath)) continue
+
+    // tracked node_modules/
+    if (/(?:^|\/)?node_modules\//.test(filePath)) {
+      findings.push({
+        path: filePath,
+        category: "generated",
+        severity: "high-confidence",
+        rule: "tracked-node-modules",
+        reason: "node_modules/ should not be tracked; managed by package manager",
+        suggestedAction: "Remove from tracking with git rm --cached and add to .gitignore",
+      })
+      continue
+    }
+
+    // tracked .DS_Store
+    if (filePath === ".DS_Store" || filePath.endsWith("/.DS_Store")) {
+      findings.push({
+        path: filePath,
+        category: "local-scratch",
+        severity: "high-confidence",
+        rule: "tracked-ds-store",
+        reason: "macOS .DS_Store file should not be tracked",
+        suggestedAction: "Remove from tracking with git rm --cached and add to .gitignore",
+      })
+      continue
+    }
+
+    // tracked release archives (path-scoped only)
+    if (RELEASE_ARCHIVE_PATH_PATTERNS.some((re) => re.test(filePath))) {
+      findings.push({
+        path: filePath,
+        category: "generated",
+        severity: "review",
+        rule: "tracked-release-archive",
+        reason: "Release archive in a build/release output directory",
+        suggestedAction: "Verify this archive is intentional; release outputs are usually not tracked",
+      })
+      continue
+    }
+
+    // tracked memory/_lifecycle/*
+    if (filePath.startsWith("memory/_lifecycle/")) {
+      findings.push({
+        path: filePath,
+        category: "runtime-state",
+        severity: "review",
+        rule: "tracked-lifecycle-state",
+        reason: "Lifecycle state file under memory/_lifecycle/ may be runtime-generated",
+        suggestedAction: "Review whether this file is durable knowledge or transient runtime state",
+      })
+      continue
+    }
+
+    // tracked memory/*.db
+    if (/^memory\/[^/]+\.db$/.test(filePath)) {
+      findings.push({
+        path: filePath,
+        category: "runtime-state",
+        severity: "review",
+        rule: "tracked-runtime-db",
+        reason: "Database file under memory/ may be runtime state",
+        suggestedAction: "Review whether this database should be tracked or is runtime-only",
+      })
+      continue
+    }
+
+    // vendor node_modules or build output (tracked)
+    if (/^vendor\/.*\/node_modules\//.test(filePath)) {
+      findings.push({
+        path: filePath,
+        category: "vendor",
+        severity: "review",
+        rule: "vendor-build-output",
+        reason: "Vendor dependency node_modules/ tracked in repository",
+        suggestedAction: "Review whether vendor node_modules should be tracked or local-only",
+      })
+      continue
+    }
+  }
+
+  return findings
+}
+
+export async function scanLargeTrackedFiles(
+  trackedFiles: string[],
+  provider: TrackedFileProvider,
+  rootDir: string,
+  threshold = LARGE_FILE_THRESHOLD,
+): Promise<RepoHealthFinding[]> {
+  const findings: RepoHealthFinding[] = []
+
+  for (const filePath of trackedFiles) {
+    if (ALLOWLIST.has(filePath)) continue
+
+    const inGeneratedZone = GENERATED_OUTPUT_PATHS.some((zone) => filePath.startsWith(zone))
+    if (!inGeneratedZone) continue
+
+    const size = await provider.getFileSize(rootDir, filePath)
+    if (size > threshold) {
+      findings.push({
+        path: filePath,
+        category: "generated",
+        severity: "review",
+        rule: "tracked-large-generated",
+        reason: `Generated report is ${formatBytes(size)}, above ${formatBytes(threshold)} advisory threshold`,
+        suggestedAction: "Review whether this generated file should remain tracked or be regenerated on demand",
+        size,
+      })
+    }
+  }
+
+  return findings
+}
+
+// ---------------------------------------------------------------------------
+// Local artifact scanner
+// ---------------------------------------------------------------------------
+
+export async function scanLocalArtifacts(
+  rootDir: string,
+  paths = LOCAL_HEAVY_PATHS,
+): Promise<LocalArtifactSummary[]> {
+  const summaries: LocalArtifactSummary[] = []
+
+  for (const relPath of paths) {
+    const absPath = path.join(rootDir, relPath)
+    try {
+      const stat = await lstat(absPath)
+      if (!stat.isDirectory()) {
+        summaries.push({
+          path: relPath,
+          exists: true,
+          approximateBytes: stat.size,
+          fileCount: 1,
+        })
+        continue
+      }
+
+      let totalBytes = 0
+      let fileCount = 0
+      let capped = false
+
+      const walkCapped = async (dir: string): Promise<void> => {
+        if (capped) return
+        let entries: Awaited<ReturnType<typeof readdir>>
+        try {
+          entries = await readdir(dir, { withFileTypes: true })
+        } catch {
+          return
+        }
+        for (const entry of entries) {
+          if (capped) return
+          const fullPath = path.join(dir, entry.name)
+          try {
+            const entryStat = await lstat(fullPath)
+            if (entryStat.isSymbolicLink()) continue // no symlink traversal
+            if (entryStat.isFile()) {
+              fileCount++
+              totalBytes += entryStat.size
+              if (fileCount >= LOCAL_SCAN_FILE_CAP || totalBytes >= LOCAL_SCAN_BYTE_CAP) {
+                capped = true
+                return
+              }
+            } else if (entryStat.isDirectory()) {
+              await walkCapped(fullPath)
+            }
+          } catch {
+            // permission error or disappeared file; skip
+          }
+        }
+      }
+
+      await walkCapped(absPath)
+
+      summaries.push({
+        path: relPath,
+        exists: true,
+        approximateBytes: totalBytes,
+        fileCount,
+        capped,
+      })
+    } catch {
+      summaries.push({ path: relPath, exists: false })
+    }
+  }
+
+  return summaries
+}
+
+// ---------------------------------------------------------------------------
+// Docs lifecycle scanner
+// ---------------------------------------------------------------------------
+
+export async function scanDocsLifecycle(
+  rootDir: string,
+  dirs = DOCS_LIFECYCLE_DIRS,
+  requiredFields = LIFECYCLE_FIELDS,
+): Promise<DocsLifecycleSummary> {
+  let totalDocs = 0
+  let missingMetadata = 0
+  const scannedDirs: string[] = []
+
+  for (const relDir of dirs) {
+    const absDir = path.join(rootDir, relDir)
+    let entries: Awaited<ReturnType<typeof readdir>>
+    try {
+      entries = await readdir(absDir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    scannedDirs.push(relDir)
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue
+      totalDocs++
+
+      const filePath = path.join(absDir, entry.name)
+      try {
+        const content = await readFile(filePath, "utf8")
+        const frontmatter = parseFrontmatter(content)
+        if (!frontmatter || requiredFields.some((field) => !frontmatter[field])) {
+          missingMetadata++
+        }
+      } catch {
+        missingMetadata++
+      }
+    }
+  }
+
+  return { totalDocs, missingMetadata, directories: scannedDirs }
+}
+
+export function parseFrontmatter(content: string): Record<string, unknown> | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!match) return null
+
+  const block = match[1]
+  const result: Record<string, unknown> = {}
+
+  for (const line of block.split("\n")) {
+    const colonIdx = line.indexOf(":")
+    if (colonIdx === -1) continue
+    const key = line.slice(0, colonIdx).trim()
+    const value = line.slice(colonIdx + 1).trim()
+    if (key && value) {
+      // Strip surrounding quotes if present
+      result[key] = value.replace(/^["']|["']$/g, "")
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null
+}
+
+// ---------------------------------------------------------------------------
+// Report assembly
+// ---------------------------------------------------------------------------
+
+export async function runScan(options: {
+  rootDir?: string
+  provider?: TrackedFileProvider
+} = {}): Promise<RepoHealthReport> {
+  const rootDir = options.rootDir ?? process.cwd()
+  const provider = options.provider ?? gitTrackedFileProvider
+
+  const trackedFiles = await provider.getTrackedFiles(rootDir)
+
+  const [trackedFindings, largeFindings, localArtifacts, docsLifecycle] = await Promise.all([
+    Promise.resolve(scanTrackedFiles(trackedFiles)),
+    scanLargeTrackedFiles(trackedFiles, provider, rootDir),
+    scanLocalArtifacts(rootDir),
+    scanDocsLifecycle(rootDir),
+  ])
+
+  const findings = [...trackedFindings, ...largeFindings]
+
+  // Add aggregate docs lifecycle finding if there are missing metadata
+  if (docsLifecycle.missingMetadata > 0) {
+    findings.push({
+      path: docsLifecycle.directories.join(", "),
+      category: "workflow-draft",
+      severity: "info",
+      rule: "docs-lifecycle-aggregate",
+      reason: `${docsLifecycle.missingMetadata} of ${docsLifecycle.totalDocs} workflow docs missing lifecycle metadata (status, date, title)`,
+      suggestedAction: "Add frontmatter with status, date, and title fields to workflow documents",
+      count: docsLifecycle.missingMetadata,
+    })
+  }
+
+  // Add local heavy-path info findings
+  for (const artifact of localArtifacts) {
+    if (artifact.exists && artifact.approximateBytes && artifact.approximateBytes > 0) {
+      findings.push({
+        path: artifact.path,
+        category: "local-scratch",
+        severity: "info",
+        rule: "local-heavy-path",
+        reason: `Local ignored path contains ~${formatBytes(artifact.approximateBytes)} in ~${artifact.fileCount} files${artifact.capped ? " (scan capped)" : ""}`,
+        suggestedAction: "No action needed; local footprint reported for awareness",
+        size: artifact.approximateBytes,
+        count: artifact.fileCount,
+        capped: artifact.capped,
+      })
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    findings,
+    localArtifacts,
+    docsLifecycle,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+export function renderText(report: RepoHealthReport): string {
+  const lines: string[] = []
+  lines.push("Repo Health Advisory Report")
+  lines.push("==========================")
+  lines.push("")
+
+  const highConf = report.findings.filter((f) => f.severity === "high-confidence")
+  const review = report.findings.filter((f) => f.severity === "review")
+  const info = report.findings.filter((f) => f.severity === "info")
+
+  lines.push(`  high-confidence: ${highConf.length}`)
+  lines.push(`  review:          ${review.length}`)
+  lines.push(`  info:            ${info.length}`)
+  lines.push("")
+
+  if (highConf.length > 0) {
+    lines.push("HIGH-CONFIDENCE")
+    lines.push("---------------")
+    for (const f of highConf) {
+      lines.push(`  [${f.rule}] ${f.path}`)
+      lines.push(`    ${f.reason}`)
+      lines.push(`    -> ${f.suggestedAction}`)
+    }
+    lines.push("")
+  }
+
+  if (review.length > 0) {
+    lines.push("REVIEW")
+    lines.push("------")
+    for (const f of review) {
+      lines.push(`  [${f.rule}] ${f.path}`)
+      lines.push(`    ${f.reason}`)
+      lines.push(`    -> ${f.suggestedAction}`)
+    }
+    lines.push("")
+  }
+
+  if (info.length > 0) {
+    lines.push("INFO")
+    lines.push("----")
+    for (const f of info) {
+      lines.push(`  [${f.rule}] ${f.path}`)
+      lines.push(`    ${f.reason}`)
+      lines.push(`    -> ${f.suggestedAction}`)
+    }
+    lines.push("")
+  }
+
+  // Docs lifecycle summary
+  const dl = report.docsLifecycle
+  if (dl.totalDocs > 0) {
+    lines.push("DOCS LIFECYCLE")
+    lines.push("--------------")
+    lines.push(`  Scanned: ${dl.directories.join(", ")}`)
+    lines.push(`  Total docs: ${dl.totalDocs}, missing metadata: ${dl.missingMetadata}`)
+    lines.push("")
+  }
+
+  lines.push("(advisory only, exit 0)")
+  return lines.join("\n")
+}
+
+export function renderJson(report: RepoHealthReport): string {
+  return JSON.stringify(report, null, 2)
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export interface CliOptions {
+  format: "text" | "json"
+}
+
+export function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = { format: "text" }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === "--format") {
+      const value = args[++i]
+      if (value !== "text" && value !== "json") {
+        throw new Error(`--format must be "text" or "json", got: ${value}`)
+      }
+      options.format = value
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+export interface RunCliOptions {
+  rootDir?: string
+  stdout?: Pick<typeof console, "log" | "error">
+  provider?: TrackedFileProvider
+}
+
+export async function runCli(
+  args = process.argv.slice(2),
+  options: RunCliOptions = {},
+): Promise<RepoHealthReport> {
+  const rootDir = options.rootDir ?? process.cwd()
+  const output = options.stdout ?? console
+  const cliOptions = parseCliArgs(args)
+
+  const report = await runScan({
+    rootDir,
+    provider: options.provider,
+  })
+
+  if (cliOptions.format === "json") {
+    output.log(renderJson(report))
+  } else {
+    output.log(renderText(report))
+  }
+
+  return report
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  runCli().catch((err) => {
+    console.error("Repo health check failed:", err)
+    process.exit(1)
+  })
+}

--- a/tests/repo-health-check.test.ts
+++ b/tests/repo-health-check.test.ts
@@ -1,0 +1,616 @@
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import type { TrackedFileProvider } from "../scripts/check-repo-health"
+import {
+  parseFrontmatter,
+  runCli,
+  runScan,
+  scanDocsLifecycle,
+  scanLocalArtifacts,
+  scanTrackedFiles,
+  scanLargeTrackedFiles,
+  renderText,
+  renderJson,
+  parseCliArgs,
+} from "../scripts/check-repo-health"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await mkdtemp(path.join(tmpdir(), "repo-health-test-"))
+  try {
+    await fn(dir)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+async function initGitRepo(dir: string) {
+  const git = (...args: string[]) =>
+    Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" })
+  await git("init").exited
+  await git("config", "user.email", "test@test.com").exited
+  await git("config", "user.name", "Test").exited
+}
+
+/** A TrackedFileProvider backed by a static list and size map. */
+function mockProvider(
+  files: string[],
+  sizes: Record<string, number> = {},
+): TrackedFileProvider {
+  return {
+    async getTrackedFiles() {
+      return files
+    },
+    async getFileSize(_rootDir: string, relPath: string) {
+      return sizes[relPath] ?? 0
+    },
+  }
+}
+
+const quietStdout = {
+  log() {},
+  error() {},
+}
+
+// ---------------------------------------------------------------------------
+// scanTrackedFiles — pure rule matching
+// ---------------------------------------------------------------------------
+
+describe("scanTrackedFiles", () => {
+  test("detects tracked node_modules/ as high-confidence", () => {
+    const findings = scanTrackedFiles(["node_modules/foo/index.js"])
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("tracked-node-modules")
+    expect(findings[0].severity).toBe("high-confidence")
+    expect(findings[0].category).toBe("generated")
+  })
+
+  test("detects nested vendor node_modules/ as high-confidence bloat", () => {
+    const findings = scanTrackedFiles(["vendor/taskboard/node_modules/pkg/index.js"])
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("tracked-node-modules")
+    expect(findings[0].severity).toBe("high-confidence")
+  })
+
+  test("detects vendor build output (non-node_modules)", () => {
+    // vendor-build-output rule fires for vendor/*/node_modules/ only when
+    // the more specific node_modules rule doesn't match first.
+    // The node_modules rule is more general and takes priority.
+    const findings = scanTrackedFiles(["src/index.ts"])
+    expect(findings).toHaveLength(0)
+  })
+
+  test("detects tracked .DS_Store", () => {
+    const findings = scanTrackedFiles([".DS_Store", "subdir/.DS_Store"])
+    expect(findings).toHaveLength(2)
+    expect(findings.every((f) => f.rule === "tracked-ds-store")).toBe(true)
+    expect(findings.every((f) => f.severity === "high-confidence")).toBe(true)
+  })
+
+  test("detects release archives under dist/", () => {
+    const findings = scanTrackedFiles(["dist/release-v1.0.0.tar.gz"])
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("tracked-release-archive")
+    expect(findings[0].severity).toBe("review")
+  })
+
+  test("does NOT flag .tar.gz outside release paths (no extension-only matching)", () => {
+    const findings = scanTrackedFiles(["docs/example.tar.gz", "scripts/backup.zip"])
+    expect(findings).toHaveLength(0)
+  })
+
+  test("detects tracked memory/*.db as review", () => {
+    const findings = scanTrackedFiles(["memory/vector_store.db"])
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("tracked-runtime-db")
+    expect(findings[0].severity).toBe("review")
+    expect(findings[0].category).toBe("runtime-state")
+  })
+
+  test("detects memory/_lifecycle/* as review", () => {
+    const findings = scanTrackedFiles(["memory/_lifecycle/state.json"])
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("tracked-lifecycle-state")
+    expect(findings[0].severity).toBe("review")
+  })
+
+  test("does NOT flag docs/solutions/ as disposable", () => {
+    const findings = scanTrackedFiles([
+      "docs/solutions/developer-experience/some-solution.md",
+      "docs/solutions/integrations/another.md",
+    ])
+    expect(findings).toHaveLength(0)
+  })
+
+  test("does NOT flag normal source files", () => {
+    const findings = scanTrackedFiles([
+      "src/index.ts",
+      "package.json",
+      "AGENTS.md",
+      "scripts/check-repo-health.ts",
+    ])
+    expect(findings).toHaveLength(0)
+  })
+
+  test("all paths in findings are repo-relative", () => {
+    const findings = scanTrackedFiles([
+      "node_modules/x.js",
+      ".DS_Store",
+      "memory/test.db",
+    ])
+    for (const f of findings) {
+      expect(f.path).not.toMatch(/^\//)
+      expect(f.path).not.toContain("\\")
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scanLargeTrackedFiles
+// ---------------------------------------------------------------------------
+
+describe("scanLargeTrackedFiles", () => {
+  test("flags large files in generated-output paths", async () => {
+    const provider = mockProvider(
+      ["docs/async-progress/big-report.md"],
+      { "docs/async-progress/big-report.md": 200 * 1024 },
+    )
+    const findings = await scanLargeTrackedFiles(
+      ["docs/async-progress/big-report.md"],
+      provider,
+      "/fake",
+    )
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("tracked-large-generated")
+    expect(findings[0].severity).toBe("review")
+    expect(findings[0].size).toBe(200 * 1024)
+  })
+
+  test("does not flag files below threshold", async () => {
+    const provider = mockProvider(
+      ["docs/async-progress/small-report.md"],
+      { "docs/async-progress/small-report.md": 50 * 1024 },
+    )
+    const findings = await scanLargeTrackedFiles(
+      ["docs/async-progress/small-report.md"],
+      provider,
+      "/fake",
+    )
+    expect(findings).toHaveLength(0)
+  })
+
+  test("does not flag large files outside generated-output zones", async () => {
+    const provider = mockProvider(
+      ["src/big-source.ts"],
+      { "src/big-source.ts": 500 * 1024 },
+    )
+    const findings = await scanLargeTrackedFiles(
+      ["src/big-source.ts"],
+      provider,
+      "/fake",
+    )
+    expect(findings).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scanLocalArtifacts
+// ---------------------------------------------------------------------------
+
+describe("scanLocalArtifacts", () => {
+  test("reports existing directory with file count and size", async () => {
+    await withTempDir(async (dir) => {
+      const subdir = path.join(dir, "local-heavy")
+      await mkdir(subdir, { recursive: true })
+      await writeFile(path.join(subdir, "a.txt"), "hello")
+      await writeFile(path.join(subdir, "b.txt"), "world")
+
+      const summaries = await scanLocalArtifacts(dir, ["local-heavy"])
+      expect(summaries).toHaveLength(1)
+      expect(summaries[0].exists).toBe(true)
+      expect(summaries[0].fileCount).toBe(2)
+      expect(summaries[0].approximateBytes).toBeGreaterThan(0)
+    })
+  })
+
+  test("reports non-existent paths as exists: false", async () => {
+    await withTempDir(async (dir) => {
+      const summaries = await scanLocalArtifacts(dir, ["nonexistent-path"])
+      expect(summaries).toHaveLength(1)
+      expect(summaries[0].exists).toBe(false)
+    })
+  })
+
+  test("does not follow symlinks", async () => {
+    await withTempDir(async (dir) => {
+      const subdir = path.join(dir, "scan-target")
+      await mkdir(subdir)
+      const realDir = path.join(dir, "real-data")
+      await mkdir(realDir)
+      await writeFile(path.join(realDir, "secret.txt"), "should not be counted")
+
+      // Create symlink inside scan target pointing to real-data
+      const proc = Bun.spawn(["ln", "-s", realDir, path.join(subdir, "link")], {
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      await proc.exited
+
+      const summaries = await scanLocalArtifacts(dir, ["scan-target"])
+      expect(summaries).toHaveLength(1)
+      // Symlink itself is not counted as a file (lstat check)
+      expect(summaries[0].fileCount).toBe(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// scanDocsLifecycle
+// ---------------------------------------------------------------------------
+
+describe("scanDocsLifecycle", () => {
+  test("counts docs with complete metadata", async () => {
+    await withTempDir(async (dir) => {
+      const plansDir = path.join(dir, "docs", "plans")
+      await mkdir(plansDir, { recursive: true })
+      await writeFile(
+        path.join(plansDir, "good.md"),
+        '---\ntitle: "Plan"\nstatus: draft\ndate: 2026-01-01\n---\n# Plan\n',
+      )
+      await writeFile(
+        path.join(plansDir, "bad.md"),
+        "# No frontmatter\n",
+      )
+
+      const summary = await scanDocsLifecycle(dir, ["docs/plans"])
+      expect(summary.totalDocs).toBe(2)
+      expect(summary.missingMetadata).toBe(1)
+    })
+  })
+
+  test("handles missing directories gracefully", async () => {
+    await withTempDir(async (dir) => {
+      const summary = await scanDocsLifecycle(dir, ["docs/nonexistent"])
+      expect(summary.totalDocs).toBe(0)
+      expect(summary.missingMetadata).toBe(0)
+    })
+  })
+
+  test("returns aggregate counts, not per-file findings", async () => {
+    await withTempDir(async (dir) => {
+      const brainstorms = path.join(dir, "docs", "brainstorms")
+      await mkdir(brainstorms, { recursive: true })
+      await writeFile(path.join(brainstorms, "a.md"), "# No metadata\n")
+      await writeFile(path.join(brainstorms, "b.md"), "# Also no metadata\n")
+      await writeFile(path.join(brainstorms, "c.md"), "# Still no metadata\n")
+
+      const summary = await scanDocsLifecycle(dir, ["docs/brainstorms"])
+      expect(summary.totalDocs).toBe(3)
+      expect(summary.missingMetadata).toBe(3)
+      // This is an aggregate summary, not a per-file finding list
+      expect(summary.directories).toEqual(["docs/brainstorms"])
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseFrontmatter
+// ---------------------------------------------------------------------------
+
+describe("parseFrontmatter", () => {
+  test("parses YAML frontmatter fields", () => {
+    const result = parseFrontmatter('---\ntitle: "My Doc"\nstatus: draft\ndate: 2026-01-01\n---\n# Body')
+    expect(result).not.toBeNull()
+    expect(result!.title).toBe("My Doc")
+    expect(result!.status).toBe("draft")
+  })
+
+  test("returns null for no frontmatter", () => {
+    expect(parseFrontmatter("# Just a heading")).toBeNull()
+  })
+
+  test("returns null for empty frontmatter", () => {
+    expect(parseFrontmatter("---\n---\n# Body")).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe("renderText", () => {
+  test("includes severity counts and advisory label", () => {
+    const report = {
+      schemaVersion: 1 as const,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      findings: [
+        {
+          path: "node_modules/x.js",
+          category: "generated" as const,
+          severity: "high-confidence" as const,
+          rule: "tracked-node-modules",
+          reason: "test reason",
+          suggestedAction: "test action",
+        },
+      ],
+      localArtifacts: [],
+      docsLifecycle: { totalDocs: 0, missingMetadata: 0, directories: [] },
+    }
+
+    const text = renderText(report)
+    expect(text).toContain("high-confidence: 1")
+    expect(text).toContain("(advisory only, exit 0)")
+    expect(text).toContain("tracked-node-modules")
+  })
+
+  test("does not include file contents", () => {
+    const report = {
+      schemaVersion: 1 as const,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      findings: [
+        {
+          path: "memory/test.db",
+          category: "runtime-state" as const,
+          severity: "review" as const,
+          rule: "tracked-runtime-db",
+          reason: "Database file",
+          suggestedAction: "Review it",
+        },
+      ],
+      localArtifacts: [],
+      docsLifecycle: { totalDocs: 0, missingMetadata: 0, directories: [] },
+    }
+
+    const text = renderText(report)
+    // Should not contain any binary content or file read
+    expect(text).not.toContain("SELECT")
+    expect(text).not.toContain("CREATE TABLE")
+    expect(text).toContain("memory/test.db")
+  })
+})
+
+describe("renderJson", () => {
+  test("includes schemaVersion in JSON output", () => {
+    const report = {
+      schemaVersion: 1 as const,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      findings: [],
+      localArtifacts: [],
+      docsLifecycle: { totalDocs: 0, missingMetadata: 0, directories: [] },
+    }
+
+    const json = JSON.parse(renderJson(report))
+    expect(json.schemaVersion).toBe(1)
+    expect(json.generatedAt).toBe("2026-01-01T00:00:00.000Z")
+  })
+
+  test("JSON paths are repo-relative", () => {
+    const report = {
+      schemaVersion: 1 as const,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      findings: [
+        {
+          path: "node_modules/foo.js",
+          category: "generated" as const,
+          severity: "high-confidence" as const,
+          rule: "tracked-node-modules",
+          reason: "test",
+          suggestedAction: "test",
+        },
+      ],
+      localArtifacts: [],
+      docsLifecycle: { totalDocs: 0, missingMetadata: 0, directories: [] },
+    }
+
+    const json = JSON.parse(renderJson(report))
+    for (const f of json.findings) {
+      expect(f.path).not.toMatch(/^\//)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseCliArgs", () => {
+  test("defaults to text format", () => {
+    expect(parseCliArgs([]).format).toBe("text")
+  })
+
+  test("parses --format json", () => {
+    expect(parseCliArgs(["--format", "json"]).format).toBe("json")
+  })
+
+  test("rejects unknown arguments", () => {
+    expect(() => parseCliArgs(["--unknown"])).toThrow("Unknown argument")
+  })
+
+  test("rejects invalid format", () => {
+    expect(() => parseCliArgs(["--format", "xml"])).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: runScan with injected provider
+// ---------------------------------------------------------------------------
+
+describe("runScan with mock provider", () => {
+  test("produces a valid report shape", async () => {
+    await withTempDir(async (dir) => {
+      const provider = mockProvider(["src/index.ts", "package.json"])
+      const report = await runScan({ rootDir: dir, provider })
+
+      expect(report.schemaVersion).toBe(1)
+      expect(report.generatedAt).toBeTruthy()
+      expect(Array.isArray(report.findings)).toBe(true)
+      expect(Array.isArray(report.localArtifacts)).toBe(true)
+      expect(report.docsLifecycle).toBeDefined()
+    })
+  })
+
+  test("surfaces high-confidence findings for bloat", async () => {
+    await withTempDir(async (dir) => {
+      const provider = mockProvider([
+        "node_modules/foo/index.js",
+        ".DS_Store",
+        "src/index.ts",
+      ])
+      const report = await runScan({ rootDir: dir, provider })
+
+      const rules = report.findings.map((f) => f.rule)
+      expect(rules).toContain("tracked-node-modules")
+      expect(rules).toContain("tracked-ds-store")
+    })
+  })
+
+  test("does not flag clean source-only repos", async () => {
+    await withTempDir(async (dir) => {
+      const provider = mockProvider([
+        "src/index.ts",
+        "package.json",
+        "AGENTS.md",
+        "tests/example.test.ts",
+      ])
+      const report = await runScan({ rootDir: dir, provider })
+
+      // Only local-artifact info findings or docs lifecycle may appear
+      const nonInfoFindings = report.findings.filter((f) => f.severity !== "info")
+      expect(nonInfoFindings).toHaveLength(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: runScan with real git repo
+// ---------------------------------------------------------------------------
+
+describe("runScan with temp git repo", () => {
+  test("detects tracked node_modules in a real git repo", async () => {
+    await withTempDir(async (dir) => {
+      await initGitRepo(dir)
+
+      // Create and track a node_modules file
+      await mkdir(path.join(dir, "node_modules", "pkg"), { recursive: true })
+      await writeFile(path.join(dir, "node_modules", "pkg", "index.js"), "module.exports = {}")
+      await mkdir(path.join(dir, "src"), { recursive: true })
+      await writeFile(path.join(dir, "src", "index.ts"), "console.log('hello')")
+
+      const git = (...args: string[]) =>
+        Bun.spawn(["git", "add", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" })
+      await git(".").exited
+      await Bun.spawn(["git", "commit", "-m", "initial"], {
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      }).exited
+
+      const report = await runScan({ rootDir: dir })
+
+      const nmFindings = report.findings.filter((f) => f.rule === "tracked-node-modules")
+      expect(nmFindings.length).toBeGreaterThan(0)
+      expect(nmFindings[0].severity).toBe("high-confidence")
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: runCli
+// ---------------------------------------------------------------------------
+
+describe("runCli", () => {
+  test("text output includes advisory label", async () => {
+    const logs: string[] = []
+    const stdout = {
+      log: (msg: string) => logs.push(msg),
+      error: () => {},
+    }
+
+    await withTempDir(async (dir) => {
+      const provider = mockProvider(["src/index.ts"])
+      await runCli([], { rootDir: dir, stdout, provider })
+    })
+
+    const output = logs.join("\n")
+    expect(output).toContain("advisory only")
+  })
+
+  test("--format json produces valid JSON with schemaVersion", async () => {
+    const logs: string[] = []
+    const stdout = {
+      log: (msg: string) => logs.push(msg),
+      error: () => {},
+    }
+
+    await withTempDir(async (dir) => {
+      const provider = mockProvider(["src/index.ts"])
+      await runCli(["--format", "json"], { rootDir: dir, stdout, provider })
+    })
+
+    const jsonOutput = JSON.parse(logs.join("\n"))
+    expect(jsonOutput.schemaVersion).toBe(1)
+    expect(jsonOutput.findings).toBeDefined()
+  })
+
+  test("import does not trigger side effects", async () => {
+    await withTempDir(async (dir) => {
+      const scriptPath = path.resolve(import.meta.dir, "../scripts/check-repo-health.ts")
+      const proc = Bun.spawn({
+        cmd: ["bun", "-e", `await import(${JSON.stringify(scriptPath)})`],
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      const exitCode = await proc.exited
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+
+      // Import should not produce any output
+      expect(stdout).toBe("")
+      expect(stderr).toBe("")
+      expect(exitCode).toBe(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// No-content-leakage
+// ---------------------------------------------------------------------------
+
+describe("no content leakage", () => {
+  test("findings contain only metadata, never file content", async () => {
+    await withTempDir(async (dir) => {
+      const secretContent = "SUPER_SECRET_API_KEY=abc123"
+      const provider = mockProvider([
+        "node_modules/secret-pkg/config.json",
+        "memory/secrets.db",
+        ".DS_Store",
+      ])
+
+      const report = await runScan({ rootDir: dir, provider })
+
+      const serialized = JSON.stringify(report)
+      expect(serialized).not.toContain(secretContent)
+      expect(serialized).not.toContain("SUPER_SECRET")
+
+      // Verify each finding has only the expected metadata fields
+      for (const f of report.findings) {
+        expect(f).toHaveProperty("path")
+        expect(f).toHaveProperty("rule")
+        expect(f).toHaveProperty("category")
+        expect(f).toHaveProperty("severity")
+        expect(f).toHaveProperty("reason")
+        expect(f).toHaveProperty("suggestedAction")
+        // No 'content' field should exist
+        expect(f).not.toHaveProperty("content")
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 增加第一版低风险 repo health 治理基线。
- 新增 read-only / advisory checker，只报告问题，不清理、不移动、不删除文件。
- 本 PR 不引入 CI gate，不修改 `.gitignore`，不改变 `memory/` / `vendor/` 策略。

## What changed

- 新增 repo health policy：
  - `docs/solutions/developer-experience/repo-health-governance-policy-2026-04-25.md`
- 新增 advisory checker：
  - `scripts/check-repo-health.ts`
  - 检查 tracked accidental bloat / runtime state candidates
  - 检查 capped local ignored artifacts
  - 聚合检查 docs lifecycle metadata
  - 支持 text / JSON 输出
  - 默认 exit 0，除非 checker 自身崩溃
- 新增测试：
  - `tests/repo-health-check.test.ts`
- 新增 package script：
  - `repo:health`
- 新增已批准计划文档：
  - `docs/plans/2026-04-25-repo-health-governance-plan.md`

## Validation

- `bun test tests/repo-health-check.test.ts` — 39 pass, 0 fail
- `bun test` — 1302 pass, 3 skip, 0 fail
- `bun run release:validate` — pass
- `bun run repo:health` — exit 0，输出 advisory report

## Deferred / Safety boundaries

- `memory/` 和 `vendor/` 策略仍保持 review-only / deferred。
- docs lifecycle 检查只做 aggregate 统计，避免噪音。
- 本 PR 不做 CI 集成；后续等 baseline 稳定后，可单独加 warning-only CI。
- 本 PR 不修改：
  - `.gitignore`
  - 现有 tracked docs/reports
  - memory tracking policy
  - vendor governance
