### PR TITLE
chore(upstream): add ce-to-gale mapping layer

### DIFF
--- a/scripts/upstream-sync/adapt-patch.py
+++ b/scripts/upstream-sync/adapt-patch.py
@@ -20,12 +20,31 @@ PATH_METADATA_PREFIXES = (
 
 
 def load_rules(rules_path: Path) -> dict:
+    """Load upstream-sync namespace mapping rules.
+
+    `rename-rules.json` is kept as the stable CLI default for backwards
+    compatibility. It may either contain the rules directly or extend the
+    canonical `ce-to-gale-map.json` mapping layer used for repeatable
+    Compound Engineering -> GaleHarnessCLI patch adaptation.
+    """
     try:
-        return json.loads(rules_path.read_text(encoding="utf-8"))
+        data = json.loads(rules_path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise SystemExit(f"Rules file not found: {rules_path}") from exc
     except json.JSONDecodeError as exc:
         raise SystemExit(f"Rules file is not valid JSON: {rules_path}: {exc}") from exc
+
+    extended = data.get("extends")
+    if extended:
+        extended_path = (rules_path.parent / extended).resolve()
+        if extended_path == rules_path.resolve():
+            raise SystemExit(f"Rules file cannot extend itself: {rules_path}")
+        base = load_rules(extended_path)
+        overlay = {k: v for k, v in data.items() if k != "extends" and not k.startswith("$")}
+        base.update(overlay)
+        return base
+
+    return data
 
 
 def apply_replacements(text: str, replacements: list[dict]) -> tuple[str, int]:

--- a/scripts/upstream-sync/ce-to-gale-map.json
+++ b/scripts/upstream-sync/ce-to-gale-map.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "description": "Canonical Compound Engineering -> GaleHarnessCLI namespace map used by upstream-sync patch adaptation.",
+  "path_prefix_replacements": [
+    {
+      "from": "plugins/compound-engineering/",
+      "to": "plugins/galeharness-cli/"
+    },
+    {
+      "from": "plugins/compound-engineering-plugin/",
+      "to": "plugins/galeharness-cli/"
+    },
+    {
+      "from": ".context/compound-engineering/",
+      "to": ".context/galeharness-cli/"
+    }
+  ],
+  "text_replacements": [
+    {
+      "from": "compound-engineering-plugin",
+      "to": "galeharness-cli"
+    },
+    {
+      "from": "compound-engineering",
+      "to": "galeharness-cli"
+    },
+    {
+      "from": "(?<![A-Za-z0-9_/-])/ce:",
+      "to": "/gh:",
+      "regex": true,
+      "description": "Slash command namespace, without touching URL/path substrings."
+    },
+    {
+      "from": "(?<![A-Za-z0-9_/-])ce:",
+      "to": "gh:",
+      "regex": true,
+      "description": "Bare skill namespace, without corrupting words such as source: or ace:thing."
+    },
+    {
+      "from": "(?<![A-Za-z0-9_-])ce-",
+      "to": "gh-",
+      "regex": true,
+      "description": "Skill directory / command prefix, including path segments after /."
+    }
+  ],
+  "warn_on_tokens": [
+    "compound-engineering-plugin",
+    "plugins/compound-engineering/",
+    "ce:"
+  ]
+}

--- a/scripts/upstream-sync/rename-rules.json
+++ b/scripts/upstream-sync/rename-rules.json
@@ -1,44 +1,4 @@
 {
-  "path_prefix_replacements": [
-    {
-      "from": "plugins/compound-engineering/",
-      "to": "plugins/galeharness-cli/"
-    },
-    {
-      "from": "plugins/compound-engineering-plugin/",
-      "to": "plugins/galeharness-cli/"
-    },
-    {
-      "from": ".context/compound-engineering/",
-      "to": ".context/galeharness-cli/"
-    }
-  ],
-  "text_replacements": [
-    {
-      "from": "compound-engineering-plugin",
-      "to": "galeharness-cli"
-    },
-    {
-      "from": "compound-engineering",
-      "to": "galeharness-cli"
-    },
-    {
-      "from": "ce:",
-      "to": "gh:"
-    },
-    {
-      "from": "/ce:",
-      "to": "/gh:"
-    },
-    {
-      "from": "\\bce-",
-      "to": "gh-",
-      "regex": true
-    }
-  ],
-  "warn_on_tokens": [
-    "compound-engineering-plugin",
-    "plugins/compound-engineering/",
-    "ce:"
-  ]
+  "$comment": "Compatibility entrypoint for upstream-sync. The canonical mapping lives in ce-to-gale-map.json.",
+  "extends": "ce-to-gale-map.json"
 }

--- a/tests/upstream-sync-adapt-patch.test.ts
+++ b/tests/upstream-sync-adapt-patch.test.ts
@@ -66,6 +66,47 @@ describe("adapt-patch.py", () => {
     expect(output).toContain("Binary files /dev/null and b/plugins/galeharness-cli/assets/logo.png differ")
   })
 
+  test("does not corrupt non-command text while applying ce-to-gale mapping", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "adapt-safe-namespace-"))
+    const inputPath = path.join(tempDir, "raw.patch")
+    const outputPath = path.join(tempDir, "adapted.patch")
+    await fs.writeFile(
+      inputPath,
+      [
+        "From abc Mon Sep 17 00:00:00 2001\n",
+        "Subject: [PATCH] docs: map ce namespace safely\n",
+        "---\n",
+        " plugins/compound-engineering/skills/ce-demo/SKILL.md | 4 ++++\n",
+        " 1 file changed, 4 insertions(+)\n",
+        "diff --git a/plugins/compound-engineering/skills/ce-demo/SKILL.md b/plugins/compound-engineering/skills/ce-demo/SKILL.md\n",
+        "--- a/plugins/compound-engineering/skills/ce-demo/SKILL.md\n",
+        "+++ b/plugins/compound-engineering/skills/ce-demo/SKILL.md\n",
+        "@@ -1,0 +1,4 @@\n",
+        "+Use ce:plan and /ce:review.\n",
+        "+Keep source: explicit and https://example.com/ace:thing intact.\n",
+        "+Prefer ce-demo only as a command slug.\n",
+      ].join(""),
+      "utf8",
+    )
+
+    const result = await runPython([
+      "--input",
+      inputPath,
+      "--output",
+      outputPath,
+      "--rules",
+      rulesPath,
+    ])
+
+    expect(result.exitCode).toBe(0)
+    const output = await fs.readFile(outputPath, "utf8")
+    expect(output).toContain("plugins/galeharness-cli/skills/gh-demo/SKILL.md")
+    expect(output).toContain("Use gh:plan and /gh:review.")
+    expect(output).toContain("source: explicit")
+    expect(output).toContain("https://example.com/ace:thing")
+    expect(output).toContain("Prefer gh-demo only as a command slug.")
+  })
+
   test("fails fast on invalid JSON rules", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "adapt-invalid-rules-"))
     const outputPath = path.join(tempDir, "adapted.patch")


### PR DESCRIPTION
## Summary
- Add a canonical `ce-to-gale-map.json` namespace mapping layer for repeatable upstream-sync patch adaptation.
- Keep `rename-rules.json` as the backwards-compatible default entrypoint via `extends`.
- Tighten CE namespace regex replacements so command/skill tokens are rewritten without corrupting normal text such as `source:` or URLs containing `ace:`.

Closes #102

## Validation
- `bun install`
- `bun test tests/upstream-sync-adapt-patch.test.ts tests/upstream-sync-generate-batch.test.ts`
- `bun test`
- `bun run release:validate`

## Risk / rollback
- Low risk: scoped to upstream-sync maintenance scripts and tests.
- Rollback: revert this PR to restore the inline legacy rename rules.
