### PR TITLE
feat(knowledge): promote dual-write knowledge docs

### DIFF
--- a/cmd/gale-knowledge/index.ts
+++ b/cmd/gale-knowledge/index.ts
@@ -18,11 +18,12 @@ import {
   resolveKnowledgePath,
   extractProjectName,
 } from "../../src/knowledge/home.js"
-import { isValidDocType } from "../../src/knowledge/types.js"
+import { isValidDocType, VALID_DOC_TYPES } from "../../src/knowledge/types.js"
 import initCommand from "./init.js"
 import commitCommand from "./git-ops.js"
 import setupCiCommand from "./ci-setup.js"
 import rebuildIndexCommand from "./rebuild-index.js"
+import syncCommand from "./sync.js"
 
 // ---------------------------------------------------------------------------
 // Subcommands
@@ -47,7 +48,7 @@ const resolvePath = defineCommand({
   args: {
     type: {
       type: "string",
-      description: "Document type (brainstorms | plans | solutions)",
+      description: `Document type (${VALID_DOC_TYPES.join(" | ")})`,
       required: true,
     },
     project: {
@@ -64,7 +65,7 @@ const resolvePath = defineCommand({
     const type = args.type as string
     if (!isValidDocType(type)) {
       process.stderr.write(
-        "Error: --type must be one of: brainstorms, plans, solutions\n",
+        `Error: --type must be one of: ${VALID_DOC_TYPES.join(", ")}\n`,
       )
       process.exit(1)
       return
@@ -113,6 +114,7 @@ const main = defineCommand({
     commit: () => commitCommand,
     "rebuild-index": () => rebuildIndexCommand,
     "setup-ci": () => setupCiCommand,
+    sync: () => syncCommand,
   },
   run: async (ctx) => {
     const hasSubCommand = ctx.rawArgs.some((arg) => !arg.startsWith("-"))

--- a/cmd/gale-knowledge/sync.ts
+++ b/cmd/gale-knowledge/sync.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * gale-knowledge sync 子命令
+ *
+ * 在全局知识仓库和项目本地 docs/ 之间单向同步缺失的文件。
+ */
+
+import { defineCommand } from "citty"
+import { existsSync, mkdirSync, readdirSync, copyFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { extractProjectName, resolveKnowledgePath } from "../../src/knowledge/home.js"
+import { isValidDocType, VALID_DOC_TYPES } from "../../src/knowledge/types.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SyncDirection = "global-to-project" | "project-to-global"
+
+interface SyncItem {
+  sourcePath: string
+  targetPath: string
+  filename: string
+  type: string
+}
+
+// ---------------------------------------------------------------------------
+// Sync logic
+// ---------------------------------------------------------------------------
+
+function listMarkdownFiles(dir: string, relativeDir = ""): string[] {
+  if (!existsSync(dir)) {
+    return []
+  }
+  try {
+    const files: string[] = []
+    for (const name of readdirSync(join(dir, relativeDir))) {
+      if (name.startsWith(".")) {
+        continue
+      }
+
+      const relativePath = join(relativeDir, name)
+      const absolutePath = join(dir, relativePath)
+      try {
+        const stat = statSync(absolutePath)
+        if (stat.isDirectory()) {
+          files.push(...listMarkdownFiles(dir, relativePath))
+        } else if (stat.isFile() && name.endsWith(".md")) {
+          files.push(relativePath)
+        }
+      } catch {
+        // Ignore unreadable entries and keep syncing the rest.
+      }
+    }
+    return files
+  } catch {
+    return []
+  }
+}
+
+function collectSyncItems(
+  direction: SyncDirection,
+  projectName: string,
+  cwd: string,
+  typeFilter?: string,
+): SyncItem[] {
+  const items: SyncItem[] = []
+  const types = typeFilter ? [typeFilter] : (VALID_DOC_TYPES as readonly string[])
+
+  for (const type of types) {
+    let sourceDir: string
+    let targetDir: string
+
+    if (direction === "global-to-project") {
+      const resolved = resolveKnowledgePath({ type: type as import("../../src/knowledge/types.js").KnowledgeDocType, projectName })
+      sourceDir = resolved.docDir
+      targetDir = join(cwd, "docs", type)
+    } else {
+      const resolved = resolveKnowledgePath({ type: type as import("../../src/knowledge/types.js").KnowledgeDocType, projectName })
+      sourceDir = join(cwd, "docs", type)
+      targetDir = resolved.docDir
+    }
+
+    const files = listMarkdownFiles(sourceDir)
+    for (const filename of files) {
+      const targetPath = join(targetDir, filename)
+      if (!existsSync(targetPath)) {
+        items.push({
+          sourcePath: join(sourceDir, filename),
+          targetPath,
+          filename,
+          type,
+        })
+      }
+    }
+  }
+
+  return items
+}
+
+function executeSync(items: SyncItem[], dryRun: boolean): { copied: number; skipped: number } {
+  let copied = 0
+  let skipped = 0
+
+  for (const item of items) {
+    if (dryRun) {
+      process.stdout.write(`[dry-run] Would copy: ${item.sourcePath} -> ${item.targetPath}\n`)
+      copied++
+      continue
+    }
+
+    try {
+      mkdirSync(join(item.targetPath, ".."), { recursive: true })
+      copyFileSync(item.sourcePath, item.targetPath)
+      process.stdout.write(`Copied: ${item.sourcePath} -> ${item.targetPath}\n`)
+      copied++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write(`Skipped (error): ${item.filename} — ${msg}\n`)
+      skipped++
+    }
+  }
+
+  return { copied, skipped }
+}
+
+// ---------------------------------------------------------------------------
+// Command definition
+// ---------------------------------------------------------------------------
+
+const syncCommand = defineCommand({
+  meta: {
+    name: "sync",
+    description: "Sync knowledge documents between global repo and project docs/",
+  },
+  args: {
+    direction: {
+      type: "string",
+      description: "Sync direction: global-to-project (default) or project-to-global",
+      required: false,
+      default: "global-to-project",
+    },
+    type: {
+      type: "string",
+      description: "Document type to sync (omit to sync all types)",
+      required: false,
+    },
+    "dry-run": {
+      type: "boolean",
+      description: "List what would be copied without writing",
+      required: false,
+    },
+  },
+  run: async ({ args }) => {
+    const direction = args.direction as SyncDirection
+    if (direction !== "global-to-project" && direction !== "project-to-global") {
+      process.stderr.write(
+        `Error: --direction must be one of: global-to-project, project-to-global\n`,
+      )
+      process.exit(1)
+      return
+    }
+
+    const typeFilter = args.type as string | undefined
+    if (typeFilter && !isValidDocType(typeFilter)) {
+      process.stderr.write(
+        `Error: --type must be one of: ${VALID_DOC_TYPES.join(", ")}\n`,
+      )
+      process.exit(1)
+      return
+    }
+
+    const dryRun = args["dry-run"] as boolean
+    const cwd = process.cwd()
+    const projectName = extractProjectName(cwd)
+
+    const items = collectSyncItems(direction, projectName, cwd, typeFilter)
+
+    if (items.length === 0) {
+      process.stdout.write(
+        `No missing files to sync (${direction}${typeFilter ? `, type=${typeFilter}` : ""}).\n`,
+      )
+      process.exit(0)
+      return
+    }
+
+    const { copied, skipped } = executeSync(items, dryRun)
+
+    const summary = dryRun
+      ? `[dry-run] ${copied} file(s) would be copied, ${skipped} skipped.\n`
+      : `Sync complete: ${copied} file(s) copied, ${skipped} skipped.\n`
+
+    process.stdout.write(summary)
+
+    if (skipped > 0) {
+      process.exit(1)
+    }
+  },
+})
+
+export default syncCommand

--- a/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-brainstorm/SKILL.md
@@ -329,6 +329,7 @@ Before writing the output document, resolve the target directory:
 
 1. Run `gale-knowledge resolve-path --type brainstorms` to get the target directory path (the command outputs a plain path string). If the command fails or `gale-knowledge` is not available, fall back to `docs/brainstorms`.
 2. Write the document to `<resolved-path>/<filename>.md`.
+3. Also write a copy to `docs/brainstorms/<filename>.md` (dual-write). If this secondary write fails, log a warning but do not fail the workflow.
 
 <!-- /HKT-PATCH:knowledge-write-path -->
 

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -273,13 +273,14 @@ The orchestrating agent (main conversation) performs these steps:
 Before writing the solution document, resolve the target directory:
 
 1. Run `gale-knowledge resolve-path --type solutions` to get the target directory path (the command outputs a plain path string). If the command fails or `gale-knowledge` is not available, fall back to `docs/solutions`.
-2. Use `<resolved-path>/[category]/` as the target directory for the solution document instead of the hardcoded `docs/solutions/[category]/` path.
+2. Use `<resolved-path>/[category]/` as the primary target directory for the solution document.
+3. Also write a copy to `docs/solutions/[category]/<filename>.md` (dual-write). If this secondary write fails, log a warning but do not fail the workflow.
 
 <!-- /HKT-PATCH:knowledge-write-path -->
 
 5. Validate YAML frontmatter against `references/schema.yaml`
-6. Create directory if needed: `mkdir -p docs/solutions/[category]/`
-7. Write the file: either the updated existing doc or the new `docs/solutions/[category]/[filename].md`
+6. Create directories if needed for both primary (`<resolved-path>/[category]/`) and secondary (`docs/solutions/[category]/`) paths.
+7. Write the file to the primary path (`<resolved-path>/[category]/[filename].md`) and the secondary path (`docs/solutions/[category]/[filename].md`).
 8. **Run `python3 scripts/validate-frontmatter.py <output-path>`** to catch silent-corruption parser-safety issues that the prose rules miss: malformed `---` delimiter lines, unquoted ` #` in scalar values (silent comment truncation), and unquoted `: ` in scalar values (silent mapping confusion). Exit 0 means the doc is parser-safe; exit 1 means the script's stderr names the offending field(s) and what to fix — quote the value(s), re-write the doc, and re-run until exit 0. Do not declare success while validation fails. The script does not enforce schema rules and does not flag YAML reserved-indicator characters (those produce loud parser errors downstream rather than silent corruption — out of scope). Uses Python 3 stdlib only (no PyYAML or other deps).
 
 When creating a new doc, preserve the section order from `assets/resolution-template.md` unless the user explicitly asks for a different structure.

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -63,7 +63,7 @@ Before any other action, log the skill start event so this execution appears on 
 
 #### 0.1 Check for Recent Ideation Work
 
-Look in `docs/ideation/` for ideation documents created within the last 30 days.
+Look in `docs/ideation/` and the resolved global knowledge path (`gale-knowledge resolve-path --type ideation`) for ideation documents created within the last 30 days.
 
 Treat a prior ideation doc as relevant when:
 - the topic matches the requested focus
@@ -281,10 +281,21 @@ After all sub-agents return:
 
 After merging and synthesis, read `references/post-ideation-workflow.md` for the adversarial filtering rubric, presentation format, artifact template, handoff options, and quality bar. Do not load this file before Phase 2 agent dispatch completes.
 
+<!-- HKT-PATCH:knowledge-write-path -->
+### Knowledge Repository Write Path
+
+Before writing the ideation artifact, resolve the target directory:
+
+1. Run `gale-knowledge resolve-path --type ideation` to get the target directory path. If the command fails or `gale-knowledge` is not available, fall back to `docs/ideation`.
+2. Write the document to `<resolved-path>/<filename>.md`.
+3. Also write a copy to `docs/ideation/<filename>.md` (dual-write). If this secondary write fails, log a warning but do not fail the workflow.
+
+<!-- /HKT-PATCH:knowledge-write-path -->
+
 <!-- HKT-PATCH:phase-2.5 -->
 ### Phase 2.5: HKTMemory Store
 
-After the ideation artifact is written to `docs/ideation/`:
+After the ideation artifact is written to the resolved knowledge path:
 
 1. Read back the full content of the ideation document
 2. Extract the title and key themes from the frontmatter/content
@@ -302,6 +313,17 @@ After the ideation artifact is written to `docs/ideation/`:
 5. On error, proceed silently — storage is supplementary
 
 **Note:** This enables future ideation sessions to discover and build upon these ideas through Phase 0.5's retrieve step.
+
+<!-- HKT-PATCH:knowledge-commit -->
+### Knowledge Repository Commit
+
+After the ideation document is written:
+
+1. Run `gale-knowledge extract-project` to get the project name. If the command fails or is not available, use the current directory basename as the project name instead.
+2. Run `gale-knowledge commit --project "<project-name>" --type ideation --title "<document-title>"` to commit the knowledge document. If this command fails, log the error but continue — the document has already been written to disk.
+3. If `gale-knowledge` is not on PATH, skip both steps and continue — this must never block the skill.
+
+<!-- /HKT-PATCH:knowledge-commit -->
 
 <!-- HKT-PATCH:gale-task-end -->
 After the ideation workflow is fully complete, log the completion event:

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -885,6 +885,7 @@ Before writing the plan file, resolve the target directory:
 
 1. Run `gale-knowledge resolve-path --type plans` to get the target directory path (the command outputs a plain path string). If the command fails or `gale-knowledge` is not available, fall back to `docs/plans`.
 2. Write the plan document to `<resolved-path>/<filename>.md` instead of the hardcoded `docs/plans/` path.
+3. Also write a copy to `docs/plans/<filename>.md` (dual-write). If this secondary write fails, log a warning but do not fail the workflow.
 
 <!-- /HKT-PATCH:knowledge-write-path -->
 

--- a/src/knowledge/home.ts
+++ b/src/knowledge/home.ts
@@ -139,7 +139,7 @@ export function extractProjectName(cwd?: string): string {
  * 如果未提供 projectName，将从当前目录的 git remote 自动提取。
  *
  * @param options - 解析选项
- * @param options.type - 文档类型 (brainstorms | plans | solutions)
+ * @param options.type - 文档类型 (brainstorms | plans | solutions | ideation)
  * @param options.projectName - 项目名（可选）
  * @returns 路径解析结果
  */

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -3,10 +3,10 @@
  */
 
 /** 知识文档类型 */
-export type KnowledgeDocType = 'brainstorms' | 'plans' | 'solutions';
+export type KnowledgeDocType = 'brainstorms' | 'plans' | 'solutions' | 'ideation';
 
 /** 有效文档类型列表 */
-export const VALID_DOC_TYPES: readonly KnowledgeDocType[] = ["brainstorms", "plans", "solutions"] as const
+export const VALID_DOC_TYPES: readonly KnowledgeDocType[] = ["brainstorms", "plans", "solutions", "ideation"] as const
 
 /** 类型守卫：判断字符串是否为有效文档类型 */
 export function isValidDocType(type: string): type is KnowledgeDocType {

--- a/src/knowledge/writer.ts
+++ b/src/knowledge/writer.ts
@@ -1,7 +1,8 @@
 /**
  * 知识文档写入器
  *
- * 将 Markdown 文档写入全局知识仓库，写入失败时自动降级到项目本地 docs/ 目录。
+ * 将 Markdown 文档同时写入全局知识仓库（主路径）和项目本地 docs/ 目录（次路径）。
+ * 主路径写入失败时自动降级到项目本地 docs/ 目录。
  */
 
 import { mkdirSync, writeFileSync } from "node:fs"
@@ -30,11 +31,15 @@ export interface WriteKnowledgeDocumentOptions {
 }
 
 export interface WriteResult {
-  /** 最终写入的文件绝对路径 */
+  /** 最终写入的文件绝对路径（向后兼容） */
   path: string
+  /** 主路径（全局知识仓库） */
+  primaryPath: string
+  /** 次路径（项目 docs/），仅在次路径写入成功时设置 */
+  secondaryPath?: string
   /** 是否使用了 fallback（写入项目本地 docs/） */
   usedFallback: boolean
-  /** 如果 fallback，警告信息 */
+  /** 警告信息 */
   warning?: string
 }
 
@@ -43,7 +48,10 @@ export interface WriteResult {
 // ---------------------------------------------------------------------------
 
 /**
- * 将知识文档写入全局知识仓库，失败时降级到项目本地 docs/ 目录
+ * 将知识文档写入全局知识仓库和项目本地 docs/ 目录
+ *
+ * - 主路径：~/.galeharness/knowledge/<project>/<type>/<filename>（必须成功，失败则抛错或降级）
+ * - 次路径：<cwd>/docs/<type>/<filename>（尽力而为，失败仅警告）
  */
 export function writeKnowledgeDocument(options: WriteKnowledgeDocumentOptions): WriteResult {
   const { type, filename, content, cwd } = options
@@ -72,33 +80,54 @@ export function writeKnowledgeDocument(options: WriteKnowledgeDocumentOptions): 
     throw new Error(`Invalid filename: path traversal detected`)
   }
 
+  // 次路径（项目本地 docs/）
+  const secondaryDir = join(workDir, "docs", type)
+  const secondaryPath = join(secondaryDir, filename)
+
+  let primaryError: Error | null = null
+  let secondaryError: Error | null = null
+
+  // Step 1: 主路径写入
   try {
     mkdirSync(dirname(primaryPath), { recursive: true })
     writeFileSync(primaryPath, finalContent, "utf8")
-    return { path: primaryPath, usedFallback: false }
-  } catch (primaryError) {
-    // 写入失败，降级到项目本地 docs/（保留原始错误信息）
-    const primaryWarning = primaryError instanceof Error ? primaryError.message : String(primaryError)
-
-    // Fallback: <cwd>/docs/<type>/
-    const fallbackDir = join(workDir, "docs", type)
-    const fallbackPath = join(fallbackDir, filename)
-    const warning = `Knowledge repo write failed (${primaryWarning}), falling back to ${fallbackPath}`
-
-    try {
-      mkdirSync(fallbackDir, { recursive: true })
-      writeFileSync(fallbackPath, finalContent, "utf8")
-      console.warn(warning)
-      return { path: fallbackPath, usedFallback: true, warning }
-    } catch (fallbackError) {
-      const fallbackMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
-      // BUG-004: 聚合主路径和 fallback 的错误信息
-      throw new Error(
-        `Failed to write knowledge document to both primary and fallback paths. ` +
-        `Primary error: ${primaryWarning}. Fallback error: ${fallbackMsg}`
-      )
-    }
+  } catch (err) {
+    primaryError = err instanceof Error ? err : new Error(String(err))
   }
+
+  // Step 2: 次路径写入（无论主路径是否成功都尝试）
+  try {
+    mkdirSync(dirname(secondaryPath), { recursive: true })
+    writeFileSync(secondaryPath, finalContent, "utf8")
+  } catch (err) {
+    secondaryError = err instanceof Error ? err : new Error(String(err))
+  }
+
+  // 判断结果
+  if (primaryError === null && secondaryError === null) {
+    // 双写成功
+    return { path: primaryPath, primaryPath, secondaryPath, usedFallback: false }
+  }
+
+  if (primaryError === null && secondaryError !== null) {
+    // 主成功，次失败 -> 仅警告
+    const warning = `Secondary write to docs/ failed: ${secondaryError.message}`
+    console.warn(warning)
+    return { path: primaryPath, primaryPath, usedFallback: false, warning }
+  }
+
+  if (primaryError !== null && secondaryError === null) {
+    // 主失败，次成功 -> fallback 模式（保留向后兼容）
+    const warning = `Knowledge repo write failed (${primaryError.message}), falling back to ${secondaryPath}`
+    console.warn(warning)
+    return { path: secondaryPath, primaryPath, secondaryPath, usedFallback: true, warning }
+  }
+
+  // 双双失败
+  throw new Error(
+    `Failed to write knowledge document to both primary and secondary paths. ` +
+    `Primary error: ${primaryError.message}. Secondary error: ${secondaryError.message}`
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/knowledge-sync.test.ts
+++ b/tests/knowledge-sync.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { promises as fs } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const repoRoot = path.join(import.meta.dir, "..")
+const tempRoots: string[] = []
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
+  tempRoots.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+async function runGaleKnowledge(
+  cwd: string,
+  knowledgeHome: string,
+  args: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", path.join(repoRoot, "cmd", "gale-knowledge", "index.ts"), ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      GALE_KNOWLEDGE_HOME: knowledgeHome,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+describe("gale-knowledge sync", () => {
+  test("recursively syncs nested solution docs while preserving relative paths", async () => {
+    const projectDir = await makeTempDir("gale-knowledge-project-")
+    const knowledgeHome = await makeTempDir("gale-knowledge-home-")
+    const projectName = path.basename(projectDir)
+    const nestedSource = path.join(projectDir, "docs", "solutions", "best-practices", "nested.md")
+    const topLevelSource = path.join(projectDir, "docs", "solutions", "top.md")
+
+    await fs.mkdir(path.dirname(nestedSource), { recursive: true })
+    await fs.writeFile(nestedSource, "# Nested solution\n")
+    await fs.writeFile(topLevelSource, "# Top solution\n")
+
+    const result = await runGaleKnowledge(projectDir, knowledgeHome, [
+      "sync",
+      "--direction",
+      "project-to-global",
+      "--type",
+      "solutions",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toContain("best-practices")
+    expect(await fs.readFile(path.join(knowledgeHome, projectName, "solutions", "best-practices", "nested.md"), "utf8")).toBe("# Nested solution\n")
+    expect(await fs.readFile(path.join(knowledgeHome, projectName, "solutions", "top.md"), "utf8")).toBe("# Top solution\n")
+  })
+})


### PR DESCRIPTION
## Summary
- promote PR #91 dual-write global/project knowledge docs changes onto `main`
- add recursive `gale-knowledge sync` support so nested `docs/solutions/<category>/<file>.md` files are preserved
- include focused nested solution sync coverage plus prior QoderCLI PASS validation

## Validation
- PR #91 CI: `labeler`, `pr-title`, `test`, `test-windows` all pass
- Local: `bun test` — 1362 pass, 3 skip, 0 fail
- Local: `bun run release:validate` — pass
- Local: `git diff --check` — pass
- QoderCLI follow-up review — PASS, blockers: none

## Related
- Promotes #91 after merge into its stale base branch
- Closes #90
