### PR TITLE
fix(memory): prefer Hermes provider vector recall

### DIFF
--- a/src/memory/hkt-client.ts
+++ b/src/memory/hkt-client.ts
@@ -4,9 +4,12 @@ import path from "node:path"
 
 export interface HktClientOptions {
   binary?: string
+  providerBinary?: string
   cwd?: string
   timeoutMs?: number
   memoryDir?: string
+  providerMemoryDir?: string
+  preferProviderVectorRecall?: boolean
   diagnostics?: Record<string, unknown>
 }
 
@@ -23,28 +26,63 @@ export interface HktTaskResult {
 
 export class HktClient {
   private binary: string
+  private providerBinary: string
   private cwd: string
   private timeoutMs: number
   private memoryDir?: string
+  private providerMemoryDir?: string
+  private preferProviderVectorRecall: boolean
   private diagnostics: Record<string, unknown>
 
   constructor(options: HktClientOptions = {}) {
     this.binary = options.binary ?? process.env.HKT_MEMORY_BIN ?? "hkt-memory"
+    this.providerBinary =
+      options.providerBinary ??
+      process.env.HERMES_HKTMEMORY_BIN ??
+      "hermes-hktmemory"
     this.cwd = options.cwd ?? process.cwd()
     this.timeoutMs = options.timeoutMs ?? 5000
     this.memoryDir = options.memoryDir
+    this.providerMemoryDir =
+      options.providerMemoryDir ?? process.env.HERMES_HKTMEMORY_DIR
+    this.preferProviderVectorRecall =
+      options.preferProviderVectorRecall ??
+      Boolean(
+        this.providerMemoryDir || isTruthy(process.env.HERMES_HKTMEMORY_RECALL),
+      )
     this.diagnostics = options.diagnostics ?? {}
   }
 
-  taskRecall(envelope: Record<string, unknown>, limit = 5): Promise<HktTaskResult> {
-    return this.runJson(["task-recall", "--json", "--envelope", JSON.stringify(envelope), "--limit", String(limit)])
+  async taskRecall(
+    envelope: Record<string, unknown>,
+    limit = 5,
+  ): Promise<HktTaskResult> {
+    if (this.preferProviderVectorRecall) {
+      const providerResult = await this.runProviderRecall(envelope, limit)
+      if (hasRecallContent(providerResult)) return providerResult
+    }
+    return this.runJson([
+      "task-recall",
+      "--json",
+      "--envelope",
+      JSON.stringify(envelope),
+      "--limit",
+      String(limit),
+    ])
   }
 
   taskCapture(event: Record<string, unknown>): Promise<HktTaskResult> {
-    return this.runJson(["task-capture", "--json", "--event", JSON.stringify(event)])
+    return this.runJson([
+      "task-capture",
+      "--json",
+      "--event",
+      JSON.stringify(event),
+    ])
   }
 
-  storeSessionTranscript(transcript: Record<string, unknown>): Promise<HktTaskResult> {
+  storeSessionTranscript(
+    transcript: Record<string, unknown>,
+  ): Promise<HktTaskResult> {
     const args = [
       "store-session-transcript",
       "--content",
@@ -80,7 +118,14 @@ export class HktClient {
   }
 
   taskLedger(project: string, taskId: string): Promise<HktTaskResult> {
-    return this.runJson(["task-ledger", "--json", "--project", project, "--task-id", taskId])
+    return this.runJson([
+      "task-ledger",
+      "--json",
+      "--project",
+      project,
+      "--task-id",
+      taskId,
+    ])
   }
 
   private runJson(args: string[]): Promise<HktTaskResult> {
@@ -99,12 +144,18 @@ export class HktClient {
       const proc = spawn(command.executable, command.args, {
         cwd: this.cwd,
         stdio: ["ignore", "pipe", "pipe"],
-        env: this.memoryDir ? { ...process.env, HKT_MEMORY_DIR: this.memoryDir } : { ...process.env },
+        env: this.memoryDir
+          ? { ...process.env, HKT_MEMORY_DIR: this.memoryDir }
+          : { ...process.env },
       })
 
       const timer = setTimeout(() => {
         proc.kill("SIGKILL")
-        finish(this.withDiagnostics(skippedResult(`hkt-memory timed out after ${this.timeoutMs}ms`)))
+        finish(
+          this.withDiagnostics(
+            skippedResult(`hkt-memory timed out after ${this.timeoutMs}ms`),
+          ),
+        )
       }, this.timeoutMs)
 
       proc.stdout.on("data", (chunk: Buffer) => {
@@ -115,32 +166,134 @@ export class HktClient {
       })
       proc.on("error", (err) => {
         clearTimeout(timer)
-        finish(this.withDiagnostics(skippedResult(`hkt-memory unavailable: ${err.message}`)))
+        finish(
+          this.withDiagnostics(
+            skippedResult(`hkt-memory unavailable: ${err.message}`),
+          ),
+        )
       })
       proc.on("close", (code) => {
         clearTimeout(timer)
         if (settled) return
         if (code !== 0) {
-          finish(this.withDiagnostics(skippedResult(`hkt-memory exited ${code}: ${stderr.trim()}`.trim())))
+          finish(
+            this.withDiagnostics(
+              skippedResult(
+                `hkt-memory exited ${code}: ${stderr.trim()}`.trim(),
+              ),
+            ),
+          )
           return
         }
         try {
           const parsed = JSON.parse(stdout) as HktTaskResult
           finish(this.withDiagnostics(parsed))
         } catch {
-          finish(this.withDiagnostics(skippedResult("hkt-memory returned malformed JSON")))
+          finish(
+            this.withDiagnostics(
+              skippedResult("hkt-memory returned malformed JSON"),
+            ),
+          )
         }
       })
     })
   }
 
-  private withDiagnostics(result: HktTaskResult): HktTaskResult {
+  private runProviderRecall(
+    envelope: Record<string, unknown>,
+    limit: number,
+  ): Promise<HktTaskResult> {
+    return new Promise((resolve) => {
+      let stdout = ""
+      let stderr = ""
+      let settled = false
+
+      const finish = (result: HktTaskResult) => {
+        if (settled) return
+        settled = true
+        resolve(result)
+      }
+
+      const query = providerRecallQuery(envelope)
+      const command = resolveExecutableCommand(this.providerBinary, [
+        "recall",
+        "-q",
+        query,
+        "--limit",
+        String(limit),
+      ])
+      const proc = spawn(command.executable, command.args, {
+        cwd: this.cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: this.providerMemoryDir
+          ? { ...process.env, HERMES_HKTMEMORY_DIR: this.providerMemoryDir }
+          : { ...process.env },
+      })
+
+      const timer = setTimeout(() => {
+        proc.kill("SIGKILL")
+        finish(
+          this.withDiagnostics(
+            skippedResult(
+              `hermes-hktmemory recall timed out after ${this.timeoutMs}ms`,
+            ),
+            { provider_vector_reason: "timeout" },
+          ),
+        )
+      }, this.timeoutMs)
+
+      proc.stdout.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString()
+      })
+      proc.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString()
+      })
+      proc.on("error", (err) => {
+        clearTimeout(timer)
+        finish(
+          this.withDiagnostics(
+            skippedResult(`hermes-hktmemory unavailable: ${err.message}`),
+            { provider_vector_reason: "unavailable" },
+          ),
+        )
+      })
+      proc.on("close", (code) => {
+        clearTimeout(timer)
+        if (settled) return
+        if (code !== 0) {
+          finish(
+            this.withDiagnostics(
+              skippedResult(
+                `hermes-hktmemory exited ${code}: ${stderr.trim()}`.trim(),
+              ),
+              { provider_vector_reason: "exit" },
+            ),
+          )
+          return
+        }
+        finish(
+          this.withDiagnostics(providerRecallResult(stdout), {
+            provider_vector_query: query,
+          }),
+        )
+      })
+    })
+  }
+
+  private withDiagnostics(
+    result: HktTaskResult,
+    extraDiagnostics: Record<string, unknown> = {},
+  ): HktTaskResult {
     return {
       ...result,
       diagnostics: {
         ...(result.diagnostics ?? {}),
         ...this.diagnostics,
         memory_dir: this.memoryDir ?? process.env.HKT_MEMORY_DIR ?? null,
+        ...(this.providerMemoryDir
+          ? { hermes_hktmemory_dir: this.providerMemoryDir }
+          : {}),
+        ...extraDiagnostics,
       },
     }
   }
@@ -158,7 +311,10 @@ export function skippedResult(reason: string): HktTaskResult {
   }
 }
 
-function resolveExecutableCommand(executable: string, args: string[]): { executable: string; args: string[] } {
+function resolveExecutableCommand(
+  executable: string,
+  args: string[],
+): { executable: string; args: string[] } {
   if (process.platform !== "win32" || !isPathLike(executable)) {
     return { executable, args }
   }
@@ -171,7 +327,11 @@ function resolveExecutableCommand(executable: string, args: string[]): { executa
 }
 
 function isPathLike(executable: string): boolean {
-  return path.isAbsolute(executable) || executable.includes("/") || executable.includes("\\")
+  return (
+    path.isAbsolute(executable) ||
+    executable.includes("/") ||
+    executable.includes("\\")
+  )
 }
 
 function shouldRunWithBun(executable: string): boolean {
@@ -180,9 +340,117 @@ function shouldRunWithBun(executable: string): boolean {
   if (!existsSync(executable)) return false
 
   try {
-    const firstLine = readFileSync(executable, "utf8").split(/\r?\n/, 1)[0] ?? ""
+    const firstLine =
+      readFileSync(executable, "utf8").split(/\r?\n/, 1)[0] ?? ""
     return firstLine.startsWith("#!") && /\b(?:bun|node)\b/.test(firstLine)
   } catch {
     return false
   }
+}
+
+function isTruthy(value: string | undefined): boolean {
+  return value === "1" || value === "true" || value === "yes" || value === "on"
+}
+
+function providerRecallQuery(envelope: Record<string, unknown>): string {
+  const inputSummary = String(envelope.input_summary ?? "").trim()
+  if (inputSummary) return inputSummary
+  return [
+    envelope.project,
+    envelope.branch,
+    envelope.skill,
+    envelope.issue_id,
+    envelope.artifact_type,
+  ]
+    .map((value) => String(value ?? "").trim())
+    .filter(Boolean)
+    .join(" ")
+}
+
+function providerRecallResult(stdout: string): HktTaskResult {
+  const text = stdout.trim()
+  if (!text) {
+    return {
+      ...skippedResult("hermes-hktmemory recall returned no matches"),
+      diagnostics: {
+        blocked: [],
+        omitted_sources: [],
+        backend: "provider_vector",
+        provider_vector_empty: true,
+      },
+    }
+  }
+
+  const parsed = parseProviderJson(text)
+  const items = extractProviderItems(parsed, text)
+  const injectable = extractProviderMarkdown(parsed, text, items)
+  return {
+    success: items.length > 0 || injectable.trim().length > 0,
+    trace_id: null,
+    injectable_markdown: injectable,
+    items,
+    diagnostics: { backend: "provider_vector" },
+  }
+}
+
+function parseProviderJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function extractProviderItems(parsed: unknown, text: string): unknown[] {
+  if (Array.isArray(parsed)) return parsed
+  if (parsed && typeof parsed === "object") {
+    const record = parsed as Record<string, unknown>
+    const value = record.items ?? record.results ?? record.memories
+    if (Array.isArray(value)) return value
+  }
+  return [{ content: text }]
+}
+
+function extractProviderMarkdown(
+  parsed: unknown,
+  text: string,
+  items: unknown[],
+): string {
+  const parsedObject = parsed && typeof parsed === "object"
+  if (parsedObject && !Array.isArray(parsed)) {
+    const record = parsed as Record<string, unknown>
+    const markdown =
+      record.injectable_markdown ?? record.markdown ?? record.text
+    if (typeof markdown === "string" && markdown.trim()) return markdown
+    if (items.length === 0) return ""
+  }
+  const body = items
+    .map((item) => {
+      if (typeof item === "string") return `- ${item}`
+      if (item && typeof item === "object") {
+        const record = item as Record<string, unknown>
+        const content =
+          record.content ??
+          record.text ??
+          record.summary ??
+          record.markdown ??
+          JSON.stringify(record)
+        return `- ${String(content)}`
+      }
+      return `- ${String(item)}`
+    })
+    .join("\n")
+  return body
+    ? `<untrusted-memory-evidence>\n${body}\n</untrusted-memory-evidence>`
+    : parsedObject
+      ? ""
+      : text
+}
+
+function hasRecallContent(result: HktTaskResult): boolean {
+  return Boolean(
+    result.success &&
+    ((result.items?.length ?? 0) > 0 ||
+      String(result.injectable_markdown ?? "").trim()),
+  )
 }

--- a/tests/gale-memory-runtime.test.ts
+++ b/tests/gale-memory-runtime.test.ts
@@ -22,7 +22,8 @@ class FakeHktClient {
     return {
       success: true,
       trace_id: "trace-123",
-      injectable_markdown: "<untrusted-memory-evidence>debug context</untrusted-memory-evidence>",
+      injectable_markdown:
+        "<untrusted-memory-evidence>debug context</untrusted-memory-evidence>",
       items: [],
       diagnostics: {},
     }
@@ -56,14 +57,28 @@ describe("Gale task memory runtime", () => {
   let contextFile: string
   let oldKnowledgeHome: string | undefined
   let oldMemoryDir: string | undefined
+  let oldHermesMemoryDir: string | undefined
+  let oldHermesRecall: string | undefined
+  let oldHermesBin: string | undefined
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(tmpdir(), "gale-memory-runtime-"))
     oldKnowledgeHome = process.env.GALE_KNOWLEDGE_HOME
     oldMemoryDir = process.env.HKT_MEMORY_DIR
+    oldHermesMemoryDir = process.env.HERMES_HKTMEMORY_DIR
+    oldHermesRecall = process.env.HERMES_HKTMEMORY_RECALL
+    oldHermesBin = process.env.HERMES_HKTMEMORY_BIN
     process.env.GALE_KNOWLEDGE_HOME = path.join(tmpDir, "knowledge")
     delete process.env.HKT_MEMORY_DIR
-    contextFile = path.join(tmpDir, ".context", "galeharness-cli", "current-task.json")
+    delete process.env.HERMES_HKTMEMORY_DIR
+    delete process.env.HERMES_HKTMEMORY_RECALL
+    delete process.env.HERMES_HKTMEMORY_BIN
+    contextFile = path.join(
+      tmpDir,
+      ".context",
+      "galeharness-cli",
+      "current-task.json",
+    )
     await mkdir(path.dirname(contextFile), { recursive: true })
   })
 
@@ -72,6 +87,14 @@ describe("Gale task memory runtime", () => {
     else process.env.GALE_KNOWLEDGE_HOME = oldKnowledgeHome
     if (oldMemoryDir === undefined) delete process.env.HKT_MEMORY_DIR
     else process.env.HKT_MEMORY_DIR = oldMemoryDir
+    if (oldHermesMemoryDir === undefined)
+      delete process.env.HERMES_HKTMEMORY_DIR
+    else process.env.HERMES_HKTMEMORY_DIR = oldHermesMemoryDir
+    if (oldHermesRecall === undefined)
+      delete process.env.HERMES_HKTMEMORY_RECALL
+    else process.env.HERMES_HKTMEMORY_RECALL = oldHermesRecall
+    if (oldHermesBin === undefined) delete process.env.HERMES_HKTMEMORY_BIN
+    else process.env.HERMES_HKTMEMORY_BIN = oldHermesBin
     await rm(tmpDir, { recursive: true, force: true })
   })
 
@@ -105,7 +128,13 @@ describe("Gale task memory runtime", () => {
     expect(envelope.project).toBe("HKTMemory")
     expect(envelope.branch).toBe("feature/task-memory")
     expect(envelope.extensions.gale).toEqual({
-      capture_policy: ["failed_attempt", "root_cause", "verification_result", "handoff_state", "next_action"],
+      capture_policy: [
+        "failed_attempt",
+        "root_cause",
+        "verification_result",
+        "handoff_state",
+        "next_action",
+      ],
       lineage_hints: { source: "current-task" },
     })
   })
@@ -124,7 +153,13 @@ describe("Gale task memory runtime", () => {
 
     expect(envelope.task_id).toBe("branch:hktmemory:feature-task-memory")
     expect(envelope.extensions.gale).toEqual({
-      capture_policy: ["failed_attempt", "root_cause", "verification_result", "handoff_state", "next_action"],
+      capture_policy: [
+        "failed_attempt",
+        "root_cause",
+        "verification_result",
+        "handoff_state",
+        "next_action",
+      ],
       lineage_hints: { source: "branch" },
     })
   })
@@ -149,14 +184,26 @@ describe("Gale task memory runtime", () => {
     expect(result.recall.success).toBe(true)
     expect(client.recallEnvelope?.schema_version).toBe("gale-task-memory.v1")
     expect(client.recallEnvelope?.artifact_type).toBe("debug_session")
-    expect(result.recall.diagnostics?.memory_dir).toBe(path.join(tmpDir, "knowledge", "HKTMemory", "hkt-memory"))
+    expect(result.recall.diagnostics?.memory_dir).toBe(
+      path.join(tmpDir, "knowledge", "HKTMemory", "hkt-memory"),
+    )
     expect(existsSync(path.join(tmpDir, "memory"))).toBe(false)
   })
 
   test("start migrates legacy local memory before recall", async () => {
-    await mkdir(path.join(tmpDir, "memory", "L2-Full", "daily"), { recursive: true })
-    await writeFile(path.join(tmpDir, "memory", "L2-Full", "daily", "legacy.md"), "legacy\n", "utf8")
-    await writeFile(path.join(tmpDir, "memory", "vector_store.db"), "db", "utf8")
+    await mkdir(path.join(tmpDir, "memory", "L2-Full", "daily"), {
+      recursive: true,
+    })
+    await writeFile(
+      path.join(tmpDir, "memory", "L2-Full", "daily", "legacy.md"),
+      "legacy\n",
+      "utf8",
+    )
+    await writeFile(
+      path.join(tmpDir, "memory", "vector_store.db"),
+      "db",
+      "utf8",
+    )
     const client = new FakeHktClient()
 
     const result = await startTaskMemory(
@@ -173,9 +220,13 @@ describe("Gale task memory runtime", () => {
 
     const memoryDir = path.join(tmpDir, "knowledge", "HKTMemory", "hkt-memory")
     expect(result.recall.diagnostics?.status).toBe("completed")
-    expect(existsSync(path.join(memoryDir, "L2-Full", "daily", "legacy.md"))).toBe(true)
+    expect(
+      existsSync(path.join(memoryDir, "L2-Full", "daily", "legacy.md")),
+    ).toBe(true)
     expect(existsSync(path.join(memoryDir, "vector_store.db"))).toBe(false)
-    expect(existsSync(path.join(tmpDir, "memory", "L2-Full", "daily", "legacy.md"))).toBe(true)
+    expect(
+      existsSync(path.join(tmpDir, "memory", "L2-Full", "daily", "legacy.md")),
+    ).toBe(true)
   })
 
   test("capture sends structured events instead of raw store content", async () => {
@@ -199,7 +250,9 @@ describe("Gale task memory runtime", () => {
 
     expect(result.capture.success).toBe(true)
     expect(client.captureEvent?.event_type).toBe("failed_attempt")
-    expect(client.captureEvent?.summary).toBe("Re-running the same test still fails")
+    expect(client.captureEvent?.summary).toBe(
+      "Re-running the same test still fails",
+    )
     expect(client.captureEvent?.payload).toEqual({ hypothesis: "cache issue" })
   })
 
@@ -269,9 +322,15 @@ describe("Gale task memory runtime", () => {
   })
 
   test("missing hkt-memory binary degrades to skipped result", async () => {
-    const client = new HktClient({ binary: "__definitely_missing_hkt_memory__", cwd: tmpDir, timeoutMs: 50 })
+    const client = new HktClient({
+      binary: "__definitely_missing_hkt_memory__",
+      cwd: tmpDir,
+      timeoutMs: 50,
+    })
 
-    const result = await client.taskRecall({ schema_version: "gale-task-memory.v1" })
+    const result = await client.taskRecall({
+      schema_version: "gale-task-memory.v1",
+    })
 
     expect(result.success).toBe(false)
     expect(result.skipped).toBe(true)
@@ -279,7 +338,9 @@ describe("Gale task memory runtime", () => {
   })
 
   test("HktClient passes HKT_MEMORY_DIR to child process", async () => {
-    const hktTmpDir = await mkdtemp(path.join(tmpdir(), "gale-memory-hkt-client-"))
+    const hktTmpDir = await mkdtemp(
+      path.join(tmpdir(), "gale-memory-hkt-client-"),
+    )
     try {
       const script = path.join(hktTmpDir, "fake-hkt")
       const memoryDir = path.join(hktTmpDir, "custom-memory")
@@ -289,12 +350,118 @@ describe("Gale task memory runtime", () => {
         "utf8",
       )
       await chmod(script, 0o755)
-      const client = new HktClient({ binary: script, cwd: hktTmpDir, timeoutMs: 10000, memoryDir })
+      const client = new HktClient({
+        binary: script,
+        cwd: hktTmpDir,
+        timeoutMs: 10000,
+        memoryDir,
+      })
 
-      const result = await client.taskRecall({ schema_version: "gale-task-memory.v1" })
+      const result = await client.taskRecall({
+        schema_version: "gale-task-memory.v1",
+      })
 
       expect(result.success).toBe(true)
       expect(result.diagnostics?.child_memory_dir).toBe(memoryDir)
+    } finally {
+      await rm(hktTmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test("HktClient prefers hermes-hktmemory provider recall when configured", async () => {
+    const hktTmpDir = await mkdtemp(
+      path.join(tmpdir(), "gale-memory-provider-"),
+    )
+    try {
+      const providerScript = path.join(hktTmpDir, "fake-hermes-hktmemory")
+      const hktScript = path.join(hktTmpDir, "fake-hkt")
+      const providerMemoryDir = path.join(hktTmpDir, "provider-memory")
+      await writeFile(
+        providerScript,
+        `#!/usr/bin/env node
+const args = process.argv.slice(2)
+console.log(JSON.stringify({
+  items: [{ content: "provider memory hit", query: args[args.indexOf("-q") + 1], dir: process.env.HERMES_HKTMEMORY_DIR }]
+}))
+`,
+        "utf8",
+      )
+      await writeFile(
+        hktScript,
+        "#!/usr/bin/env node\nconsole.log(JSON.stringify({ success: true, diagnostics: { backend: 'fallback' }, items: [{ content: 'fallback' }] }))\n",
+        "utf8",
+      )
+      await chmod(providerScript, 0o755)
+      await chmod(hktScript, 0o755)
+      const client = new HktClient({
+        binary: hktScript,
+        providerBinary: providerScript,
+        cwd: hktTmpDir,
+        timeoutMs: 10000,
+        providerMemoryDir,
+      })
+
+      const result = await client.taskRecall(
+        {
+          schema_version: "gale-task-memory.v1",
+          input_summary: "resume failing test",
+        },
+        3,
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.diagnostics?.backend).toBe("provider_vector")
+      expect(result.diagnostics?.hermes_hktmemory_dir).toBe(providerMemoryDir)
+      expect(result.diagnostics?.provider_vector_query).toBe(
+        "resume failing test",
+      )
+      expect(result.injectable_markdown).toContain("provider memory hit")
+      expect(result.items?.[0]).toMatchObject({
+        content: "provider memory hit",
+        query: "resume failing test",
+        dir: providerMemoryDir,
+      })
+    } finally {
+      await rm(hktTmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test("HktClient falls back to hkt-memory task-recall when provider recall is empty", async () => {
+    const hktTmpDir = await mkdtemp(
+      path.join(tmpdir(), "gale-memory-provider-fallback-"),
+    )
+    try {
+      const providerScript = path.join(hktTmpDir, "fake-hermes-hktmemory")
+      const hktScript = path.join(hktTmpDir, "fake-hkt")
+      await writeFile(
+        providerScript,
+        "#!/usr/bin/env node\nprocess.exit(0)\n",
+        "utf8",
+      )
+      await writeFile(
+        hktScript,
+        "#!/usr/bin/env node\nconsole.log(JSON.stringify({ success: true, injectable_markdown: 'fallback markdown', items: [{ content: 'fallback' }], diagnostics: { backend: 'hkt_task_recall' } }))\n",
+        "utf8",
+      )
+      await chmod(providerScript, 0o755)
+      await chmod(hktScript, 0o755)
+      const client = new HktClient({
+        binary: hktScript,
+        providerBinary: providerScript,
+        cwd: hktTmpDir,
+        timeoutMs: 10000,
+        providerMemoryDir: path.join(hktTmpDir, "provider-memory"),
+      })
+
+      const result = await client.taskRecall({
+        schema_version: "gale-task-memory.v1",
+        input_summary: "resume failing test",
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.diagnostics?.backend).toBe("hkt_task_recall")
+      expect(result.injectable_markdown).toBe("fallback markdown")
+      expect(result.items?.[0]).toEqual({ content: "fallback" })
     } finally {
       await rm(hktTmpDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
Closes #82.

## Summary
- Add optional provider-vector recall before the existing `hkt-memory task-recall` path.
- Activate provider recall only when `HERMES_HKTMEMORY_DIR`, `HERMES_HKTMEMORY_RECALL`, or explicit `HktClient` options are configured.
- Preserve existing `hkt-memory` fallback for unavailable/empty provider results.
- Add regression coverage for provider preference and fallback behavior.

## Validation
- `bun test tests/gale-memory-runtime.test.ts`
- `bun run build:gale-memory`
- `git diff --check`

## Notes
- This is the downstream GaleHarnessCodingCLI integration follow-up to `hktmemory-provider-hermes#4` / PR #5.
