### PR TITLE
feat: store HKT session transcripts on skill completion

### DIFF
--- a/cmd/gale-memory/index.ts
+++ b/cmd/gale-memory/index.ts
@@ -4,6 +4,7 @@ import {
   captureTaskMemory,
   feedbackTaskMemory,
   startTaskMemory,
+  storeSessionTranscript,
 } from "../../src/memory/task-runtime.js"
 import { skippedResult } from "../../src/memory/hkt-client.js"
 import { migrateLegacyMemory, migrationStatus } from "../../src/memory/migration.js"
@@ -115,6 +116,22 @@ async function main(): Promise<void> {
       return
     }
 
+    if (command === "store-session-transcript") {
+      const result = await storeSessionTranscript({
+        ...common,
+        phase: flags.phase ?? "completed",
+        content: flags.content ?? flags.summary ?? common.inputSummary,
+        title: flags.title,
+        summary: flags.summary ?? common.inputSummary,
+        sourceMode: flags["source-mode"] ?? "phase_completed",
+        importance: (flags.importance ?? "medium") as "high" | "medium" | "low",
+        maxChars: flags["max-chars"] ? Number(flags["max-chars"]) : undefined,
+        metadata: parseJsonObject(flags.metadata),
+      })
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n")
+      return
+    }
+
     if (command === "feedback") {
       const result = await feedbackTaskMemory({
         ...common,
@@ -129,13 +146,13 @@ async function main(): Promise<void> {
 
     if (!command || command === "--help" || command === "-h") {
       process.stdout.write(
-        "Usage: gale-memory <start|capture|feedback|status|resolve-root|migrate> [flags]\n" +
+        "Usage: gale-memory <start|capture|store-session-transcript|feedback|status|resolve-root|migrate> [flags]\n" +
         "Flags: --cwd <path> --project <name> --memory-dir <path> --json\n",
       )
       return
     }
 
-    process.stdout.write(JSON.stringify(skippedResult("Usage: gale-memory <start|capture|feedback|status|resolve-root|migrate> [flags]")) + "\n")
+    process.stdout.write(JSON.stringify(skippedResult("Usage: gale-memory <start|capture|store-session-transcript|feedback|status|resolve-root|migrate> [flags]")) + "\n")
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     process.stdout.write(JSON.stringify(skippedResult(message)) + "\n")

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -621,6 +621,8 @@ Based on problem type, these agents can enhance documentation:
 
 After the compound workflow is fully complete (documentation written, discoverability check done), log the completion event:
 
-1. Run `gale-task log skill_completed` to record the completion event.
-2. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
+1. Run `gale-memory store-session-transcript --skill gh:compound --phase completed --source-mode compound_artifact --importance high --summary "<learning document title and reusable pattern>" --content "<problem, root cause, solution, artifacts written, verification, links>"` to make the completed compound artifact session available to `list-recent` and `session-search`.
+2. If `gale-memory` is not on PATH or the command fails, skip and continue — this must never block the skill.
+3. Run `gale-task log skill_completed` to record the completion event.
+4. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
 <!-- /HKT-PATCH:gale-task-end -->

--- a/plugins/galeharness-cli/skills/gh-debug/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug/SKILL.md
@@ -283,6 +283,8 @@ Options (include only those that apply):
 <!-- HKT-PATCH:gale-task-end -->
 After presenting handoff options and completing this skill, log the completion event:
 
-1. Run `gale-task log skill_completed` to record the completion event.
-2. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
+1. Run `gale-memory store-session-transcript --skill gh:debug --mode debug --phase completed --source-mode phase_completed --importance high --summary "<confirmed root cause and fix status>" --content "<debug timeline, failed attempts, root cause, changed files, verification, remaining blockers>"` to make the completed debug session available to `list-recent` and `session-search`.
+2. If `gale-memory` is not on PATH or the command fails, skip and continue — this must never block the skill.
+3. Run `gale-task log skill_completed` to record the completion event.
+4. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
 <!-- /HKT-PATCH:gale-task-end -->

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -462,6 +462,8 @@ After the work is complete and the shipping workflow has finished (PR created or
 <!-- HKT-PATCH:gale-task-end -->
 After the work workflow is fully complete, log the completion event:
 
-1. Run `gale-task log skill_completed` to record the completion event.
-2. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
+1. Run `gale-memory store-session-transcript --skill gh:work --phase completed --source-mode phase_completed --importance high --summary "<concise work summary>" --content "<final summary, changed files, verification, blockers, PR/issue context>"` to make the completed work session available to `list-recent` and `session-search`.
+2. If `gale-memory` is not on PATH or the command fails, skip and continue — this must never block the skill.
+3. Run `gale-task log skill_completed` to record the completion event.
+4. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
 <!-- /HKT-PATCH:gale-task-end -->

--- a/src/memory/hkt-client.ts
+++ b/src/memory/hkt-client.ts
@@ -44,6 +44,41 @@ export class HktClient {
     return this.runJson(["task-capture", "--json", "--event", JSON.stringify(event)])
   }
 
+  storeSessionTranscript(transcript: Record<string, unknown>): Promise<HktTaskResult> {
+    const args = [
+      "store-session-transcript",
+      "--content",
+      String(transcript.content ?? ""),
+      "--session-id",
+      String(transcript.session_id ?? ""),
+      "--source",
+      String(transcript.source ?? "galeharness"),
+      "--source-mode",
+      String(transcript.source_mode ?? "phase_completed"),
+      "--importance",
+      String(transcript.importance ?? "medium"),
+    ]
+    for (const [flag, key] of [
+      ["--title", "title"],
+      ["--topic", "topic"],
+      ["--task-id", "task_id"],
+      ["--project", "project"],
+      ["--repo-root", "repo_root"],
+      ["--branch", "branch"],
+      ["--pr-id", "pr_id"],
+      ["--max-chars", "max_chars"],
+    ] as const) {
+      const value = transcript[key]
+      if (value !== undefined && value !== null && value !== "") {
+        args.push(flag, String(value))
+      }
+    }
+    if (transcript.metadata && typeof transcript.metadata === "object") {
+      args.push("--metadata", JSON.stringify(transcript.metadata))
+    }
+    return this.runJson(args)
+  }
+
   taskLedger(project: string, taskId: string): Promise<HktTaskResult> {
     return this.runJson(["task-ledger", "--json", "--project", project, "--task-id", taskId])
   }

--- a/src/memory/task-runtime.ts
+++ b/src/memory/task-runtime.ts
@@ -66,6 +66,17 @@ export interface CaptureOptions extends BuildEnvelopeOptions {
   payload?: Record<string, unknown>
 }
 
+export interface StoreSessionTranscriptOptions extends BuildEnvelopeOptions {
+  content: string
+  title?: string
+  summary?: string
+  phase?: string
+  sourceMode?: string
+  importance?: "high" | "medium" | "low"
+  maxChars?: number
+  metadata?: Record<string, unknown>
+}
+
 export async function buildTaskEnvelope(options: BuildEnvelopeOptions): Promise<TaskEnvelope> {
   const cwd = options.cwd ?? process.cwd()
   const context = await detectProjectContext(cwd, options)
@@ -134,6 +145,58 @@ export async function captureTaskMemory(
     })
   }
   return { event, capture }
+}
+
+export async function storeSessionTranscript(
+  options: StoreSessionTranscriptOptions,
+  client?: Pick<HktClient, "storeSessionTranscript">,
+): Promise<{ transcript: Record<string, unknown>; store: HktTaskResult }> {
+  const envelope = await buildTaskEnvelope({
+    ...options,
+    phase: options.phase ?? "completed",
+    artifactType: options.artifactType ?? `${options.skill.replace(/^gh:/, "")}_session_transcript`,
+  })
+  const memory = prepareTaskMemory(options)
+  const transcript = {
+    content: options.content,
+    session_id: envelope.task_id,
+    title: options.title ?? `${envelope.skill} session transcript`,
+    topic: "session",
+    task_id: envelope.task_id,
+    project: envelope.project,
+    repo_root: envelope.repo_root,
+    branch: envelope.branch,
+    pr_id: envelope.pr_id,
+    source: "galeharness",
+    source_mode: options.sourceMode ?? "phase_completed",
+    importance: options.importance ?? "medium",
+    max_chars: options.maxChars ?? 12000,
+    metadata: {
+      skill: envelope.skill,
+      phase: envelope.phase,
+      mode: envelope.mode,
+      issue_id: envelope.issue_id,
+      artifact_type: envelope.artifact_type,
+      files: envelope.files,
+      verification: envelope.verification,
+      summary: options.summary ?? envelope.input_summary,
+      ...(options.metadata ?? {}),
+    },
+  }
+  const hktClient = client ?? new HktClient({ cwd: options.cwd, memoryDir: memory.root.memoryDir, diagnostics: memory.diagnostics })
+  const store = withMemoryDiagnostics(await hktClient.storeSessionTranscript(transcript), memory.diagnostics)
+  if (store.success) {
+    const memoryId = String(store.L2 ?? store.memory_ids?.L2 ?? store.existing_memory_id ?? "")
+    if (memoryId) {
+      await logMemoryLinked({
+        cwd: options.cwd ?? process.cwd(),
+        skill: envelope.skill,
+        memoryId,
+        taskId: envelope.task_id,
+      })
+    }
+  }
+  return { transcript, store }
 }
 
 export async function feedbackTaskMemory(

--- a/tests/gale-memory-runtime.test.ts
+++ b/tests/gale-memory-runtime.test.ts
@@ -8,12 +8,14 @@ import {
   captureTaskMemory,
   feedbackTaskMemory,
   startTaskMemory,
+  storeSessionTranscript,
 } from "../src/memory/task-runtime.js"
 import { HktClient } from "../src/memory/hkt-client.js"
 
 class FakeHktClient {
   recallEnvelope: Record<string, unknown> | null = null
   captureEvent: Record<string, unknown> | null = null
+  transcript: Record<string, unknown> | null = null
 
   async taskRecall(envelope: Record<string, unknown>) {
     this.recallEnvelope = envelope
@@ -35,6 +37,15 @@ class FakeHktClient {
       ledger_updated: true,
       durable_memory_id: null,
       memory_link_required: false,
+      diagnostics: {},
+    }
+  }
+
+  async storeSessionTranscript(transcript: Record<string, unknown>) {
+    this.transcript = transcript
+    return {
+      success: true,
+      L2: "memory-session-123",
       diagnostics: {},
     }
   }
@@ -192,6 +203,43 @@ describe("Gale task memory runtime", () => {
     expect(client.captureEvent?.payload).toEqual({ hypothesis: "cache issue" })
   })
 
+  test("storeSessionTranscript sends phase completion transcript with provenance", async () => {
+    const client = new FakeHktClient()
+
+    const result = await storeSessionTranscript(
+      {
+        cwd: tmpDir,
+        contextFile,
+        project: "HKTMemory",
+        repoRoot: tmpDir,
+        branch: "feature/task-memory",
+        skill: "gh:work",
+        mode: "implement",
+        phase: "completed",
+        content: "Implemented transcript hooks and verified tests",
+        summary: "Transcript hooks completed",
+        files: ["src/memory/task-runtime.ts"],
+        verification: { status: "passed", command: "bun test" },
+        importance: "high",
+      },
+      client,
+    )
+
+    expect(result.store.success).toBe(true)
+    expect(client.transcript?.source).toBe("galeharness")
+    expect(client.transcript?.source_mode).toBe("phase_completed")
+    expect(client.transcript?.project).toBe("HKTMemory")
+    expect(client.transcript?.repo_root).toBe(tmpDir)
+    expect(client.transcript?.branch).toBe("feature/task-memory")
+    expect(client.transcript?.importance).toBe("high")
+    expect(client.transcript?.metadata).toMatchObject({
+      skill: "gh:work",
+      phase: "completed",
+      artifact_type: "work_session_transcript",
+      summary: "Transcript hooks completed",
+    })
+  })
+
   test("feedback is captured as a structured task event", async () => {
     const client = new FakeHktClient()
 
@@ -235,7 +283,7 @@ describe("Gale task memory runtime", () => {
     const memoryDir = path.join(tmpDir, "custom-memory")
     await writeFile(
       script,
-      "#!/usr/bin/env node\nconsole.log(JSON.stringify({ success: true, diagnostics: { child_memory_dir: process.env.HKT_MEMORY_DIR } }))\n",
+      "#!/usr/bin/env node\nprocess.stdin.resume(); console.log(JSON.stringify({ success: true, diagnostics: { child_memory_dir: process.env.HKT_MEMORY_DIR } }))\n",
       "utf8",
     )
     await chmod(script, 0o755)

--- a/tests/gale-memory-runtime.test.ts
+++ b/tests/gale-memory-runtime.test.ts
@@ -279,19 +279,24 @@ describe("Gale task memory runtime", () => {
   })
 
   test("HktClient passes HKT_MEMORY_DIR to child process", async () => {
-    const script = path.join(tmpDir, "fake-hkt")
-    const memoryDir = path.join(tmpDir, "custom-memory")
-    await writeFile(
-      script,
-      "#!/usr/bin/env node\nprocess.stdin.resume(); console.log(JSON.stringify({ success: true, diagnostics: { child_memory_dir: process.env.HKT_MEMORY_DIR } }))\n",
-      "utf8",
-    )
-    await chmod(script, 0o755)
-    const client = new HktClient({ binary: script, cwd: tmpDir, timeoutMs: 1000, memoryDir })
+    const hktTmpDir = await mkdtemp(path.join(tmpdir(), "gale-memory-hkt-client-"))
+    try {
+      const script = path.join(hktTmpDir, "fake-hkt")
+      const memoryDir = path.join(hktTmpDir, "custom-memory")
+      await writeFile(
+        script,
+        "#!/usr/bin/env node\nconsole.log(JSON.stringify({ success: true, diagnostics: { child_memory_dir: process.env.HKT_MEMORY_DIR } })); process.exit(0)\n",
+        "utf8",
+      )
+      await chmod(script, 0o755)
+      const client = new HktClient({ binary: script, cwd: hktTmpDir, timeoutMs: 10000, memoryDir })
 
-    const result = await client.taskRecall({ schema_version: "gale-task-memory.v1" })
+      const result = await client.taskRecall({ schema_version: "gale-task-memory.v1" })
 
-    expect(result.success).toBe(true)
-    expect(result.diagnostics?.child_memory_dir).toBe(memoryDir)
+      expect(result.success).toBe(true)
+      expect(result.diagnostics?.child_memory_dir).toBe(memoryDir)
+    } finally {
+      await rm(hktTmpDir, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/hkt-memory-compounding.test.ts
+++ b/tests/hkt-memory-compounding.test.ts
@@ -480,4 +480,22 @@ describe("Gale Task Memory Runtime Pilot", () => {
     expect(ctx).toContain("--event-type root_cause")
     expect(ctx).not.toContain("hkt-memory store")
   })
+
+  for (const [skill, mode] of [
+    ["gh-work", "gh:work"],
+    ["gh-debug", "gh:debug"],
+    ["gh-compound", "gh:compound"],
+  ]) {
+    test(`${skill} completion stores a session transcript through gale-memory`, async () => {
+      const content = await readFile(path.join(PLUGIN_ROOT, skill, "SKILL.md"), "utf8")
+      const ctx = extractPhaseContext(content, "gale-task-end")
+
+      expect(ctx).toContain("gale-memory store-session-transcript")
+      expect(ctx).toContain(`--skill ${mode}`)
+      expect(ctx).toContain("--phase completed")
+      expect(ctx).toContain("list-recent")
+      expect(ctx).toContain("session-search")
+      expect(ctx).toMatch(/never block the skill/i)
+    })
+  }
 })

--- a/tests/repo-health-check.test.ts
+++ b/tests/repo-health-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import type { TrackedFileProvider } from "../scripts/check-repo-health"
@@ -234,13 +234,7 @@ describe("scanLocalArtifacts", () => {
       await mkdir(realDir)
       await writeFile(path.join(realDir, "secret.txt"), "should not be counted")
 
-      // Create symlink inside scan target pointing to real-data
-      const proc = Bun.spawn(["ln", "-s", realDir, path.join(subdir, "link")], {
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "pipe",
-      })
-      await proc.exited
+      await symlink(realDir, path.join(subdir, "link"), "dir")
 
       const summaries = await scanLocalArtifacts(dir, ["scan-target"])
       expect(summaries).toHaveLength(1)


### PR DESCRIPTION
## Summary
- add Gale runtime and gale-memory command support for HKT store-session-transcript
- wire gh:work, gh:debug, and gh:compound completion paths to best-effort transcript storage
- add runtime and skill contract coverage for transcript hooks

## Verification
- bun test tests/gale-memory-runtime.test.ts tests/hkt-memory-compounding.test.ts

Depends on the HKTMemory store-session-transcript surface from wangrenzhu-ola/HKTMemory#8.