### PR TITLE
feat: add workflow runtime projections

### DIFF
--- a/cmd/gale-task/index.ts
+++ b/cmd/gale-task/index.ts
@@ -1,28 +1,10 @@
-/**
- * gale-task CLI entry point
- *
- * Usage:
- *   gale-task log <event_type> [flags]
- *
- * Supported event types:
- *   skill_started   --skill <name> [--title <title>] [--task-id <id>]
- *   skill_completed --skill <name> [--title <title>] [--task-id <id>]
- *   skill_failed    --skill <name> [--error <msg>]   [--task-id <id>]
- *   memory_linked   --skill <name> [--memory-id <id>] [--memory-title <t>] [--task-id <id>]
- *   pr_linked       --skill <name> [--pr-url <url>] [--pr-number <n>]      [--task-id <id>]
- *
- * Contract: all errors are caught, logged to stderr, process.exit(0).
- * The writer MUST never block skills.
- */
-
 import { spawn } from "node:child_process"
+import { readFile } from "node:fs/promises"
 import path from "path"
-import { appendEvent, type TaskEvent } from "../../src/utils/sqlite-writer.js"
-import { readCurrentTask, writeCurrentTask, CONTEXT_FILE } from "./context.js"
-
-// ---------------------------------------------------------------------------
-// Arg parsing helpers
-// ---------------------------------------------------------------------------
+import { appendEvent, DB_PATH, type TaskEvent } from "../../src/utils/sqlite-writer.js"
+import { projectWorkflowRuns, readWorkflowEventsFromPath, rollupWorkflowRun } from "../../src/workflow/projection.js"
+import { validateWorkflowBundle } from "../../src/workflow/validators.js"
+import { readCurrentTask, writeCurrentTask } from "./context.js"
 
 function parseFlags(argv: string[]): Record<string, string> {
   const flags: Record<string, string> = {}
@@ -46,17 +28,47 @@ function parseFlags(argv: string[]): Record<string, string> {
   return flags
 }
 
-// ---------------------------------------------------------------------------
-// Git helpers
-// ---------------------------------------------------------------------------
+function optionalJson(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    JSON.parse(value)
+    return value
+  } catch {
+    return JSON.stringify({ value })
+  }
+}
+
+function applyWorkflowFlags(event: TaskEvent, flags: Record<string, string>): TaskEvent {
+  const metadata = optionalJson(flags["metadata-json"] ?? flags["metadata"])
+  return {
+    ...event,
+    ...(flags["run-type"] !== undefined ? { run_type: flags["run-type"] } : {}),
+    ...(flags["parent-run-id"] !== undefined ? { parent_run_id: flags["parent-run-id"] } : {}),
+    ...(flags["related-run-id"] !== undefined ? { related_run_id: flags["related-run-id"] } : {}),
+    ...(flags["relation-type"] !== undefined ? { relation_type: flags["relation-type"] } : {}),
+    ...(flags["node-id"] !== undefined ? { node_id: flags["node-id"] } : {}),
+    ...(flags["review-role"] !== undefined ? { review_role: flags["review-role"] } : {}),
+    ...(flags["artifact-id"] !== undefined ? { artifact_id: flags["artifact-id"] } : {}),
+    ...(flags["artifact-type"] !== undefined ? { artifact_type: flags["artifact-type"] } : {}),
+    ...(flags["artifact-path"] !== undefined ? { artifact_path: flags["artifact-path"] } : {}),
+    ...(flags["artifact-url"] !== undefined ? { artifact_url: flags["artifact-url"] } : {}),
+    ...(flags["artifact-title"] !== undefined ? { artifact_title: flags["artifact-title"] } : {}),
+    ...(metadata !== undefined ? { metadata_json: metadata } : {}),
+  }
+}
+
+function isWorkflowEvent(eventType: string): boolean {
+  return eventType.startsWith("workflow_")
+    || eventType.startsWith("review_role_")
+    || eventType === "handoff_artifact_linked"
+    || eventType === "run_relation_linked"
+}
 
 function spawnCapture(cmd: string, args: string[], cwd: string): Promise<string> {
   return new Promise((resolve) => {
     let stdout = ""
-    let stderr = ""
     const proc = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] })
     proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
-    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
     proc.on("error", () => resolve(""))
     proc.on("close", (code) => {
       if (code === 0) resolve(stdout.trim())
@@ -66,10 +78,6 @@ function spawnCapture(cmd: string, args: string[], cwd: string): Promise<string>
 }
 
 function extractRepoName(remoteUrl: string): string {
-  // Handle various URL formats:
-  //   git@github.com:org/repo.git
-  //   https://github.com/org/repo.git
-  //   https://github.com/org/repo
   try {
     const cleaned = remoteUrl.replace(/\.git$/, "")
     const parts = cleaned.split(/[/:]/g)
@@ -82,65 +90,81 @@ function extractRepoName(remoteUrl: string): string {
 
 async function detectProject(): Promise<{ project: string; project_path: string }> {
   const cwd = process.cwd()
-
   const [remoteUrl, toplevel] = await Promise.all([
     spawnCapture("git", ["remote", "get-url", "origin"], cwd),
     spawnCapture("git", ["rev-parse", "--show-toplevel"], cwd),
   ])
-
-  const project = remoteUrl ? extractRepoName(remoteUrl) : path.basename(cwd)
-  const project_path = toplevel || cwd
-
-  return { project, project_path }
+  return {
+    project: remoteUrl ? extractRepoName(remoteUrl) : path.basename(cwd),
+    project_path: toplevel || cwd,
+  }
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
+async function outputProjection(command: string, argv: string[]): Promise<void> {
+  const flags = parseFlags(argv)
+  const dbPath = flags["db"] ?? DB_PATH
+  const runId = flags["run-id"] ?? flags["task-id"]
+  const events = readWorkflowEventsFromPath(dbPath, runId)
+  if (command === "events") {
+    process.stdout.write(JSON.stringify(events, null, 2) + "\n")
+    return
+  }
+  const runs = projectWorkflowRuns(events)
+  if (command === "graph") {
+    process.stdout.write(JSON.stringify(runs, null, 2) + "\n")
+    return
+  }
+  if (!runId) {
+    process.stderr.write("Usage: gale-task rollup --run-id <id> [--db <path>]\n")
+    process.exit(0)
+    return
+  }
+  process.stdout.write(JSON.stringify(rollupWorkflowRun(runId, runs), null, 2) + "\n")
+}
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2)
 
-  // Expect: log <event_type> [flags]
-  if (argv[0] !== "log" || !argv[1]) {
-    process.stderr.write("Usage: gale-task log <event_type> [--skill <name>] [...flags]\n")
-    process.exit(0)
-    return
-  }
-
-  const eventType = argv[1] as string
-  const flags = parseFlags(argv.slice(2))
-
-  const skill = flags["skill"] ?? ""
-  const title = flags["title"]
-  const error = flags["error"]
-  const memoryId = flags["memory-id"]
-  const memoryTitle = flags["memory-title"]
-  const prUrl = flags["pr-url"]
-  const prNumber = flags["pr-number"]
-  const flagTaskId = flags["task-id"]
-
-  const timestamp = new Date().toISOString()
-
   try {
-    if (eventType === "skill_started") {
-      // ------------------------------------------------------------------
-      // skill_started: generate new task_id, detect project, chain parent
-      // ------------------------------------------------------------------
-      const existingTask = await readCurrentTask()
-      const parentTaskId = existingTask?.task_id ?? undefined
+    if (argv[0] === "events" || argv[0] === "graph" || argv[0] === "rollup") {
+      await outputProjection(argv[0], argv.slice(1))
+      return
+    }
 
+    if (argv[0] === "validate") {
+      const flags = parseFlags(argv.slice(1))
+      if (!flags.file) {
+        process.stderr.write("Usage: gale-task validate --file <workflow-bundle.json>\n")
+        process.exit(0)
+        return
+      }
+      const input = JSON.parse(await readFile(flags.file, "utf8")) as Parameters<typeof validateWorkflowBundle>[0]
+      const result = validateWorkflowBundle(input)
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n")
+      process.exit(result.valid ? 0 : 1)
+      return
+    }
+
+    if (argv[0] !== "log" || !argv[1]) {
+      process.stderr.write("Usage: gale-task log <event_type> [--skill <name>] [...flags]\n")
+      process.exit(0)
+      return
+    }
+
+    const eventType = argv[1]
+    const flags = parseFlags(argv.slice(2))
+    const skill = flags["skill"] ?? ""
+    const title = flags["title"]
+    const error = flags["error"]
+    const flagTaskId = flags["task-id"] ?? flags["run-id"]
+    const timestamp = new Date().toISOString()
+
+    if (eventType === "skill_started") {
+      const existingTask = await readCurrentTask()
       const taskId = flagTaskId ?? crypto.randomUUID()
       const { project, project_path } = await detectProject()
-
-      // Write new current-task.json in the working project
-      await writeCurrentTask({
-        task_id: taskId,
-        started_at: timestamp,
-        skill,
-      })
-
-      const event: TaskEvent = {
+      await writeCurrentTask({ task_id: taskId, started_at: timestamp, skill })
+      const event = applyWorkflowFlags({
         task_id: taskId,
         event_type: "skill_started",
         timestamp,
@@ -148,121 +172,45 @@ async function main(): Promise<void> {
         project_path,
         skill,
         ...(title !== undefined ? { title } : {}),
-        ...(parentTaskId !== undefined ? { parent_task_id: parentTaskId } : {}),
-      }
-
+        ...(existingTask?.task_id !== undefined ? { parent_task_id: existingTask.task_id } : {}),
+      }, flags)
       await appendEvent(event)
-
-      // Print the generated task_id to stdout for callers to capture
       process.stdout.write(taskId + "\n")
-
-    } else if (eventType === "skill_completed" || eventType === "skill_failed") {
-      // ------------------------------------------------------------------
-      // skill_completed / skill_failed: resolve task_id from context if needed
-      // ------------------------------------------------------------------
-      const currentTask = await readCurrentTask()
-      const taskId = flagTaskId ?? currentTask?.task_id
-      const resolvedSkill = skill || (currentTask?.skill ?? "")
-
-      if (!taskId) {
-        process.stderr.write("[gale-task] No task_id available for event: " + eventType + "\n")
-        process.exit(0)
-        return
-      }
-
-      const { project, project_path } = await detectProject()
-
-      let event: TaskEvent
-      if (eventType === "skill_completed") {
-        event = {
-          task_id: taskId,
-          event_type: "skill_completed",
-          timestamp,
-          project,
-          project_path,
-          skill: resolvedSkill,
-          ...(title !== undefined ? { title } : {}),
-        }
-      } else {
-        event = {
-          task_id: taskId,
-          event_type: "skill_failed",
-          timestamp,
-          project,
-          project_path,
-          skill: resolvedSkill,
-          ...(error !== undefined ? { error } : {}),
-        }
-      }
-
-      await appendEvent(event)
-
-    } else if (eventType === "memory_linked") {
-      // ------------------------------------------------------------------
-      // memory_linked
-      // ------------------------------------------------------------------
-      const currentTask = await readCurrentTask()
-      const taskId = flagTaskId ?? currentTask?.task_id
-      const resolvedSkill = skill || (currentTask?.skill ?? "")
-
-      if (!taskId) {
-        process.stderr.write("[gale-task] No task_id available for event: memory_linked\n")
-        process.exit(0)
-        return
-      }
-
-      const { project, project_path } = await detectProject()
-
-      const event: TaskEvent = {
-        task_id: taskId,
-        event_type: "memory_linked",
-        timestamp,
-        project,
-        project_path,
-        skill: resolvedSkill,
-        ...(memoryId !== undefined ? { memory_id: memoryId } : {}),
-        ...(memoryTitle !== undefined ? { memory_title: memoryTitle } : {}),
-      }
-
-      await appendEvent(event)
-
-    } else if (eventType === "pr_linked") {
-      // ------------------------------------------------------------------
-      // pr_linked
-      // ------------------------------------------------------------------
-      const currentTask = await readCurrentTask()
-      const taskId = flagTaskId ?? currentTask?.task_id
-      const resolvedSkill = skill || (currentTask?.skill ?? "")
-
-      if (!taskId) {
-        process.stderr.write("[gale-task] No task_id available for event: pr_linked\n")
-        process.exit(0)
-        return
-      }
-
-      const { project, project_path } = await detectProject()
-
-      const event: TaskEvent = {
-        task_id: taskId,
-        event_type: "pr_linked",
-        timestamp,
-        project,
-        project_path,
-        skill: resolvedSkill,
-        ...(prUrl !== undefined ? { pr_url: prUrl } : {}),
-        ...(prNumber !== undefined ? { pr_number: prNumber } : {}),
-      }
-
-      await appendEvent(event)
-
-    } else {
-      process.stderr.write("[gale-task] Unknown event_type: " + eventType + "\n")
-      process.exit(0)
+      return
     }
+
+    if (eventType === "skill_completed" || eventType === "skill_failed" || eventType === "memory_linked" || eventType === "pr_linked" || isWorkflowEvent(eventType)) {
+      const currentTask = await readCurrentTask()
+      const taskId = flagTaskId ?? currentTask?.task_id ?? (isWorkflowEvent(eventType) ? crypto.randomUUID() : undefined)
+      const resolvedSkill = skill || (currentTask?.skill ?? "")
+      if (!taskId) {
+        process.stderr.write(`[gale-task] No task_id available for event: ${eventType}\n`)
+        process.exit(0)
+        return
+      }
+      const { project, project_path } = await detectProject()
+      const base: TaskEvent = {
+        task_id: taskId,
+        event_type: eventType as TaskEvent["event_type"],
+        timestamp,
+        project,
+        project_path,
+        skill: resolvedSkill,
+        ...(title !== undefined ? { title } : {}),
+        ...(error !== undefined ? { error } : {}),
+        ...(flags["memory-id"] !== undefined ? { memory_id: flags["memory-id"] } : {}),
+        ...(flags["memory-title"] !== undefined ? { memory_title: flags["memory-title"] } : {}),
+        ...(flags["pr-url"] !== undefined ? { pr_url: flags["pr-url"] } : {}),
+        ...(flags["pr-number"] !== undefined ? { pr_number: flags["pr-number"] } : {}),
+      }
+      await appendEvent(applyWorkflowFlags(base, flags))
+      return
+    }
+
+    process.stderr.write("[gale-task] Unknown event_type: " + eventType + "\n")
+    process.exit(0)
   } catch (err) {
-    process.stderr.write(
-      "[gale-task] Unexpected error: " + (err instanceof Error ? err.message : String(err)) + "\n",
-    )
+    process.stderr.write("[gale-task] Unexpected error: " + (err instanceof Error ? err.message : String(err)) + "\n")
     process.exit(0)
   }
 }

--- a/cmd/gale-task/index.ts
+++ b/cmd/gale-task/index.ts
@@ -138,10 +138,15 @@ async function main(): Promise<void> {
         process.exit(0)
         return
       }
-      const input = JSON.parse(await readFile(flags.file, "utf8")) as Parameters<typeof validateWorkflowBundle>[0]
-      const result = validateWorkflowBundle(input)
-      process.stdout.write(JSON.stringify(result, null, 2) + "\n")
-      process.exit(result.valid ? 0 : 1)
+      try {
+        const input = JSON.parse(await readFile(flags.file, "utf8")) as Parameters<typeof validateWorkflowBundle>[0]
+        const result = validateWorkflowBundle(input)
+        process.stdout.write(JSON.stringify(result, null, 2) + "\n")
+        process.exit(result.valid ? 0 : 1)
+      } catch (err) {
+        process.stderr.write("[gale-task] validate error: " + (err instanceof Error ? err.message : String(err)) + "\n")
+        process.exit(1)
+      }
       return
     }
 

--- a/docs/workflow-runtime.md
+++ b/docs/workflow-runtime.md
@@ -4,9 +4,9 @@ This runtime surface adds a typed workflow layer over the existing `gale-task` l
 
 ## Schema surfaces
 
-- `WorkflowDagSpec`: minimal DAG with `nodes[].id`, `kind`, `name`, `skill`, `role`, `dependsOn`, `produces`, and `consumes`.
-- `HandoffArtifactContract`: stable handoff artifact pointer with `artifactId`, `runId`, `kind`, `path` or `url`, optional `sha256`, and metadata.
-- `RunRelationSpec`: parent/child/sibling/blocking relation between run ids.
+- `WorkflowDagSpec`: minimal DAG with required `nodes[].id`, `kind`, and `name`; dependency aliases `dependsOn` and `depends_on`; artifact arrays `produces`, `consumes`, `input_artifacts`, and `output_artifacts`; and issue #96 contract fields `type` (`ai`, `script`, `approval`, `handoff`, `pmo`), `trigger_rule`, `context_boundary` (`handoff`, `fresh`, `inherit`), `validators`, `parallel_group`, and `risk_level`.
+- `HandoffArtifactContract`: stable handoff artifact pointer with `artifactId`, `runId`, enum-checked `kind`, `path` or `url`, optional `sha256`, and metadata.
+- `RunRelationSpec`: enum-checked parent/child/sibling/blocking relation between run ids.
 
 Runtime types live in `src/workflow/schema.ts`.
 
@@ -17,7 +17,9 @@ Runtime types live in `src/workflow/schema.ts`.
 1. DAG node identity and required fields.
 2. Dependency integrity and acyclic DAG shape.
 3. Handoff artifact location/checksum shape.
-4. Run relation required fields and self-relation rejection.
+4. Run relation required fields, enum relation type validation, and self-relation rejection.
+
+Unreadable or malformed validation input exits non-zero. Passive runtime logging remains best-effort: `gale-task log` continues to report ledger errors without failing the invoking skill.
 
 CLI usage:
 
@@ -29,7 +31,25 @@ where `workflow-bundle.json` may contain:
 
 ```json
 {
-  "dag": { "id": "gcw-demo", "nodes": [{ "id": "plan", "kind": "skill", "name": "Plan" }] },
+  "dag": {
+    "id": "gcw-demo",
+    "nodes": [
+      {
+        "id": "plan",
+        "kind": "skill",
+        "name": "Plan",
+        "type": "ai",
+        "depends_on": [],
+        "trigger_rule": "all_success",
+        "context_boundary": "inherit",
+        "input_artifacts": [],
+        "output_artifacts": ["plan"],
+        "validators": ["schema"],
+        "parallel_group": "analysis",
+        "risk_level": "medium"
+      }
+    ]
+  },
   "artifacts": [{ "artifactId": "handoff-1", "runId": "run-1", "kind": "handoff", "path": ".context/handoff.md" }],
   "relations": [{ "runId": "run-1", "relatedRunId": "run-2", "relationType": "child" }]
 }

--- a/docs/workflow-runtime.md
+++ b/docs/workflow-runtime.md
@@ -1,0 +1,60 @@
+# Gale workflow runtime MVP
+
+This runtime surface adds a typed workflow layer over the existing `gale-task` ledger. It does not replace `gh:review` or any existing skill: it projects current skill, review, handoff, and relation events into a queryable workflow graph.
+
+## Schema surfaces
+
+- `WorkflowDagSpec`: minimal DAG with `nodes[].id`, `kind`, `name`, `skill`, `role`, `dependsOn`, `produces`, and `consumes`.
+- `HandoffArtifactContract`: stable handoff artifact pointer with `artifactId`, `runId`, `kind`, `path` or `url`, optional `sha256`, and metadata.
+- `RunRelationSpec`: parent/child/sibling/blocking relation between run ids.
+
+Runtime types live in `src/workflow/schema.ts`.
+
+## Validators
+
+`src/workflow/validators.ts` provides deterministic validators for:
+
+1. DAG node identity and required fields.
+2. Dependency integrity and acyclic DAG shape.
+3. Handoff artifact location/checksum shape.
+4. Run relation required fields and self-relation rejection.
+
+CLI usage:
+
+```bash
+gale-task validate --file workflow-bundle.json
+```
+
+where `workflow-bundle.json` may contain:
+
+```json
+{
+  "dag": { "id": "gcw-demo", "nodes": [{ "id": "plan", "kind": "skill", "name": "Plan" }] },
+  "artifacts": [{ "artifactId": "handoff-1", "runId": "run-1", "kind": "handoff", "path": ".context/handoff.md" }],
+  "relations": [{ "runId": "run-1", "relatedRunId": "run-2", "relationType": "child" }]
+}
+```
+
+## Event ledger projection
+
+The SQLite `task_events` table now accepts additive nullable workflow columns (`run_type`, `node_id`, `review_role`, `artifact_*`, relation fields, and `metadata_json`). Existing rows and existing Board-compatible fields remain valid.
+
+Log examples:
+
+```bash
+gale-task log workflow_started --task-id run-1 --run-type compound --title "GCW issue 42"
+gale-task log review_role_started --task-id run-1 --review-role security --node-id review-security
+gale-task log review_role_completed --task-id run-1 --review-role security --node-id review-security
+gale-task log handoff_artifact_linked --task-id run-1 --artifact-id handoff-1 --artifact-type handoff --artifact-path .context/gcw/handoff.md
+gale-task log run_relation_linked --task-id run-1 --related-run-id run-2 --relation-type child
+```
+
+Projection APIs:
+
+```bash
+gale-task events --run-id run-1
+gale-task graph --run-id run-1
+gale-task rollup --run-id run-1
+```
+
+The graph projection explicitly models multi-role `gh:review` output as review-role events/artifacts rather than rebuilding the review workflow.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "gale-harness": "src/index.ts",
     "compound-plugin": "src/index.ts",
     "gale-knowledge": "cmd/gale-knowledge/index.ts",
-    "gale-memory": "cmd/gale-memory/index.ts"
+    "gale-memory": "cmd/gale-memory/index.ts",
+    "gale-task": "cmd/gale-task/index.ts"
   },
   "scripts": {
     "dev": "bun run src/index.ts",

--- a/src/utils/sqlite-writer.ts
+++ b/src/utils/sqlite-writer.ts
@@ -24,6 +24,16 @@ export type EventType =
   | "skill_failed"
   | "memory_linked"
   | "pr_linked"
+  | "workflow_started"
+  | "workflow_completed"
+  | "workflow_failed"
+  | "workflow_node_started"
+  | "workflow_node_completed"
+  | "workflow_node_failed"
+  | "handoff_artifact_linked"
+  | "review_role_started"
+  | "review_role_completed"
+  | "run_relation_linked"
 
 export interface TaskEvent {
   task_id: string
@@ -39,6 +49,18 @@ export interface TaskEvent {
   pr_number?: string | number
   memory_id?: string
   memory_title?: string
+  run_type?: string
+  parent_run_id?: string
+  related_run_id?: string
+  relation_type?: string
+  node_id?: string
+  review_role?: string
+  artifact_id?: string
+  artifact_type?: string
+  artifact_path?: string
+  artifact_url?: string
+  artifact_title?: string
+  metadata_json?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -66,22 +88,60 @@ const CREATE_TABLE_SQL = `
     pr_url TEXT,
     pr_number INTEGER,
     memory_id TEXT,
-    memory_title TEXT
+    memory_title TEXT,
+    run_type TEXT,
+    parent_run_id TEXT,
+    related_run_id TEXT,
+    relation_type TEXT,
+    node_id TEXT,
+    review_role TEXT,
+    artifact_id TEXT,
+    artifact_type TEXT,
+    artifact_path TEXT,
+    artifact_url TEXT,
+    artifact_title TEXT,
+    metadata_json TEXT
   )
 `
 
 const CREATE_INDEX_TASK_ID_SQL = `CREATE INDEX IF NOT EXISTS idx_task_events_task_id ON task_events(task_id)`
 const CREATE_INDEX_TIMESTAMP_SQL = `CREATE INDEX IF NOT EXISTS idx_task_events_timestamp ON task_events(timestamp)`
 
+const EXTRA_COLUMNS: Record<string, string> = {
+  run_type: "TEXT",
+  parent_run_id: "TEXT",
+  related_run_id: "TEXT",
+  relation_type: "TEXT",
+  node_id: "TEXT",
+  review_role: "TEXT",
+  artifact_id: "TEXT",
+  artifact_type: "TEXT",
+  artifact_path: "TEXT",
+  artifact_url: "TEXT",
+  artifact_title: "TEXT",
+  metadata_json: "TEXT",
+}
+
 const INSERT_SQL = `
   INSERT INTO task_events (
     task_id, event_type, timestamp, project, project_path, skill, title,
-    parent_task_id, error, pr_url, pr_number, memory_id, memory_title
+    parent_task_id, error, pr_url, pr_number, memory_id, memory_title,
+    run_type, parent_run_id, related_run_id, relation_type, node_id, review_role,
+    artifact_id, artifact_type, artifact_path, artifact_url, artifact_title, metadata_json
   ) VALUES (
     $task_id, $event_type, $timestamp, $project, $project_path, $skill, $title,
-    $parent_task_id, $error, $pr_url, $pr_number, $memory_id, $memory_title
+    $parent_task_id, $error, $pr_url, $pr_number, $memory_id, $memory_title,
+    $run_type, $parent_run_id, $related_run_id, $relation_type, $node_id, $review_role,
+    $artifact_id, $artifact_type, $artifact_path, $artifact_url, $artifact_title, $metadata_json
   )
 `
+
+function ensureExtraColumns(db: Database): void {
+  const columns = new Set((db.query("PRAGMA table_info(task_events)").all() as Array<{ name: string }>).map((column) => column.name))
+  for (const [name, type] of Object.entries(EXTRA_COLUMNS)) {
+    if (!columns.has(name)) db.run(`ALTER TABLE task_events ADD COLUMN ${name} ${type}`)
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Retry configuration
@@ -119,6 +179,7 @@ export function writeEvent(event: TaskEvent, dbPath: string = DB_PATH): void {
 
       // Ensure schema exists
       db.run(CREATE_TABLE_SQL)
+      ensureExtraColumns(db)
       db.run(CREATE_INDEX_TASK_ID_SQL)
       db.run(CREATE_INDEX_TIMESTAMP_SQL)
 
@@ -138,6 +199,18 @@ export function writeEvent(event: TaskEvent, dbPath: string = DB_PATH): void {
         $pr_number: event.pr_number != null ? Number(event.pr_number) : null,
         $memory_id: event.memory_id ?? null,
         $memory_title: event.memory_title ?? null,
+        $run_type: event.run_type ?? null,
+        $parent_run_id: event.parent_run_id ?? null,
+        $related_run_id: event.related_run_id ?? null,
+        $relation_type: event.relation_type ?? null,
+        $node_id: event.node_id ?? null,
+        $review_role: event.review_role ?? null,
+        $artifact_id: event.artifact_id ?? null,
+        $artifact_type: event.artifact_type ?? null,
+        $artifact_path: event.artifact_path ?? null,
+        $artifact_url: event.artifact_url ?? null,
+        $artifact_title: event.artifact_title ?? null,
+        $metadata_json: event.metadata_json ?? null,
       })
       stmt.finalize()
     } finally {

--- a/src/workflow/projection.ts
+++ b/src/workflow/projection.ts
@@ -1,0 +1,189 @@
+import { Database } from "bun:sqlite"
+import type { TaskEvent } from "../utils/sqlite-writer.js"
+
+export interface WorkflowRunProjection {
+  runId: string
+  title?: string
+  project?: string
+  projectPath?: string
+  skill?: string
+  kind?: string
+  status: "running" | "completed" | "failed" | "unknown"
+  startedAt?: string
+  endedAt?: string
+  parentRunId?: string
+  childRunIds: string[]
+  siblingRunIds: string[]
+  artifacts: WorkflowArtifactProjection[]
+  reviewRoles: WorkflowReviewRoleProjection[]
+  events: TaskEvent[]
+}
+
+export interface WorkflowArtifactProjection {
+  artifactId?: string
+  kind?: string
+  path?: string
+  url?: string
+  title?: string
+  nodeId?: string
+}
+
+export interface WorkflowReviewRoleProjection {
+  role: string
+  nodeId?: string
+  status: "running" | "completed" | "failed" | "unknown"
+  startedAt?: string
+  endedAt?: string
+}
+
+export interface WorkflowRollupProjection {
+  runId: string
+  status: WorkflowRunProjection["status"]
+  totalRuns: number
+  completedRuns: number
+  failedRuns: number
+  runningRuns: number
+  artifactCount: number
+  reviewRoleCount: number
+  children: WorkflowRollupProjection[]
+}
+
+function parseMetadata(event: TaskEvent): Record<string, unknown> {
+  const raw = (event as TaskEvent & { metadata_json?: string }).metadata_json
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {}
+  } catch {
+    return {}
+  }
+}
+
+export function readWorkflowEventsFromPath(dbPath: string, runId?: string): TaskEvent[] {
+  const db = new Database(dbPath, { readonly: true, create: false })
+  try {
+    if (runId) {
+      return db.query("SELECT * FROM task_events WHERE task_id = $runId OR parent_task_id = $runId OR parent_run_id = $runId OR related_run_id = $runId ORDER BY timestamp ASC").all({ $runId: runId }) as TaskEvent[]
+    }
+    return db.query("SELECT * FROM task_events ORDER BY timestamp ASC").all() as TaskEvent[]
+  } finally {
+    db.close()
+  }
+}
+
+export function projectWorkflowRuns(events: TaskEvent[]): WorkflowRunProjection[] {
+  const runs = new Map<string, WorkflowRunProjection>()
+
+  function getRun(runId: string): WorkflowRunProjection {
+    const existing = runs.get(runId)
+    if (existing) return existing
+    const created: WorkflowRunProjection = {
+      runId,
+      status: "unknown",
+      childRunIds: [],
+      siblingRunIds: [],
+      artifacts: [],
+      reviewRoles: [],
+      events: [],
+    }
+    runs.set(runId, created)
+    return created
+  }
+
+  for (const event of events) {
+    const ext = event as TaskEvent & Record<string, string | null | undefined>
+    const run = getRun(event.task_id)
+    run.events.push(event)
+    run.project = run.project ?? event.project
+    run.projectPath = run.projectPath ?? event.project_path
+    run.skill = run.skill ?? event.skill
+    run.title = run.title ?? event.title
+    run.kind = run.kind ?? ext.run_type ?? undefined
+    run.parentRunId = run.parentRunId ?? event.parent_task_id ?? ext.parent_run_id ?? undefined
+
+    if (event.event_type === "skill_started" || event.event_type === "workflow_started") {
+      run.status = "running"
+      run.startedAt = run.startedAt ?? event.timestamp
+    }
+    if (event.event_type === "skill_completed" || event.event_type === "workflow_completed") {
+      run.status = "completed"
+      run.endedAt = event.timestamp
+    }
+    if (event.event_type === "skill_failed" || event.event_type === "workflow_failed") {
+      run.status = "failed"
+      run.endedAt = event.timestamp
+    }
+
+    if (event.event_type === "handoff_artifact_linked" || event.event_type === "memory_linked" || event.event_type === "pr_linked") {
+      const metadata = parseMetadata(event)
+      run.artifacts.push({
+        artifactId: ext.artifact_id ?? event.memory_id ?? event.pr_url ?? undefined,
+        kind: ext.artifact_type ?? (event.event_type === "memory_linked" ? "memory" : event.event_type === "pr_linked" ? "pr" : undefined),
+        path: ext.artifact_path ?? undefined,
+        url: ext.artifact_url ?? event.pr_url ?? undefined,
+        title: ext.artifact_title ?? event.memory_title ?? event.title ?? undefined,
+        nodeId: ext.node_id ?? (typeof metadata.nodeId === "string" ? metadata.nodeId : undefined),
+      })
+    }
+
+    if (event.event_type === "review_role_started" || event.event_type === "review_role_completed") {
+      const role = ext.review_role ?? ext.node_id ?? event.skill ?? "reviewer"
+      let review = run.reviewRoles.find((item) => item.role === role)
+      if (!review) {
+        review = { role, nodeId: ext.node_id ?? undefined, status: "unknown" }
+        run.reviewRoles.push(review)
+      }
+      if (event.event_type === "review_role_started") {
+        review.status = "running"
+        review.startedAt = review.startedAt ?? event.timestamp
+      } else {
+        review.status = "completed"
+        review.endedAt = event.timestamp
+      }
+    }
+
+    if (event.event_type === "run_relation_linked") {
+      const relationType = ext.relation_type
+      const relatedRunId = ext.related_run_id
+      if (relatedRunId && relationType === "child" && !run.childRunIds.includes(relatedRunId)) run.childRunIds.push(relatedRunId)
+      if (relatedRunId && relationType === "sibling" && !run.siblingRunIds.includes(relatedRunId)) run.siblingRunIds.push(relatedRunId)
+      if (relatedRunId && relationType === "parent") getRun(relatedRunId).childRunIds.push(run.runId)
+    }
+  }
+
+  for (const run of runs.values()) {
+    if (run.parentRunId) {
+      const parent = getRun(run.parentRunId)
+      if (!parent.childRunIds.includes(run.runId)) parent.childRunIds.push(run.runId)
+    }
+  }
+
+  return [...runs.values()].sort((a, b) => (a.startedAt ?? "").localeCompare(b.startedAt ?? ""))
+}
+
+export function rollupWorkflowRun(runId: string, runs: WorkflowRunProjection[]): WorkflowRollupProjection {
+  const byId = new Map(runs.map((run) => [run.runId, run]))
+  const seen = new Set<string>()
+
+  function build(id: string): WorkflowRollupProjection {
+    const run = byId.get(id) ?? { runId: id, status: "unknown", childRunIds: [], siblingRunIds: [], artifacts: [], reviewRoles: [], events: [] } as WorkflowRunProjection
+    if (seen.has(id)) {
+      return { runId: id, status: run.status, totalRuns: 0, completedRuns: 0, failedRuns: 0, runningRuns: 0, artifactCount: 0, reviewRoleCount: 0, children: [] }
+    }
+    seen.add(id)
+    const children = run.childRunIds.map(build)
+    return {
+      runId: id,
+      status: run.status,
+      totalRuns: 1 + children.reduce((sum, child) => sum + child.totalRuns, 0),
+      completedRuns: (run.status === "completed" ? 1 : 0) + children.reduce((sum, child) => sum + child.completedRuns, 0),
+      failedRuns: (run.status === "failed" ? 1 : 0) + children.reduce((sum, child) => sum + child.failedRuns, 0),
+      runningRuns: (run.status === "running" ? 1 : 0) + children.reduce((sum, child) => sum + child.runningRuns, 0),
+      artifactCount: run.artifacts.length + children.reduce((sum, child) => sum + child.artifactCount, 0),
+      reviewRoleCount: run.reviewRoles.length + children.reduce((sum, child) => sum + child.reviewRoleCount, 0),
+      children,
+    }
+  }
+
+  return build(runId)
+}

--- a/src/workflow/projection.ts
+++ b/src/workflow/projection.ts
@@ -62,10 +62,38 @@ function parseMetadata(event: TaskEvent): Record<string, unknown> {
 export function readWorkflowEventsFromPath(dbPath: string, runId?: string): TaskEvent[] {
   const db = new Database(dbPath, { readonly: true, create: false })
   try {
-    if (runId) {
-      return db.query("SELECT * FROM task_events WHERE task_id = $runId OR parent_task_id = $runId OR parent_run_id = $runId OR related_run_id = $runId ORDER BY timestamp ASC").all({ $runId: runId }) as TaskEvent[]
+    const events = db.query("SELECT * FROM task_events ORDER BY timestamp ASC").all() as TaskEvent[]
+    if (!runId) return events
+
+    const included = new Set<string>([runId])
+    let changed = true
+    while (changed) {
+      changed = false
+      for (const event of events) {
+        const ext = event as TaskEvent & Record<string, string | null | undefined>
+        const parentId = event.parent_task_id ?? ext.parent_run_id ?? undefined
+        if (parentId && included.has(parentId) && !included.has(event.task_id)) {
+          included.add(event.task_id)
+          changed = true
+        }
+        if (included.has(event.task_id) && ext.relation_type === "child" && ext.related_run_id && !included.has(ext.related_run_id)) {
+          included.add(ext.related_run_id)
+          changed = true
+        }
+        if (included.has(event.task_id) && ext.relation_type === "parent" && ext.related_run_id && !included.has(ext.related_run_id)) {
+          included.add(ext.related_run_id)
+          changed = true
+        }
+      }
     }
-    return db.query("SELECT * FROM task_events ORDER BY timestamp ASC").all() as TaskEvent[]
+
+    return events.filter((event) => {
+      const ext = event as TaskEvent & Record<string, string | null | undefined>
+      return included.has(event.task_id)
+        || (ext.related_run_id !== undefined && included.has(ext.related_run_id))
+        || (event.parent_task_id !== undefined && included.has(event.parent_task_id))
+        || (ext.parent_run_id !== undefined && included.has(ext.parent_run_id))
+    })
   } finally {
     db.close()
   }

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -1,17 +1,38 @@
 export type WorkflowRunKind = "compound" | "skill" | "review" | "handoff" | "custom"
 export type WorkflowNodeKind = "skill" | "agent" | "review_role" | "handoff" | "validator" | "manual" | "custom"
+export type WorkflowContractNodeType = "ai" | "script" | "approval" | "handoff" | "pmo"
+export type WorkflowTriggerRule = "all_success" | "all_done" | "one_success" | "none_failed"
+export type WorkflowContextBoundary = "handoff" | "fresh" | "inherit"
+export type WorkflowRiskLevel = "low" | "medium" | "high" | "critical"
 export type RunRelationType = "parent" | "child" | "sibling" | "blocks" | "relates_to"
 export type ArtifactKind = "handoff" | "review_findings" | "plan" | "patch" | "pr" | "memory" | "log" | "custom"
+
+export const WORKFLOW_NODE_KINDS = ["skill", "agent", "review_role", "handoff", "validator", "manual", "custom"] as const
+export const WORKFLOW_CONTRACT_NODE_TYPES = ["ai", "script", "approval", "handoff", "pmo"] as const
+export const WORKFLOW_TRIGGER_RULES = ["all_success", "all_done", "one_success", "none_failed"] as const
+export const WORKFLOW_CONTEXT_BOUNDARIES = ["handoff", "fresh", "inherit"] as const
+export const WORKFLOW_RISK_LEVELS = ["low", "medium", "high", "critical"] as const
+export const RUN_RELATION_TYPES = ["parent", "child", "sibling", "blocks", "relates_to"] as const
+export const ARTIFACT_KINDS = ["handoff", "review_findings", "plan", "patch", "pr", "memory", "log", "custom"] as const
 
 export interface WorkflowDagNodeSpec {
   id: string
   kind: WorkflowNodeKind
   name: string
+  type?: WorkflowContractNodeType
   skill?: string
   role?: string
   dependsOn?: string[]
+  depends_on?: string[]
   produces?: ArtifactKind[]
   consumes?: ArtifactKind[]
+  trigger_rule?: WorkflowTriggerRule
+  context_boundary?: WorkflowContextBoundary
+  input_artifacts?: ArtifactKind[]
+  output_artifacts?: ArtifactKind[]
+  validators?: string[]
+  parallel_group?: string
+  risk_level?: WorkflowRiskLevel
   metadata?: Record<string, unknown>
 }
 

--- a/src/workflow/schema.ts
+++ b/src/workflow/schema.ts
@@ -1,0 +1,72 @@
+export type WorkflowRunKind = "compound" | "skill" | "review" | "handoff" | "custom"
+export type WorkflowNodeKind = "skill" | "agent" | "review_role" | "handoff" | "validator" | "manual" | "custom"
+export type RunRelationType = "parent" | "child" | "sibling" | "blocks" | "relates_to"
+export type ArtifactKind = "handoff" | "review_findings" | "plan" | "patch" | "pr" | "memory" | "log" | "custom"
+
+export interface WorkflowDagNodeSpec {
+  id: string
+  kind: WorkflowNodeKind
+  name: string
+  skill?: string
+  role?: string
+  dependsOn?: string[]
+  produces?: ArtifactKind[]
+  consumes?: ArtifactKind[]
+  metadata?: Record<string, unknown>
+}
+
+export interface WorkflowDagSpec {
+  id: string
+  title?: string
+  kind?: WorkflowRunKind
+  version?: string
+  nodes: WorkflowDagNodeSpec[]
+  metadata?: Record<string, unknown>
+}
+
+export interface HandoffArtifactContract {
+  artifactId: string
+  runId: string
+  producerNodeId?: string
+  kind: ArtifactKind
+  path?: string
+  url?: string
+  title?: string
+  summary?: string
+  sha256?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface RunRelationSpec {
+  runId: string
+  relatedRunId: string
+  relationType: RunRelationType
+  reason?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface WorkflowValidationIssue {
+  code: string
+  message: string
+  path?: string
+}
+
+export interface WorkflowValidationResult {
+  valid: boolean
+  issues: WorkflowValidationIssue[]
+}
+
+export const WORKFLOW_EVENT_TYPES = [
+  "workflow_started",
+  "workflow_completed",
+  "workflow_failed",
+  "workflow_node_started",
+  "workflow_node_completed",
+  "workflow_node_failed",
+  "handoff_artifact_linked",
+  "review_role_started",
+  "review_role_completed",
+  "run_relation_linked",
+] as const
+
+export type WorkflowEventType = (typeof WORKFLOW_EVENT_TYPES)[number]

--- a/src/workflow/validators.ts
+++ b/src/workflow/validators.ts
@@ -1,0 +1,109 @@
+import type {
+  HandoffArtifactContract,
+  RunRelationSpec,
+  WorkflowDagSpec,
+  WorkflowValidationIssue,
+  WorkflowValidationResult,
+} from "./schema.js"
+
+function issue(code: string, message: string, path?: string): WorkflowValidationIssue {
+  return { code, message, ...(path ? { path } : {}) }
+}
+
+export function validateWorkflowDag(spec: WorkflowDagSpec): WorkflowValidationResult {
+  const issues: WorkflowValidationIssue[] = []
+
+  if (!spec.id || typeof spec.id !== "string") {
+    issues.push(issue("dag.id.required", "Workflow DAG id is required", "id"))
+  }
+  if (!Array.isArray(spec.nodes) || spec.nodes.length === 0) {
+    issues.push(issue("dag.nodes.required", "Workflow DAG must include at least one node", "nodes"))
+    return { valid: issues.length === 0, issues }
+  }
+
+  const ids = new Set<string>()
+  const duplicateIds = new Set<string>()
+  for (const [index, node] of spec.nodes.entries()) {
+    const path = `nodes[${index}]`
+    if (!node.id) issues.push(issue("node.id.required", "Node id is required", `${path}.id`))
+    if (!node.name) issues.push(issue("node.name.required", "Node name is required", `${path}.name`))
+    if (node.id && ids.has(node.id)) duplicateIds.add(node.id)
+    if (node.id) ids.add(node.id)
+  }
+  for (const id of duplicateIds) {
+    issues.push(issue("node.id.duplicate", `Duplicate node id: ${id}`, "nodes"))
+  }
+
+  for (const node of spec.nodes) {
+    for (const dep of node.dependsOn ?? []) {
+      if (!ids.has(dep)) {
+        issues.push(issue("node.dependency.missing", `Node ${node.id} depends on missing node ${dep}`, `nodes.${node.id}.dependsOn`))
+      }
+      if (dep === node.id) {
+        issues.push(issue("node.dependency.self", `Node ${node.id} cannot depend on itself`, `nodes.${node.id}.dependsOn`))
+      }
+    }
+  }
+
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const byId = new Map(spec.nodes.map((node) => [node.id, node]))
+  const stack: string[] = []
+
+  function visit(id: string): void {
+    if (visited.has(id) || !byId.has(id)) return
+    if (visiting.has(id)) {
+      const cycleStart = stack.indexOf(id)
+      const cycle = stack.slice(cycleStart).concat(id).join(" -> ")
+      issues.push(issue("dag.cycle", `Workflow DAG contains a cycle: ${cycle}`, "nodes"))
+      return
+    }
+    visiting.add(id)
+    stack.push(id)
+    for (const dep of byId.get(id)?.dependsOn ?? []) visit(dep)
+    stack.pop()
+    visiting.delete(id)
+    visited.add(id)
+  }
+
+  for (const node of spec.nodes) visit(node.id)
+  return { valid: issues.length === 0, issues }
+}
+
+export function validateHandoffArtifact(artifact: HandoffArtifactContract): WorkflowValidationResult {
+  const issues: WorkflowValidationIssue[] = []
+  if (!artifact.artifactId) issues.push(issue("artifact.id.required", "Artifact id is required", "artifactId"))
+  if (!artifact.runId) issues.push(issue("artifact.run.required", "Artifact runId is required", "runId"))
+  if (!artifact.kind) issues.push(issue("artifact.kind.required", "Artifact kind is required", "kind"))
+  if (!artifact.path && !artifact.url) issues.push(issue("artifact.location.required", "Artifact must include path or url", "path"))
+  if (artifact.path && artifact.path.includes("\0")) issues.push(issue("artifact.path.invalid", "Artifact path contains a null byte", "path"))
+  if (artifact.sha256 && !/^[a-f0-9]{64}$/i.test(artifact.sha256)) {
+    issues.push(issue("artifact.sha256.invalid", "Artifact sha256 must be 64 hex characters", "sha256"))
+  }
+  return { valid: issues.length === 0, issues }
+}
+
+export function validateRunRelation(relation: RunRelationSpec): WorkflowValidationResult {
+  const issues: WorkflowValidationIssue[] = []
+  if (!relation.runId) issues.push(issue("relation.run.required", "Relation runId is required", "runId"))
+  if (!relation.relatedRunId) issues.push(issue("relation.related.required", "Relation relatedRunId is required", "relatedRunId"))
+  if (relation.runId && relation.relatedRunId && relation.runId === relation.relatedRunId) {
+    issues.push(issue("relation.self.invalid", "A run cannot relate to itself", "relatedRunId"))
+  }
+  if (!relation.relationType) issues.push(issue("relation.type.required", "Relation type is required", "relationType"))
+  return { valid: issues.length === 0, issues }
+}
+
+export function validateWorkflowBundle(input: {
+  dag?: WorkflowDagSpec
+  artifacts?: HandoffArtifactContract[]
+  relations?: RunRelationSpec[]
+}): WorkflowValidationResult {
+  const results = [
+    ...(input.dag ? [validateWorkflowDag(input.dag)] : []),
+    ...(input.artifacts ?? []).map(validateHandoffArtifact),
+    ...(input.relations ?? []).map(validateRunRelation),
+  ]
+  const issues = results.flatMap((result) => result.issues)
+  return { valid: issues.length === 0, issues }
+}

--- a/src/workflow/validators.ts
+++ b/src/workflow/validators.ts
@@ -1,18 +1,122 @@
-import type {
-  HandoffArtifactContract,
-  RunRelationSpec,
-  WorkflowDagSpec,
-  WorkflowValidationIssue,
-  WorkflowValidationResult,
+import {
+  ARTIFACT_KINDS,
+  RUN_RELATION_TYPES,
+  WORKFLOW_CONTEXT_BOUNDARIES,
+  WORKFLOW_CONTRACT_NODE_TYPES,
+  WORKFLOW_NODE_KINDS,
+  WORKFLOW_RISK_LEVELS,
+  WORKFLOW_TRIGGER_RULES,
+  type HandoffArtifactContract,
+  type RunRelationSpec,
+  type WorkflowDagNodeSpec,
+  type WorkflowDagSpec,
+  type WorkflowValidationIssue,
+  type WorkflowValidationResult,
 } from "./schema.js"
 
 function issue(code: string, message: string, path?: string): WorkflowValidationIssue {
   return { code, message, ...(path ? { path } : {}) }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function enumSet<T extends readonly string[]>(values: T): Set<string> {
+  return new Set(values as readonly string[])
+}
+
+const nodeKinds = enumSet(WORKFLOW_NODE_KINDS)
+const nodeTypes = enumSet(WORKFLOW_CONTRACT_NODE_TYPES)
+const triggerRules = enumSet(WORKFLOW_TRIGGER_RULES)
+const contextBoundaries = enumSet(WORKFLOW_CONTEXT_BOUNDARIES)
+const riskLevels = enumSet(WORKFLOW_RISK_LEVELS)
+const artifactKinds = enumSet(ARTIFACT_KINDS)
+const relationTypes = enumSet(RUN_RELATION_TYPES)
+
+function requireString(value: unknown, code: string, message: string, path: string, issues: WorkflowValidationIssue[]): value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    issues.push(issue(code, message, path))
+    return false
+  }
+  return true
+}
+
+function validateStringArray(value: unknown, code: string, message: string, path: string, issues: WorkflowValidationIssue[]): string[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) {
+    issues.push(issue(code, message, path))
+    return []
+  }
+  const strings: string[] = []
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || item.length === 0) {
+      issues.push(issue(code, `${message}; item ${index} must be a non-empty string`, `${path}[${index}]`))
+    } else {
+      strings.push(item)
+    }
+  }
+  return strings
+}
+
+function validateEnum(value: unknown, allowed: Set<string>, code: string, message: string, path: string, issues: WorkflowValidationIssue[]): void {
+  if (typeof value !== "string" || !allowed.has(value)) {
+    issues.push(issue(code, `${message}. Allowed values: ${[...allowed].join(", ")}`, path))
+  }
+}
+
+function validateEnumArray(value: unknown, allowed: Set<string>, code: string, message: string, path: string, issues: WorkflowValidationIssue[]): void {
+  if (value === undefined) return
+  if (!Array.isArray(value)) {
+    issues.push(issue(code, message, path))
+    return
+  }
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || !allowed.has(item)) {
+      issues.push(issue(code, `${message}; item ${index} must be one of: ${[...allowed].join(", ")}`, `${path}[${index}]`))
+    }
+  }
+}
+
+function nodeDependencies(node: WorkflowDagNodeSpec): string[] {
+  return [...(Array.isArray(node.dependsOn) ? node.dependsOn : []), ...(Array.isArray(node.depends_on) ? node.depends_on : [])]
+}
+
+function validateNodeShape(node: unknown, path: string, issues: WorkflowValidationIssue[]): node is WorkflowDagNodeSpec {
+  if (!isRecord(node)) {
+    issues.push(issue("node.shape.invalid", "Node must be an object", path))
+    return false
+  }
+  requireString(node.id, "node.id.required", "Node id is required", `${path}.id`, issues)
+  requireString(node.name, "node.name.required", "Node name is required", `${path}.name`, issues)
+  if (node.kind === undefined) {
+    issues.push(issue("node.kind.required", "Node kind is required", `${path}.kind`))
+  } else {
+    validateEnum(node.kind, nodeKinds, "node.kind.invalid", "Node kind is invalid", `${path}.kind`, issues)
+  }
+  if (node.type !== undefined) validateEnum(node.type, nodeTypes, "node.type.invalid", "Node type is invalid", `${path}.type`, issues)
+  if (node.trigger_rule !== undefined) validateEnum(node.trigger_rule, triggerRules, "node.trigger_rule.invalid", "Node trigger_rule is invalid", `${path}.trigger_rule`, issues)
+  if (node.context_boundary !== undefined) validateEnum(node.context_boundary, contextBoundaries, "node.context_boundary.invalid", "Node context_boundary is invalid", `${path}.context_boundary`, issues)
+  if (node.risk_level !== undefined) validateEnum(node.risk_level, riskLevels, "node.risk_level.invalid", "Node risk_level is invalid", `${path}.risk_level`, issues)
+  if (node.parallel_group !== undefined && typeof node.parallel_group !== "string") {
+    issues.push(issue("node.parallel_group.invalid", "Node parallel_group must be a string", `${path}.parallel_group`))
+  }
+  validateStringArray(node.dependsOn, "node.dependsOn.invalid", "Node dependsOn must be an array of node ids", `${path}.dependsOn`, issues)
+  validateStringArray(node.depends_on, "node.depends_on.invalid", "Node depends_on must be an array of node ids", `${path}.depends_on`, issues)
+  validateEnumArray(node.produces, artifactKinds, "node.produces.invalid", "Node produces must be an array of artifact kinds", `${path}.produces`, issues)
+  validateEnumArray(node.consumes, artifactKinds, "node.consumes.invalid", "Node consumes must be an array of artifact kinds", `${path}.consumes`, issues)
+  validateEnumArray(node.input_artifacts, artifactKinds, "node.input_artifacts.invalid", "Node input_artifacts must be an array of artifact kinds", `${path}.input_artifacts`, issues)
+  validateEnumArray(node.output_artifacts, artifactKinds, "node.output_artifacts.invalid", "Node output_artifacts must be an array of artifact kinds", `${path}.output_artifacts`, issues)
+  validateStringArray(node.validators, "node.validators.invalid", "Node validators must be an array of validator ids", `${path}.validators`, issues)
+  return true
+}
+
 export function validateWorkflowDag(spec: WorkflowDagSpec): WorkflowValidationResult {
   const issues: WorkflowValidationIssue[] = []
 
+  if (!isRecord(spec)) {
+    return { valid: false, issues: [issue("dag.shape.invalid", "Workflow DAG must be an object")] }
+  }
   if (!spec.id || typeof spec.id !== "string") {
     issues.push(issue("dag.id.required", "Workflow DAG id is required", "id"))
   }
@@ -21,12 +125,14 @@ export function validateWorkflowDag(spec: WorkflowDagSpec): WorkflowValidationRe
     return { valid: issues.length === 0, issues }
   }
 
+  const nodes: WorkflowDagNodeSpec[] = []
   const ids = new Set<string>()
   const duplicateIds = new Set<string>()
-  for (const [index, node] of spec.nodes.entries()) {
+  for (const [index, rawNode] of spec.nodes.entries()) {
     const path = `nodes[${index}]`
-    if (!node.id) issues.push(issue("node.id.required", "Node id is required", `${path}.id`))
-    if (!node.name) issues.push(issue("node.name.required", "Node name is required", `${path}.name`))
+    if (!validateNodeShape(rawNode, path, issues)) continue
+    const node = rawNode as WorkflowDagNodeSpec
+    nodes.push(node)
     if (node.id && ids.has(node.id)) duplicateIds.add(node.id)
     if (node.id) ids.add(node.id)
   }
@@ -34,8 +140,8 @@ export function validateWorkflowDag(spec: WorkflowDagSpec): WorkflowValidationRe
     issues.push(issue("node.id.duplicate", `Duplicate node id: ${id}`, "nodes"))
   }
 
-  for (const node of spec.nodes) {
-    for (const dep of node.dependsOn ?? []) {
+  for (const node of nodes) {
+    for (const dep of nodeDependencies(node)) {
       if (!ids.has(dep)) {
         issues.push(issue("node.dependency.missing", `Node ${node.id} depends on missing node ${dep}`, `nodes.${node.id}.dependsOn`))
       }
@@ -47,7 +153,7 @@ export function validateWorkflowDag(spec: WorkflowDagSpec): WorkflowValidationRe
 
   const visiting = new Set<string>()
   const visited = new Set<string>()
-  const byId = new Map(spec.nodes.map((node) => [node.id, node]))
+  const byId = new Map(nodes.map((node) => [node.id, node]))
   const stack: string[] = []
 
   function visit(id: string): void {
@@ -60,21 +166,23 @@ export function validateWorkflowDag(spec: WorkflowDagSpec): WorkflowValidationRe
     }
     visiting.add(id)
     stack.push(id)
-    for (const dep of byId.get(id)?.dependsOn ?? []) visit(dep)
+    for (const dep of nodeDependencies(byId.get(id) as WorkflowDagNodeSpec)) visit(dep)
     stack.pop()
     visiting.delete(id)
     visited.add(id)
   }
 
-  for (const node of spec.nodes) visit(node.id)
+  for (const node of nodes) visit(node.id)
   return { valid: issues.length === 0, issues }
 }
 
 export function validateHandoffArtifact(artifact: HandoffArtifactContract): WorkflowValidationResult {
   const issues: WorkflowValidationIssue[] = []
+  if (!isRecord(artifact)) return { valid: false, issues: [issue("artifact.shape.invalid", "Artifact must be an object")] }
   if (!artifact.artifactId) issues.push(issue("artifact.id.required", "Artifact id is required", "artifactId"))
   if (!artifact.runId) issues.push(issue("artifact.run.required", "Artifact runId is required", "runId"))
   if (!artifact.kind) issues.push(issue("artifact.kind.required", "Artifact kind is required", "kind"))
+  else validateEnum(artifact.kind, artifactKinds, "artifact.kind.invalid", "Artifact kind is invalid", "kind", issues)
   if (!artifact.path && !artifact.url) issues.push(issue("artifact.location.required", "Artifact must include path or url", "path"))
   if (artifact.path && artifact.path.includes("\0")) issues.push(issue("artifact.path.invalid", "Artifact path contains a null byte", "path"))
   if (artifact.sha256 && !/^[a-f0-9]{64}$/i.test(artifact.sha256)) {
@@ -85,12 +193,14 @@ export function validateHandoffArtifact(artifact: HandoffArtifactContract): Work
 
 export function validateRunRelation(relation: RunRelationSpec): WorkflowValidationResult {
   const issues: WorkflowValidationIssue[] = []
+  if (!isRecord(relation)) return { valid: false, issues: [issue("relation.shape.invalid", "Relation must be an object")] }
   if (!relation.runId) issues.push(issue("relation.run.required", "Relation runId is required", "runId"))
   if (!relation.relatedRunId) issues.push(issue("relation.related.required", "Relation relatedRunId is required", "relatedRunId"))
   if (relation.runId && relation.relatedRunId && relation.runId === relation.relatedRunId) {
     issues.push(issue("relation.self.invalid", "A run cannot relate to itself", "relatedRunId"))
   }
   if (!relation.relationType) issues.push(issue("relation.type.required", "Relation type is required", "relationType"))
+  else validateEnum(relation.relationType, relationTypes, "relation.type.invalid", "Relation type is invalid", "relationType", issues)
   return { valid: issues.length === 0, issues }
 }
 
@@ -99,11 +209,16 @@ export function validateWorkflowBundle(input: {
   artifacts?: HandoffArtifactContract[]
   relations?: RunRelationSpec[]
 }): WorkflowValidationResult {
-  const results = [
-    ...(input.dag ? [validateWorkflowDag(input.dag)] : []),
-    ...(input.artifacts ?? []).map(validateHandoffArtifact),
-    ...(input.relations ?? []).map(validateRunRelation),
-  ]
-  const issues = results.flatMap((result) => result.issues)
+  const issues: WorkflowValidationIssue[] = []
+  if (!isRecord(input)) return { valid: false, issues: [issue("bundle.shape.invalid", "Workflow bundle must be an object")] }
+  if (input.dag) issues.push(...validateWorkflowDag(input.dag).issues)
+  if (input.artifacts !== undefined) {
+    if (!Array.isArray(input.artifacts)) issues.push(issue("bundle.artifacts.invalid", "Bundle artifacts must be an array", "artifacts"))
+    else issues.push(...input.artifacts.flatMap((artifact) => validateHandoffArtifact(artifact).issues))
+  }
+  if (input.relations !== undefined) {
+    if (!Array.isArray(input.relations)) issues.push(issue("bundle.relations.invalid", "Bundle relations must be an array", "relations"))
+    else issues.push(...input.relations.flatMap((relation) => validateRunRelation(relation).issues))
+  }
   return { valid: issues.length === 0, issues }
 }

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "path"
 import { appendEventToPath, type TaskEvent } from "../src/utils/sqlite-writer.js"
@@ -52,10 +52,68 @@ describe("workflow validators", () => {
     expect(cycleResult.issues.map((issue) => issue.code)).toContain("dag.cycle")
   })
 
-  test("validates handoff artifacts and run relations deterministically", () => {
-    expect(validateHandoffArtifact({ artifactId: "h1", runId: "r1", kind: "handoff", path: "docs/handoff.md" }).valid).toBe(true)
-    expect(validateHandoffArtifact({ artifactId: "h1", runId: "r1", kind: "handoff", sha256: "bad" }).issues.map((i) => i.code)).toContain("artifact.location.required")
-    expect(validateRunRelation({ runId: "r1", relatedRunId: "r1", relationType: "sibling" }).issues.map((i) => i.code)).toContain("relation.self.invalid")
+  test("accepts issue #96 DAG contract aliases", () => {
+    const result = validateWorkflowDag({
+      id: "gcw-96",
+      nodes: [
+        {
+          id: "plan",
+          kind: "skill",
+          name: "Plan",
+          type: "ai",
+          depends_on: [],
+          trigger_rule: "all_success",
+          context_boundary: "inherit",
+          input_artifacts: ["plan"],
+          output_artifacts: ["handoff"],
+          validators: ["schema", "tests"],
+          parallel_group: "analysis",
+          risk_level: "medium",
+        },
+        { id: "approve", kind: "manual", name: "Approve", type: "approval", depends_on: ["plan"] },
+      ],
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  test("rejects invalid runtime enum values and array shapes", () => {
+    const dagResult = validateWorkflowDag({
+      id: "bad-enums",
+      nodes: [
+        {
+          id: "a",
+          kind: "unsupported",
+          name: "A",
+          type: "robot",
+          dependsOn: "b",
+          produces: ["not-artifact"],
+          consumes: "handoff",
+          input_artifacts: ["handoff", 42],
+          output_artifacts: "patch",
+          validators: "schema",
+          trigger_rule: "sometimes",
+          context_boundary: "shared",
+          risk_level: "extreme",
+        },
+      ],
+    } as unknown as Parameters<typeof validateWorkflowDag>[0])
+    const artifactResult = validateHandoffArtifact({ artifactId: "h1", runId: "r1", kind: "zip", path: "out.zip" } as unknown as Parameters<typeof validateHandoffArtifact>[0])
+    const relationResult = validateRunRelation({ runId: "r1", relatedRunId: "r2", relationType: "cousin" } as unknown as Parameters<typeof validateRunRelation>[0])
+    const codes = dagResult.issues.map((item) => item.code)
+    expect(dagResult.valid).toBe(false)
+    expect(codes).toContain("node.kind.invalid")
+    expect(codes).toContain("node.type.invalid")
+    expect(codes).toContain("node.dependsOn.invalid")
+    expect(codes).toContain("node.produces.invalid")
+    expect(codes).toContain("node.consumes.invalid")
+    expect(codes).toContain("node.input_artifacts.invalid")
+    expect(codes).toContain("node.output_artifacts.invalid")
+    expect(codes).toContain("node.validators.invalid")
+    expect(codes).toContain("node.trigger_rule.invalid")
+    expect(codes).toContain("node.context_boundary.invalid")
+    expect(codes).toContain("node.risk_level.invalid")
+    expect(artifactResult.issues.map((item) => item.code)).toContain("artifact.kind.invalid")
+    expect(relationResult.issues.map((item) => item.code)).toContain("relation.type.invalid")
   })
 })
 
@@ -96,5 +154,40 @@ describe("workflow event projection", () => {
     expect(rollup.completedRuns).toBe(2)
     expect(rollup.artifactCount).toBe(1)
     expect(rollup.reviewRoleCount).toBe(1)
+  })
+
+  test("projects filtered rollups with recursive descendants", async () => {
+    await appendEventToPath(event({ task_id: "root", event_type: "workflow_started", title: "Root", timestamp: "2026-01-01T00:00:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "child", event_type: "skill_started", parent_task_id: "root", timestamp: "2026-01-01T00:01:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "grandchild", event_type: "skill_started", parent_task_id: "child", timestamp: "2026-01-01T00:02:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "grandchild", event_type: "handoff_artifact_linked", artifact_id: "deep", artifact_type: "handoff", artifact_path: ".context/deep.md", timestamp: "2026-01-01T00:03:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "grandchild", event_type: "skill_completed", timestamp: "2026-01-01T00:04:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "child", event_type: "skill_completed", timestamp: "2026-01-01T00:05:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "root", event_type: "workflow_completed", timestamp: "2026-01-01T00:06:00.000Z" }), dbPath)
+
+    const filteredEvents = readWorkflowEventsFromPath(dbPath, "root")
+    const runs = projectWorkflowRuns(filteredEvents)
+    const rollup = rollupWorkflowRun("root", runs)
+
+    expect(runs.map((run) => run.runId)).toEqual(["root", "child", "grandchild"])
+    expect(rollup.totalRuns).toBe(3)
+    expect(rollup.completedRuns).toBe(3)
+    expect(rollup.children[0]?.children[0]?.runId).toBe("grandchild")
+    expect(rollup.artifactCount).toBe(1)
+  })
+
+  test("gale-task validate exits non-zero for malformed input", async () => {
+    const malformedPath = path.join(tmpDir, "malformed.json")
+    await writeFile(malformedPath, "{ not-json", "utf8")
+    const proc = Bun.spawn(["bun", "run", "cmd/gale-task/index.ts", "validate", "--file", malformedPath], {
+      cwd: path.resolve(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stdout, stderr, exitCode] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited])
+
+    expect(exitCode).toBe(1)
+    expect(stdout).toBe("")
+    expect(stderr).toContain("[gale-task] validate error")
   })
 })

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "path"
+import { appendEventToPath, type TaskEvent } from "../src/utils/sqlite-writer.js"
+import { projectWorkflowRuns, readWorkflowEventsFromPath, rollupWorkflowRun } from "../src/workflow/projection.js"
+import { validateHandoffArtifact, validateRunRelation, validateWorkflowDag } from "../src/workflow/validators.js"
+
+function event(overrides: Partial<TaskEvent>): TaskEvent {
+  return {
+    task_id: "root",
+    event_type: "workflow_started",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    project: "demo",
+    project_path: "/tmp/demo",
+    ...overrides,
+  } as TaskEvent
+}
+
+describe("workflow validators", () => {
+  test("accepts a valid DAG with typed node fields", () => {
+    const result = validateWorkflowDag({
+      id: "gcw-demo",
+      kind: "compound",
+      nodes: [
+        { id: "plan", kind: "skill", name: "Plan", skill: "gh:plan" },
+        { id: "review-security", kind: "review_role", name: "Security review", role: "security", dependsOn: ["plan"] },
+      ],
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  test("rejects duplicate ids, missing dependencies, and cycles", () => {
+    const shapeResult = validateWorkflowDag({
+      id: "bad-shape",
+      nodes: [
+        { id: "a", kind: "skill", name: "A", dependsOn: ["missing"] },
+        { id: "a", kind: "skill", name: "Duplicate" },
+      ],
+    })
+    const cycleResult = validateWorkflowDag({
+      id: "bad-cycle",
+      nodes: [
+        { id: "a", kind: "skill", name: "A", dependsOn: ["b"] },
+        { id: "b", kind: "skill", name: "B", dependsOn: ["a"] },
+      ],
+    })
+    expect(shapeResult.valid).toBe(false)
+    expect(shapeResult.issues.map((issue) => issue.code)).toContain("node.id.duplicate")
+    expect(shapeResult.issues.map((issue) => issue.code)).toContain("node.dependency.missing")
+    expect(cycleResult.valid).toBe(false)
+    expect(cycleResult.issues.map((issue) => issue.code)).toContain("dag.cycle")
+  })
+
+  test("validates handoff artifacts and run relations deterministically", () => {
+    expect(validateHandoffArtifact({ artifactId: "h1", runId: "r1", kind: "handoff", path: "docs/handoff.md" }).valid).toBe(true)
+    expect(validateHandoffArtifact({ artifactId: "h1", runId: "r1", kind: "handoff", sha256: "bad" }).issues.map((i) => i.code)).toContain("artifact.location.required")
+    expect(validateRunRelation({ runId: "r1", relatedRunId: "r1", relationType: "sibling" }).issues.map((i) => i.code)).toContain("relation.self.invalid")
+  })
+})
+
+describe("workflow event projection", () => {
+  let tmpDir: string
+  let dbPath: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "gale-workflow-test-"))
+    dbPath = path.join(tmpDir, "tasks.db")
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test("projects events, handoff artifacts, review roles, and child rollups from ledger", async () => {
+    await appendEventToPath(event({ task_id: "root", event_type: "workflow_started", run_type: "compound", title: "Root", timestamp: "2026-01-01T00:00:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "child", event_type: "skill_started", parent_task_id: "root", skill: "gh:work", timestamp: "2026-01-01T00:01:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "root", event_type: "run_relation_linked", related_run_id: "child", relation_type: "child", timestamp: "2026-01-01T00:02:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "root", event_type: "review_role_started", review_role: "security", node_id: "review-security", timestamp: "2026-01-01T00:03:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "root", event_type: "review_role_completed", review_role: "security", node_id: "review-security", timestamp: "2026-01-01T00:04:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "root", event_type: "handoff_artifact_linked", artifact_id: "handoff-1", artifact_type: "handoff", artifact_path: ".context/handoff.md", timestamp: "2026-01-01T00:05:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "child", event_type: "skill_completed", timestamp: "2026-01-01T00:06:00.000Z" }), dbPath)
+    await appendEventToPath(event({ task_id: "root", event_type: "workflow_completed", timestamp: "2026-01-01T00:07:00.000Z" }), dbPath)
+
+    const events = readWorkflowEventsFromPath(dbPath)
+    const runs = projectWorkflowRuns(events)
+    const root = runs.find((run) => run.runId === "root")
+
+    expect(root?.status).toBe("completed")
+    expect(root?.childRunIds).toContain("child")
+    expect(root?.artifacts[0].artifactId).toBe("handoff-1")
+    expect(root?.reviewRoles[0]).toMatchObject({ role: "security", status: "completed" })
+
+    const rollup = rollupWorkflowRun("root", runs)
+    expect(rollup.totalRuns).toBe(2)
+    expect(rollup.completedRuns).toBe(2)
+    expect(rollup.artifactCount).toBe(1)
+    expect(rollup.reviewRoleCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add typed workflow DAG, handoff artifact, and run relation schema surfaces
- add deterministic workflow validators for DAG shape/dependencies/cycles, handoff artifacts, and run relations
- extend gale-task SQLite events with additive workflow metadata and expose events/graph/rollup/validate CLI projections
- project existing multi-role gh:review activity into review-role graph/events/artifacts without rebuilding review runtime

Closes #96
Refs wangrenzhu-ola/ai-infra-demand-pool#42
Refs wangrenzhu-ola/infra-hermes-core-skills#111

## Tests
- bun test tests/workflow-runtime.test.ts
- bun test tests/sqlite-writer.test.ts tests/workflow-runtime.test.ts
- bun test
- bun run build:gale-task