### PR TITLE
fix(release): include gale-task in cli archives

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -110,6 +110,11 @@ jobs:
       - name: Build release binaries
         run: bun run build:release --version ${{ needs.determine-version.outputs.version }} --platform ${{ matrix.platform }}
 
+      - name: Verify release archive contract
+        run: |
+          ARCHIVE="galeharness-cli-${{ needs.determine-version.outputs.version }}-${{ matrix.platform }}.tar.gz"
+          bun run scripts/release/verify-archive.ts "$ARCHIVE"
+
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -100,13 +100,14 @@ expected_files() {
     "compound-plugin$exe" \
     "gale-knowledge$exe" \
     "gale-memory$exe" \
+    "gale-task$exe" \
     "VERSION"
 }
 
 is_expected_file() {
   local entry="$1"
   case "$entry" in
-    "gale-harness$exe" | "compound-plugin$exe" | "gale-knowledge$exe" | "gale-memory$exe" | "VERSION")
+    "gale-harness$exe" | "compound-plugin$exe" | "gale-knowledge$exe" | "gale-memory$exe" | "gale-task$exe" | "VERSION")
       return 0
       ;;
     *)
@@ -189,7 +190,7 @@ fi
 validate_archive_listing "$archive_path"
 tar -xzf "$archive_path" -C "$tmpdir"
 
-for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
+for bin in gale-harness compound-plugin gale-knowledge gale-memory gale-task; do
   src="$tmpdir/$bin$exe"
   if [ ! -f "$src" ] || [ -L "$src" ]; then
     err "archive entry is not a regular file: $bin$exe"
@@ -203,7 +204,7 @@ if [ ! -f "$tmpdir/VERSION" ] || [ -L "$tmpdir/VERSION" ]; then
 fi
 
 mkdir -p "$install_dir"
-for bin in gale-harness compound-plugin gale-knowledge gale-memory; do
+for bin in gale-harness compound-plugin gale-knowledge gale-memory gale-task; do
   src="$tmpdir/$bin$exe"
   dest="$install_dir/$bin$exe"
   if [ -L "$dest" ]; then
@@ -227,6 +228,7 @@ Then verify:
   gale-harness --version
   gale-harness update --check
   gale-memory status
+  gale-task validate --file <workflow-bundle.json>
 
 Gale-managed HKTMemory uses ~/.galeharness/knowledge/<project>/hkt-memory by default.
 If hkt-memory is not on PATH, gale-memory status/start will report a diagnostic instead

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -50,6 +50,25 @@ const version = parsed.version || packageJson.version
 const platform = parsed.platform || detectReleasePlatform()
 const platformConfig = getReleasePlatformConfig(platform)
 
+function compileBinary(entrypoint: string, outfile: string): void {
+  execFileSync(
+    "bun",
+    [
+      "build",
+      "--compile",
+      entrypoint,
+      "--outfile",
+      outfile,
+      "--target",
+      platformConfig.bunTarget,
+    ],
+    {
+      cwd: repoRoot,
+      stdio: ["ignore", "ignore", "inherit"],
+    },
+  )
+}
+
 // ── Build ───────────────────────────────────────────────────────────────────
 
 const buildDir = path.join(os.tmpdir(), `galeharness-build-${version}-${platform}`)
@@ -70,22 +89,7 @@ console.error(`[build] Compiling binaries (v${version}, ${platform}, target ${pl
 
 // 1. Compile gale-harness (src/index.ts)
 const galeHarnessBinary = getReleaseBinaryFileName("gale-harness", platform)
-execFileSync(
-  "bun",
-  [
-    "build",
-    "--compile",
-    "src/index.ts",
-    "--outfile",
-    path.join(buildDir, galeHarnessBinary),
-    "--target",
-    platformConfig.bunTarget,
-  ],
-  {
-    cwd: repoRoot,
-    stdio: ["ignore", "ignore", "inherit"],
-  },
-)
+compileBinary("src/index.ts", path.join(buildDir, galeHarnessBinary))
 
 // 2. Copy as compound-plugin (same entry point, different binary name)
 fs.copyFileSync(
@@ -97,23 +101,9 @@ fs.copyFileSync(
 for (const [basename, entrypoint] of [
   ["gale-knowledge", "cmd/gale-knowledge/index.ts"],
   ["gale-memory", "cmd/gale-memory/index.ts"],
+  ["gale-task", "cmd/gale-task/index.ts"],
 ] as const) {
-  execFileSync(
-    "bun",
-    [
-      "build",
-      "--compile",
-      entrypoint,
-      "--outfile",
-      path.join(buildDir, getReleaseBinaryFileName(basename, platform)),
-      "--target",
-      platformConfig.bunTarget,
-    ],
-    {
-      cwd: repoRoot,
-      stdio: ["ignore", "ignore", "inherit"],
-    },
-  )
+  compileBinary(entrypoint, path.join(buildDir, getReleaseBinaryFileName(basename, platform)))
 }
 
 // 4. Write VERSION file

--- a/src/utils/release-platforms.ts
+++ b/src/utils/release-platforms.ts
@@ -5,6 +5,7 @@ export const RELEASE_BINARY_BASENAMES = [
   "compound-plugin",
   "gale-knowledge",
   "gale-memory",
+  "gale-task",
 ] as const
 
 export type ReleaseBinaryBaseName = (typeof RELEASE_BINARY_BASENAMES)[number]

--- a/tests/release-archive.test.ts
+++ b/tests/release-archive.test.ts
@@ -24,7 +24,7 @@ function validEntries(platform: string, version = "9.8.7"): TarFixtureEntry[] {
 }
 
 describe("release archive verifier", () => {
-  test("accepts a linux archive with all four CLI binaries and VERSION", async () => {
+  test("accepts a linux archive with all release CLI binaries and VERSION", async () => {
     const archive = await writeArchive("galeharness-cli-9.8.7-linux-x64.tar.gz", validEntries("linux-x64"))
 
     expect(() => verifyReleaseArchive(archive)).not.toThrow()

--- a/tests/update-command.test.ts
+++ b/tests/update-command.test.ts
@@ -111,6 +111,7 @@ describe("update utils", () => {
         "compound-plugin.exe",
         "gale-knowledge.exe",
         "gale-memory.exe",
+        "gale-task.exe",
       ])
     })
   })


### PR DESCRIPTION
## Summary

Fixes #99 by shipping the workflow runtime CLI in release archives.

- compile `cmd/gale-task/index.ts` into every `galeharness-cli-*` archive
- add `gale-task(.exe)` to release platform metadata / verifier expectations
- verify the release archive contract in the Release Assets workflow before upload
- update release archive/update tests for the fifth binary

## Local validation

```text
bun test tests/release-archive.test.ts tests/update-command.test.ts tests/workflow-runtime.test.ts
# 33 pass, 3 skip, 0 fail

bun run build:release --version 2.11.99 --platform darwin-arm64
bun run scripts/release/verify-archive.ts galeharness-cli-2.11.99-darwin-arm64.tar.gz
# Verified galeharness-cli-2.11.99-darwin-arm64.tar.gz

archive contents:
VERSION
compound-plugin
gale-harness
gale-knowledge
gale-memory
gale-task
```

## Production acceptance plan after merge/release

Publish patch release and download the real GitHub release asset, then verify:

- archive includes executable `gale-task`
- `gale-task validate --file <sample>` exits 0
- `gale-task events|graph|rollup --db <sample>` are invokable on the released binary
