### PR TITLE
chore(upstream): import p0 review plan session fixes

### DIFF
--- a/plugins/galeharness-cli/agents/adversarial-reviewer.md
+++ b/plugins/galeharness-cli/agents/adversarial-reviewer.md
@@ -2,7 +2,7 @@
 name: adversarial-reviewer
 description: Conditional code-review persona, selected when the diff is large (>=50 changed lines) or touches high-risk domains like auth, payments, data mutations, or external APIs. Actively constructs failure scenarios to break the implementation rather than checking against known patterns.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: red
 
 ---

--- a/plugins/galeharness-cli/agents/api-contract-reviewer.md
+++ b/plugins/galeharness-cli/agents/api-contract-reviewer.md
@@ -2,7 +2,7 @@
 name: api-contract-reviewer
 description: Conditional code-review persona, selected when the diff touches API routes, request/response types, serialization, versioning, or exported type signatures. Reviews code for breaking contract changes.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/correctness-reviewer.md
+++ b/plugins/galeharness-cli/agents/correctness-reviewer.md
@@ -2,7 +2,7 @@
 name: correctness-reviewer
 description: Always-on code-review persona. Reviews code for logic errors, edge cases, state management bugs, error propagation failures, and intent-vs-implementation mismatches.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/data-migrations-reviewer.md
+++ b/plugins/galeharness-cli/agents/data-migrations-reviewer.md
@@ -2,7 +2,7 @@
 name: data-migrations-reviewer
 description: Conditional code-review persona, selected when the diff touches migration files, schema changes, data transformations, or backfill scripts. Reviews code for data integrity and migration safety.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/dhh-rails-reviewer.md
+++ b/plugins/galeharness-cli/agents/dhh-rails-reviewer.md
@@ -2,7 +2,7 @@
 name: dhh-rails-reviewer
 description: Conditional code-review persona, selected when Rails diffs introduce architectural choices, abstractions, or frontend patterns that may fight the framework. Reviews code from an opinionated DHH perspective.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/galeharness-cli/agents/gale-python-reviewer.md
+++ b/plugins/galeharness-cli/agents/gale-python-reviewer.md
@@ -2,7 +2,7 @@
 name: gale-python-reviewer
 description: Conditional code-review persona, selected when the diff touches Python code. Reviews changes with wangrenzhu's strict bar for Pythonic clarity, type hints, and maintainability.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/galeharness-cli/agents/gale-rails-reviewer.md
+++ b/plugins/galeharness-cli/agents/gale-rails-reviewer.md
@@ -2,7 +2,7 @@
 name: gale-rails-reviewer
 description: Conditional code-review persona, selected when the diff touches Rails application code. Reviews Rails changes with wangrenzhu's strict bar for clarity, conventions, and maintainability.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/galeharness-cli/agents/gale-typescript-reviewer.md
+++ b/plugins/galeharness-cli/agents/gale-typescript-reviewer.md
@@ -2,7 +2,7 @@
 name: gale-typescript-reviewer
 description: Conditional code-review persona, selected when the diff touches TypeScript code. Reviews changes with wangrenzhu's strict bar for type safety, clarity, and maintainability.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/galeharness-cli/agents/julik-frontend-races-reviewer.md
+++ b/plugins/galeharness-cli/agents/julik-frontend-races-reviewer.md
@@ -2,7 +2,7 @@
 name: julik-frontend-races-reviewer
 description: Conditional code-review persona, selected when the diff touches async UI code, Stimulus/Turbo lifecycles, or DOM-timing-sensitive frontend behavior. Reviews code for race conditions and janky UI failure modes.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/galeharness-cli/agents/maintainability-reviewer.md
+++ b/plugins/galeharness-cli/agents/maintainability-reviewer.md
@@ -2,7 +2,7 @@
 name: maintainability-reviewer
 description: Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/performance-reviewer.md
+++ b/plugins/galeharness-cli/agents/performance-reviewer.md
@@ -2,7 +2,7 @@
 name: performance-reviewer
 description: Conditional code-review persona, selected when the diff touches database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths. Reviews code for runtime performance and scalability issues.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/previous-comments-reviewer.md
+++ b/plugins/galeharness-cli/agents/previous-comments-reviewer.md
@@ -2,7 +2,7 @@
 name: previous-comments-reviewer
 description: Conditional code-review persona, selected when reviewing a PR that has existing review comments or review threads. Checks whether prior feedback has been addressed in the current diff.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: yellow
 
 ---

--- a/plugins/galeharness-cli/agents/project-standards-reviewer.md
+++ b/plugins/galeharness-cli/agents/project-standards-reviewer.md
@@ -2,7 +2,7 @@
 name: project-standards-reviewer
 description: Always-on code-review persona. Audits changes against the project's own CLAUDE.md and AGENTS.md standards -- frontmatter rules, reference inclusion, naming conventions, cross-platform portability, and tool selection policies.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/reliability-reviewer.md
+++ b/plugins/galeharness-cli/agents/reliability-reviewer.md
@@ -2,7 +2,7 @@
 name: reliability-reviewer
 description: Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Reviews code for production reliability and failure modes.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/security-reviewer.md
+++ b/plugins/galeharness-cli/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Conditional code-review persona, selected when the diff touches auth middleware, public endpoints, user input handling, or permission checks. Reviews code for exploitable vulnerabilities.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/agents/swift-ios-reviewer.md
+++ b/plugins/galeharness-cli/agents/swift-ios-reviewer.md
@@ -2,7 +2,7 @@
 name: swift-ios-reviewer
 description: Conditional code-review persona, selected when the diff touches Swift files (.swift), SwiftUI views, UIKit controllers, iOS entitlements, privacy manifests, Core Data model bundles, SPM manifests, storyboards/XIBs, or semantic build-setting/target/signing changes inside .pbxproj. Reviews Swift and iOS code for SwiftUI correctness, state management, memory safety, Swift concurrency, Core Data threading, and accessibility.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/galeharness-cli/agents/testing-reviewer.md
+++ b/plugins/galeharness-cli/agents/testing-reviewer.md
@@ -2,7 +2,7 @@
 name: testing-reviewer
 description: Always-on code-review persona. Reviews code for test coverage gaps, weak assertions, brittle implementation-coupled tests, and missing edge case coverage.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/galeharness-cli/skills/document-review/SKILL.md
+++ b/plugins/galeharness-cli/skills/document-review/SKILL.md
@@ -198,3 +198,8 @@ For the four-option routing question and per-finding walk-through (interactive m
 ### Findings Schema
 
 @./references/findings-schema.json
+
+
+## Dispatch capacity rule
+
+Use bounded parallelism for persona dispatch. Queue selected reviewers, respect the active-subagent limit exposed by the harness, treat capacity spawn errors as backpressure rather than reviewer failure, and fill freed slots until all queued reviewers complete or time out.

--- a/plugins/galeharness-cli/skills/gh-compound-refresh/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound-refresh/SKILL.md
@@ -74,6 +74,14 @@ For each candidate artifact, classify it into one of five outcomes:
 | **Replace** | The old artifact is now misleading, but there is a known better replacement | Create a trustworthy successor, then delete the old artifact |
 | **Delete** | No longer useful, applicable, or distinct | Delete the file — git history preserves it if anyone needs to recover it later |
 
+## Before deleting: check for inbound links
+
+Delete is safe only after checking for inbound links from other solution, plan, requirement, or pattern docs. Treat citations as evidence, not decoration:
+
+- **Decorative citations** (generic “see also” links with no dependency on the stale artifact) allow Delete when the normal missing-code/no-successor criteria are met.
+- **Substantive citations** (links that rely on the artifact for rationale, implementation steps, or pattern evidence) signal Replace or Update instead of Delete.
+- **Autofix auto-delete** is permitted only when the code is gone, no trustworthy successor exists, and inbound citations are absent or purely decorative.
+
 ## Core Rules
 
 1. **Evidence informs judgment.** The signals below are inputs, not a mechanical scorecard. Use engineering judgment to decide whether the artifact is still trustworthy.

--- a/plugins/galeharness-cli/skills/gh-compound/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-compound/SKILL.md
@@ -24,7 +24,7 @@ Captures problem solutions while context is fresh, creating structured documenta
 
 **Repo name (pre-resolved):** !`bash scripts/resolve-repo-name.sh`
 
-**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null`
+**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || true`
 
 If the lines above resolved to plain values (a folder name like `my-repo` and a branch name like `feat/my-branch`), pass them into the Session Historian dispatch in Phase 1 so the agent does not waste a turn deriving them. If they still contain backtick command strings or are empty, omit them from the dispatch and let the agent derive them at runtime.
 

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -1001,3 +1001,16 @@ After the plan document is written and all phases are complete, log the completi
 2. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
 
 <!-- /HKT-PATCH:gale-task-end -->
+
+### Post-generation handoff routing
+
+STOP. Load `references/plan-handoff.md` now before continuing. This load is non-optional: `gh:plan` is not complete until the post-generation menu selection has been routed or executed.
+
+Post-generation menu routing is part of this skill, not a prose-only suggestion. Present and route these options inline:
+
+1. **Start `/gh:work`** -- invoke the `gh-work` skill using the platform's skill-invocation primitive, passing the saved plan path as the primary argument.
+2. **Create Issue** -- create or draft the issue using the saved plan path and summary.
+3. **Open in Proof** -- invoke the `proof` HITL flow with the saved plan path, then recommend `/gh:work` when proofing is complete.
+4. **Done for now** -- confirm the plan path and end without starting execution.
+
+Completion check: do not mark the planning flow complete until one menu route has been selected and either executed or explicitly deferred by the user.

--- a/plugins/galeharness-cli/skills/gh-plan/references/plan-handoff.md
+++ b/plugins/galeharness-cli/skills/gh-plan/references/plan-handoff.md
@@ -80,3 +80,8 @@ When the user selects "Create Issue", detect their project tracker:
 After issue creation:
 - Display the issue URL
 - Ask whether to proceed to `/gh:work` using the platform's blocking question tool
+
+
+## Routing contract
+
+For **Start `/gh:work`**, invoke the `gh-work` skill using the platform's skill-invocation primitive and pass the saved plan path. Do not merely tell the user to call `/gh:work`; route or explicitly defer the action.

--- a/plugins/galeharness-cli/skills/gh-plan/references/synthesis-summary.md
+++ b/plugins/galeharness-cli/skills/gh-plan/references/synthesis-summary.md
@@ -241,3 +241,8 @@ The plan's `## Summary` and `## Problem Frame` must serve distinct purposes: Sum
 - Re-statement of the entire brainstorm doc — the synthesis is plan-perspective, not a copy
 - Defensive what-ifs and hedges — if a concern is real, state it as Inferred or Out; if speculation, drop it
 - Open questions surfaced outside the three buckets — by synthesis time, every scope-shaping question must be in **Stated** (asked and answered earlier), **Inferred** (agent's bet for correction), or **Out** (deliberately excluded). There is no fourth status. If a question genuinely cannot be defaulted, pause synthesis and resolve it before presenting — pick the question shape that matches: a blocking multiple-choice tool when options are bounded and meaningfully distinct, prose when option sets would bias the answer per Interaction Rule 5(a). Integrate the answer, then present synthesis. Never present synthesis with adjacent floating questions — that gives the user no clear resolution path
+
+
+## Counter-warning for rich-context invocations
+
+When `gh-plan` is invoked with a rich requirements document, review bundle, or prior `document-review` output, do not drift into a new generic plan. Preserve the source document's decisions, unresolved questions, and scope boundaries, then synthesize implementation steps that `gh-work` can execute. If context conflicts, name the conflict instead of silently replacing the source of truth.

--- a/plugins/galeharness-cli/skills/gh-review/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-review/SKILL.md
@@ -308,10 +308,10 @@ If the output is non-empty, inform the user: "You have uncommitted changes on th
 git checkout <branch>
 ```
 
-Then detect the review base branch and compute the merge-base. Run the `references/resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
+Then detect the review base branch and compute the merge-base. Run the `scripts/resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
 
 ```
-RESOLVE_OUT=$(bash references/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+RESOLVE_OUT=$(bash scripts/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
@@ -328,10 +328,10 @@ You may still fetch additional PR metadata with `gh pr view` for title, body, an
 
 **If no argument (standalone on current branch):**
 
-Detect the review base branch and compute the merge-base using the same `references/resolve-base.sh` script as branch mode:
+Detect the review base branch and compute the merge-base using the same `scripts/resolve-base.sh` script as branch mode:
 
 ```
-RESOLVE_OUT=$(bash references/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+RESOLVE_OUT=$(bash scripts/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
@@ -884,3 +884,14 @@ After the review workflow is fully complete, log the completion event:
 1. Run `gale-task log skill_completed` to record the completion event.
 2. If `gale-task` is not on PATH or the command fails, skip and continue — this must never block the skill.
 <!-- /HKT-PATCH:gale-task-end -->
+
+
+## Upstream P0 review compatibility notes
+
+**PR comment gate for `previous-comments`.** In PR mode, compute `hasPriorComments` from `gh pr view --json state,title,body,files,reviews,comments` (or equivalent API output) before Stage 3. Exclude empty approval-only reviews and empty comments. Select `galeharness-cli:previous-comments-reviewer` only when PR metadata exists and `hasPriorComments == true`; standalone branch mode and PRs with no substantive previous comments skip this persona.
+
+**Bounded parallel dispatch.** Stage 4 reviewer dispatch and Stage 5b validator dispatch use bounded parallel dispatch. Queue selected reviewers, respect the harness active-subagent limit, treat capacity spawn errors as backpressure rather than reviewer failure, and fill freed slots until the queue is drained.
+
+**Model override at dispatch point.** Restate the model override in every subagent dispatch call: in Claude Code pass `model: "sonnet"` for standard persona and CE sub-agents, with escalation allowed for higher-risk reviewers such as `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer`. On other platforms use the equivalent mid-tier model when supported.
+
+**Walk-through entry.** Before showing the first interactive walk-through finding, read `references/walkthrough.md` in full. The walk-through reference is mandatory for per-finding routing.

--- a/plugins/galeharness-cli/skills/gh-review/references/persona-catalog.md
+++ b/plugins/galeharness-cli/skills/gh-review/references/persona-catalog.md
@@ -65,3 +65,6 @@ These CE-native agents provide specialized analysis beyond what the persona agen
 3. **For each stack-specific conditional persona**, use file types and changed patterns as a starting point, then decide whether the diff actually introduces meaningful work for that reviewer. Do not spawn language-specific reviewers just because one config or generated file happens to match the extension.
 4. **For CE conditional agents**, spawn when the diff includes migration files (`db/migrate/*.rb`, `db/schema.rb`) or data backfill scripts.
 5. **Announce the team** before spawning with a one-line justification per conditional reviewer selected.
+
+
+`previous-comments` is PR-only and comment-gated: select it only when PR metadata exists and `hasPriorComments == true` after excluding empty approval-only reviews/comments.

--- a/plugins/galeharness-cli/skills/gh-review/scripts/resolve-base.sh
+++ b/plugins/galeharness-cli/skills/gh-review/scripts/resolve-base.sh
@@ -2,7 +2,7 @@
 # Resolve the review base branch and compute the merge-base for ce:review.
 # Handles fork-safe remote resolution, PR metadata, and multi-fallback detection.
 #
-# Usage: bash references/resolve-base.sh
+# Usage: bash scripts/resolve-base.sh
 # Output: BASE:<sha> on success, ERROR:<message> on failure.
 #
 # Detects the base branch from (in priority order):

--- a/plugins/galeharness-cli/skills/gh-sessions/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-sessions/SKILL.md
@@ -18,7 +18,7 @@ Search your session history.
 
 **Repo name (pre-resolved):** !`bash scripts/resolve-repo-name.sh`
 
-**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null`
+**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || true`
 
 If the lines above resolved to plain values (a folder name like `my-repo` and a branch name like `feat/my-branch`), pass them into the Session Historian dispatch so the agent does not waste a turn deriving them. If they still contain backtick command strings or are empty, omit them from the dispatch and let the agent derive them at runtime.
 

--- a/plugins/galeharness-cli/skills/gh-setup/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-setup/SKILL.md
@@ -233,3 +233,6 @@ Display a brief summary:
 ```
 
 If this is a Claude Code session (per platform detection in Step 3), append: "Run /gh:update to grab the latest plugin version."
+
+
+Agent skill detection checks CLI output first, then falls back to on-disk roots `~/.claude/skills/<skill-name>`, `~/.agents/skills/<skill-name>`, and `~/.codex/skills/<skill-name>` so Codex global skills are detected alongside Claude/Agents installs.

--- a/plugins/galeharness-cli/skills/gh-setup/scripts/check-health
+++ b/plugins/galeharness-cli/skills/gh-setup/scripts/check-health
@@ -56,6 +56,15 @@ detail()  { echo "       $1"; }
 section() { echo ""; echo " $1"; }
 
 has_brew=$(command -v brew >/dev/null 2>&1 && echo "yes" || echo "no")
+skill_roots=("$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.codex/skills")
+skill_exists_on_disk() {
+  local skill_name="$1"
+  local root
+  for root in "${skill_roots[@]}"; do
+    [ -d "$root/$skill_name" ] && return 0
+  done
+  return 1
+}
 in_repo=$(git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo "yes" || echo "no")
 
 # =====================================================

--- a/plugins/galeharness-cli/skills/gh-update/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-update/SKILL.md
@@ -8,6 +8,7 @@ description: |
   that might stem from a stale GaleHarnessCLI plugin version. This skill only works
   in Claude Code — it relies on the plugin harness cache layout.
 disable-model-invocation: true
+allowed-tools: Bash(bash *upstream-version.sh), Bash(bash *currently-loaded-version.sh), Bash(bash *marketplace-name.sh)
 ce_platforms: [claude]
 ---
 
@@ -20,35 +21,19 @@ Claude Code only.
 > **Note:** This skill updates the **plugin cache** only. To update the CLI binary
 > itself, run `gale-harness update` from your terminal.
 
-## Pre-resolved context
+## Runtime probes
 
-Only the **Skill directory** determines whether this session is Claude Code —
-if empty or unresolved, the skill requires Claude Code. The other sections may
-contain error sentinels even in valid Claude Code sessions; the decision logic
-below handles those cases.
+Only the **Skill directory** determines whether this session is Claude Code -- if empty or unresolved, the skill requires Claude Code. Probe versions at runtime rather than through `!` pre-resolution so Claude Code permission checks do not reject nested command substitutions or bundled shell scripts.
 
-`${CLAUDE_SKILL_DIR}` is a Claude Code-documented substitution that resolves
-at skill-load time. For a marketplace-cached install it looks like
-`~/.claude/plugins/cache/<marketplace>/galeharness-cli/<version>/skills/gh-update`,
-so the currently-loaded version is the basename two `dirname` levels up.
+Run these probes from the skill body using the documented `${CLAUDE_SKILL_DIR}` substitution:
 
-The upstream version comes from `plugins/galeharness-cli/.claude-plugin/plugin.json`
-on `main` rather than the latest GitHub release tag, because the marketplace
-installs plugin contents from `main` HEAD. Comparing against release tags
-false-positives whenever `main` is ahead of the last tag (the normal state
-between releases).
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/upstream-version.sh"
+bash "${CLAUDE_SKILL_DIR}/scripts/currently-loaded-version.sh"
+bash "${CLAUDE_SKILL_DIR}/scripts/marketplace-name.sh"
+```
 
-**Skill directory:**
-!`echo "${CLAUDE_SKILL_DIR}"`
-
-**Latest upstream version:**
-!`version=$(gh api repos/wangrenzhu-ola/GaleHarnessCLI/contents/plugins/galeharness-cli/.claude-plugin/plugin.json --jq '.content | @base64d | fromjson | .version' 2>/dev/null) && [ -n "$version" ] && echo "$version" || echo '__CE_UPDATE_VERSION_FAILED__'`
-
-**Currently loaded version:**
-!`echo "${CLAUDE_SKILL_DIR}" | grep -q "/plugins/cache/.*/galeharness-cli/.*/skills/gh-update$" && basename "$(dirname "$(dirname "${CLAUDE_SKILL_DIR}")")" || echo '__CE_UPDATE_NOT_MARKETPLACE__'`
-
-**Marketplace name:**
-!`echo "${CLAUDE_SKILL_DIR}" | grep -q "/plugins/cache/.*/galeharness-cli/.*/skills/gh-update$" && basename "$(dirname "$(dirname "$(dirname "$(dirname "${CLAUDE_SKILL_DIR}")")")")" || echo '__CE_UPDATE_NOT_MARKETPLACE__'`
+The upstream version comes from `plugins/galeharness-cli/.claude-plugin/plugin.json` on `main` rather than the latest GitHub release tag, because the marketplace installs plugin contents from `main` HEAD. Comparing against release tags false-positives whenever `main` is ahead of the last tag.
 
 ## Decision logic
 
@@ -59,11 +44,11 @@ requires Claude Code and stop. No further action.
 
 ### 2. Handle failure cases
 
-If **Latest upstream version** contains `__CE_UPDATE_VERSION_FAILED__`: tell
+If **Latest upstream version** contains `__GH_UPDATE_VERSION_FAILED__`: tell
 the user the upstream version could not be fetched (gh may be unavailable or
 rate-limited) and stop.
 
-If **Currently loaded version** contains `__CE_UPDATE_NOT_MARKETPLACE__`: this
+If **Currently loaded version** contains `__GH_UPDATE_NOT_MARKETPLACE__`: this
 session loaded the skill from outside the standard marketplace cache (typical
 when using `claude --plugin-dir` for local development, or for a non-standard
 install). Tell the user (substituting the actual path):

--- a/plugins/galeharness-cli/skills/gh-update/scripts/currently-loaded-version.sh
+++ b/plugins/galeharness-cli/skills/gh-update/scripts/currently-loaded-version.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -o pipefail
+if echo "${CLAUDE_SKILL_DIR:-}" | grep -q "/plugins/cache/.*/galeharness-cli/.*/skills/gh-update$"; then
+  basename "$(dirname "$(dirname "${CLAUDE_SKILL_DIR}")")"
+else
+  echo '__GH_UPDATE_NOT_MARKETPLACE__'
+fi

--- a/plugins/galeharness-cli/skills/gh-update/scripts/marketplace-name.sh
+++ b/plugins/galeharness-cli/skills/gh-update/scripts/marketplace-name.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -o pipefail
+if echo "${CLAUDE_SKILL_DIR:-}" | grep -q "/plugins/cache/.*/galeharness-cli/.*/skills/gh-update$"; then
+  basename "$(dirname "$(dirname "$(dirname "$(dirname "${CLAUDE_SKILL_DIR}")")")")"
+else
+  echo '__GH_UPDATE_NOT_MARKETPLACE__'
+fi

--- a/plugins/galeharness-cli/skills/gh-update/scripts/upstream-version.sh
+++ b/plugins/galeharness-cli/skills/gh-update/scripts/upstream-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o pipefail
+version=$(gh api repos/wangrenzhu-ola/GaleHarnessCodingCLI/contents/plugins/galeharness-cli/.claude-plugin/plugin.json --jq '.content | @base64d | fromjson | .version' 2>/dev/null)
+if [ -n "$version" ]; then
+  echo "$version"
+else
+  echo '__GH_UPDATE_VERSION_FAILED__'
+fi

--- a/plugins/galeharness-cli/skills/gh-work-beta/references/shipping-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-work-beta/references/shipping-workflow.md
@@ -20,13 +20,15 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    Every change gets reviewed before shipping. The depth scales with the change's risk profile, but review itself is never skipped.
 
-   **Tier 2: Full review (default)** -- REQUIRED unless Tier 1 criteria are explicitly met. Invoke the `gh:review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and record residual downstream work in the per-run artifact. When the plan file path is known, pass it as `plan:<path>`. This is the mandatory default -- proceed to Tier 1 only after confirming every criterion below.
+   **Tier 1 -- harness-native code review (default)** -- Use the harness-native code review first (`/review` in Claude Code, or the equivalent native review surface in other harnesses). This is the default for ordinary, well-scoped changes because it is fast and keeps review close to the current diff.
 
-   **Tier 1: Inline self-review** -- A lighter alternative permitted only when **all four** criteria are true. Before choosing Tier 1, explicitly state which criteria apply and why. If any criterion is uncertain, use Tier 2.
-   - Purely additive (new files only, no existing behavior modified)
-   - Single concern (one skill, one component -- not cross-cutting)
-   - Pattern-following (implementation mirrors an existing example with no novel logic)
-   - Plan-faithful (no scope growth, no deferred questions resolved with surprising answers)
+   **Tier 2 -- `gh:review` escalation** -- Invoke `gh:review mode:autofix` when risk calls for specialized reviewer agents, auto-applied safe fixes, and a durable residual artifact. Escalate when any of these apply:
+   - Sensitive surface touched (security, data migrations, permissions, release automation, billing, authentication, or user data)
+   - Large, diffuse, or cross-cutting changes
+   - Very large changes where multiple review personas materially reduce risk
+   - Explicit request for full review
+
+   When the plan file path is known, pass it as `plan:<path>`. Record whether Tier 1 harness-native or Tier 2 `gh:review` was used in the PR evidence.
 
 3. **Final Validation**
    - All tasks marked completed

--- a/plugins/galeharness-cli/skills/gh-work/references/shipping-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-work/references/shipping-workflow.md
@@ -20,13 +20,15 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    Every change gets reviewed before shipping. The depth scales with the change's risk profile, but review itself is never skipped.
 
-   **Tier 2: Full review (default)** -- REQUIRED unless Tier 1 criteria are explicitly met. Invoke the `gh:review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and record residual downstream work in the per-run artifact. When the plan file path is known, pass it as `plan:<path>`. This is the mandatory default -- proceed to Tier 1 only after confirming every criterion below.
+   **Tier 1 -- harness-native code review (default)** -- Use the harness-native code review first (`/review` in Claude Code, or the equivalent native review surface in other harnesses). This is the default for ordinary, well-scoped changes because it is fast and keeps review close to the current diff.
 
-   **Tier 1: Inline self-review** -- A lighter alternative permitted only when **all four** criteria are true. Before choosing Tier 1, explicitly state which criteria apply and why. If any criterion is uncertain, use Tier 2.
-   - Purely additive (new files only, no existing behavior modified)
-   - Single concern (one skill, one component -- not cross-cutting)
-   - Pattern-following (implementation mirrors an existing example with no novel logic)
-   - Plan-faithful (no scope growth, no deferred questions resolved with surprising answers)
+   **Tier 2 -- `gh:review` escalation** -- Invoke `gh:review mode:autofix` when risk calls for specialized reviewer agents, auto-applied safe fixes, and a durable residual artifact. Escalate when any of these apply:
+   - Sensitive surface touched (security, data migrations, permissions, release automation, billing, authentication, or user data)
+   - Large, diffuse, or cross-cutting changes
+   - Very large changes where multiple review personas materially reduce risk
+   - Explicit request for full review
+
+   When the plan file path is known, pass it as `plan:<path>`. Record whether Tier 1 harness-native or Tier 2 `gh:review` was used in the PR evidence.
 
 3. **Final Validation**
    - All tasks marked completed

--- a/plugins/galeharness-cli/skills/git-commit-push-pr/references/pr-description-writing.md
+++ b/plugins/galeharness-cli/skills/git-commit-push-pr/references/pr-description-writing.md
@@ -284,3 +284,8 @@ Before applying, re-read the composed body and apply these cuts:
 **Value-lead check.** Re-read the first sentence of the Summary. If it describes what was moved around, renamed, or added ("This PR introduces three-tier autofix..."), rewrite to lead with what's now possible or what was broken and is now fixed ("Document reviews previously produced 14+ findings requiring user judgment; this PR cuts that to 4-6.").
 
 Large PRs benefit from selectivity, not comprehensiveness.
+
+
+### Model slug URL encoding
+
+When model badges include literal parentheses, URL-encode literal parens as `%28` and `%29`. Examples: `Opus_4.6_%281M,_Extended_Thinking%29`, `Sonnet_4.6_%28200K%29`. Do not emit unencoded parenthesized model slugs in badge URLs.

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -20,10 +20,12 @@ describe("gh:work review contract", () => {
     // Phase 3 has a mandatory code review step in the reference file
     expect(shipping).toContain("2. **Code Review**")
 
-    // Two-tier rubric in reference file
-    expect(shipping).toContain("**Tier 1: Inline self-review**")
-    expect(shipping).toContain("**Tier 2: Full review (default)**")
-    expect(shipping).toContain("gh:review")
+    // Risk-scaled review rubric in reference file
+    expect(shipping).toContain("**Tier 1 -- harness-native code review (default)**")
+    expect(shipping).toContain("**Tier 2 -- `gh:review` escalation**")
+    expect(shipping).toContain("Sensitive surface touched")
+    expect(shipping).toContain("Large, diffuse, or cross-cutting changes")
+    expect(shipping).toContain("Explicit request for full review")
     expect(shipping).toContain("mode:autofix")
 
     // Quality checklist includes review

--- a/tests/resolve-base-script.test.ts
+++ b/tests/resolve-base-script.test.ts
@@ -19,7 +19,7 @@ const resolveBaseScript = path.join(
   "galeharness-cli",
   "skills",
   "gh-review",
-  "references",
+  "scripts",
   "resolve-base.sh",
 )
 

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -414,9 +414,9 @@ describe("ce-review contract", () => {
 
     // Branch and standalone modes delegate to resolve-base.sh and check its ERROR: output.
     // The script itself emits ERROR: when the base is unresolved.
-    expect(content).toContain("references/resolve-base.sh")
+    expect(content).toContain("scripts/resolve-base.sh")
     const resolveScript = await readRepoFile(
-      "plugins/galeharness-cli/skills/gh-review/references/resolve-base.sh",
+      "plugins/galeharness-cli/skills/gh-review/scripts/resolve-base.sh",
     )
     expect(resolveScript).toContain("ERROR:")
 
@@ -424,6 +424,49 @@ describe("ce-review contract", () => {
     expect(content).toContain(
       "If the script outputs an error, stop instead of falling back to `git diff HEAD`",
     )
+  })
+
+  test("imports P0 upstream review dispatch fixes", async () => {
+    const content = await readRepoFile("plugins/galeharness-cli/skills/gh-review/SKILL.md")
+    const catalog = await readRepoFile(
+      "plugins/galeharness-cli/skills/gh-review/references/persona-catalog.md",
+    )
+
+    expect(content).toContain("hasPriorComments")
+    expect(content).toMatch(/comment gate for `previous-comments`/i)
+    expect(catalog).toContain("hasPriorComments == true")
+    expect(content).toContain("Bounded parallel dispatch")
+    expect(content).toMatch(/capacity spawn errors as backpressure/i)
+    expect(content).toMatch(/model: "sonnet"/)
+    expect(content).toMatch(/Before showing the first interactive walk-through finding, read `references\/walkthrough.md` in full/)
+  })
+
+  test("JSON-pipeline reviewers can write artifact files", async () => {
+    const reviewers = [
+      "correctness-reviewer",
+      "testing-reviewer",
+      "maintainability-reviewer",
+      "project-standards-reviewer",
+      "security-reviewer",
+      "performance-reviewer",
+      "api-contract-reviewer",
+      "data-migrations-reviewer",
+      "reliability-reviewer",
+      "adversarial-reviewer",
+      "previous-comments-reviewer",
+      "dhh-rails-reviewer",
+      "gale-rails-reviewer",
+      "gale-python-reviewer",
+      "gale-typescript-reviewer",
+      "julik-frontend-races-reviewer",
+      "swift-ios-reviewer",
+    ]
+
+    for (const reviewer of reviewers) {
+      const content = await readRepoFile(`plugins/galeharness-cli/agents/${reviewer}.md`)
+      const parsed = parseFrontmatter(content)
+      expect(String(parsed.data.tools ?? "")).toContain("Write")
+    }
   })
 
   test("orchestration callers pass explicit mode flags", async () => {

--- a/tests/skills/gh-update.test.ts
+++ b/tests/skills/gh-update.test.ts
@@ -26,13 +26,17 @@ describe("gh-update SKILL.md", () => {
 // Comparing the installed folder against the latest GitHub release tag caused
 // a persistent false-positive "out of date" whenever `main` was ahead of the
 // last tag, and the prescribed fix reinstalled the same version in a loop.
-describe("gh-update 'Latest upstream version' pre-resolution command", () => {
-  test("declares a 'Latest upstream version' pre-resolution section", () => {
-    expect(SKILL_BODY).toMatch(/\*\*Latest upstream version:\*\*\s*\n!`[^`\n]+`/)
+describe("gh-update runtime probe scripts", () => {
+  test("declares runtime script probes instead of unsafe pre-resolution commands", () => {
+    expect(SKILL_BODY).toContain("## Runtime probes")
+    expect(SKILL_BODY).toContain('bash "${CLAUDE_SKILL_DIR}/scripts/upstream-version.sh"')
+    expect(SKILL_BODY).toContain('bash "${CLAUDE_SKILL_DIR}/scripts/currently-loaded-version.sh"')
+    expect(SKILL_BODY).toContain('bash "${CLAUDE_SKILL_DIR}/scripts/marketplace-name.sh"')
+    expect(SKILL_BODY).not.toMatch(/\*\*Latest upstream version:\*\*\s*\n!`/)
   })
 
   test("returns the version from main's plugin.json, not any release tag", () => {
-    const stdout = runUpstreamCommand(extractUpstreamVersionCommand(SKILL_BODY), {
+    const stdout = runUpstreamCommand(upstreamVersionScript(), {
       pluginJsonVersion: "99.0.0",
       releaseTagVersion: "1.0.0",
     })
@@ -40,23 +44,20 @@ describe("gh-update 'Latest upstream version' pre-resolution command", () => {
     expect(stdout).toBe("99.0.0")
   })
 
-  test("emits __CE_UPDATE_VERSION_FAILED__ when upstream plugin.json cannot be read", () => {
-    const stdout = runUpstreamCommand(extractUpstreamVersionCommand(SKILL_BODY), {
+  test("emits __GH_UPDATE_VERSION_FAILED__ when upstream plugin.json cannot be read", () => {
+    const stdout = runUpstreamCommand(upstreamVersionScript(), {
       ghExitCode: 1,
     })
 
-    expect(stdout).toContain("__CE_UPDATE_VERSION_FAILED__")
+    expect(stdout).toContain("__GH_UPDATE_VERSION_FAILED__")
   })
 })
 
-function extractUpstreamVersionCommand(body: string): string {
-  const match = body.match(/\*\*Latest upstream version:\*\*\s*\n!`([^`\n]+)`/)
-  if (!match) {
-    throw new Error(
-      `Could not extract 'Latest upstream version' pre-resolution command from ${SKILL_PATH}`,
-    )
-  }
-  return match[1]
+function upstreamVersionScript(): string {
+  return path.join(
+    process.cwd(),
+    "plugins/galeharness-cli/skills/gh-update/scripts/upstream-version.sh",
+  )
 }
 
 type MockOptions = {
@@ -111,7 +112,7 @@ esac
     writeFileSync(ghPath, ghScript)
     chmodSync(ghPath, 0o755)
 
-    return execFileSync("bash", ["-c", command], {
+    return execFileSync("bash", [command], {
       env: { ...process.env, PATH: `${mockDir}:${process.env.PATH ?? ""}` },
       encoding: "utf8",
     }).trim()


### PR DESCRIPTION
## Summary
- Imports the P0 upstream v3.4.1 review/plan/session/setup/update fixes after the CE->Gale mapping layer landed in #104.
- Moves the review resolve-base helper into `gh-review/scripts/`, updates reviewer agent JSON pipeline permissions, and tightens review contract tests.
- Adds runtime-safe `gh:update` probe scripts and P0 workflow guidance for plan/session/compound/shipping paths.

## Validation
- `bun test` -> 1372 pass, 3 skip, 0 fail
- `bun run release:validate` -> Release metadata is in sync. compound-engineering currently has 50 agents, 38 skills, and 0 MCP servers.

## Risks / rollback
- Touches multiple plugin runtime skills and reviewer agents; rollback is reverting this PR.
- Agent inventory cleanup is intentionally deferred to #103 so this PR stays focused on P0 fixes.
- Strategy/Product Pulse/Simplify Code capability expansion is intentionally deferred to #101.

Closes #100
Depends on #104
