### PR TITLE
feat(skills): add GitNexus guidance to gh-plan, gh-work, gh-debug

### DIFF
--- a/plugins/galeharness-cli/skills/gh-debug/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug/SKILL.md
@@ -10,6 +10,47 @@ Find root causes, then fix them. This skill investigates bugs systematically —
 
 <bug_description> #$ARGUMENTS </bug_description>
 
+## GitNexus Context (Optional Code Intelligence)
+
+`gh:debug` may optionally use GitNexus to enrich debugging context when the local repo has a GitNexus index. GitNexus provides code-structure awareness, symbol-level context, and impact analysis that can accelerate root-cause identification. It is **never required** — missing `gitnexus`, a stale index, timeout, or command failure must not block debugging.
+
+### Detecting GitNexus Availability
+
+Before using GitNexus, verify the repo is indexed:
+
+```bash
+# Check if gitnexus is available and the repo has an index
+gitnexus list 2>/dev/null && echo "GitNexus available" || echo "GitNexus unavailable — proceeding without it"
+```
+
+For multi-repo environments, use explicit repo labels: `gitnexus list -r <repo-label>`.
+
+### Stable Commands (Preferred)
+
+When GitNexus is available, prefer these stable commands:
+
+- **`gitnexus cypher -r <repo-label>`** — Markdown/file/content lookup. Use for finding relevant files, symbols, or content patterns related to the bug surface.
+- **`gitnexus context -r <repo-label>`** — Symbol-level context. Use for understanding the surroundings of a specific function, class, or module implicated in the error.
+- **`gitnexus impact -r <repo-label>`** — Impact analysis. Use for assessing blast radius when the root cause touches shared surfaces, callbacks, or exported APIs.
+
+### Best-Effort / Experimental
+
+- **`gitnexus query`** — Best-effort/experimental only. Current versions can emit read-only FTS warnings or return empty markdown-heavy results. Use only when the stable commands above do not cover the need, and treat results as supplementary.
+
+### Integration Points
+
+- **Phase 1 (Investigate):** After reproducing the bug and tracing the code path, if GitNexus is available, run `gitnexus cypher` or `gitnexus context` for the error surface and upstream callers. Include findings in the causal chain analysis.
+- **Phase 2 (Root Cause):** When the bug touches shared surfaces, `gitnexus impact` can help identify cross-layer callers or consumers that local grep might miss. Cross-check with actual source files — GitNexus findings are guidance only, never primary evidence.
+- **Phase 3 (Fix):** Before implementing a fix that modifies shared code, `gitnexus impact` can surface other locations that may need the same correction.
+
+### License Caution
+
+`gitnexus` currently advertises `PolyForm-Noncommercial-1.0.0`; production/company usage needs commercial/legal review. P0 remains optional/local.
+
+### Boundary Note
+
+GitNexus is optional code intelligence for `gh:debug`. It is not a mandatory runtime dependency, not a GitHub fact source, and not HKTMemory. Always re-check code and tests independently.
+
 ## Core Principles
 
 These principles govern every phase. They are repeated at decision points because they matter most when the pressure to skip them is highest.

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -36,6 +36,47 @@ At the start of execution, use your native file-read tool to read `.compound-eng
 If the config file contains `language: en`, write documents in English.
 If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
+## GitNexus Context (Optional Code Intelligence)
+
+`gh:plan` may optionally use GitNexus to enrich planning context when the local repo has a GitNexus index. GitNexus provides code-structure awareness, likely file/module hints, and impact analysis that can improve plan quality. It is **never required** — missing `gitnexus`, a stale index, timeout, or command failure must not block planning.
+
+### Detecting GitNexus Availability
+
+Before using GitNexus, verify the repo is indexed:
+
+```bash
+# Check if gitnexus is available and the repo has an index
+gitnexus list 2>/dev/null && echo "GitNexus available" || echo "GitNexus unavailable — proceeding without it"
+```
+
+For multi-repo environments, use explicit repo labels: `gitnexus list -r <repo-label>`.
+
+### Stable Commands (Preferred)
+
+When GitNexus is available, prefer these stable commands:
+
+- **`gitnexus cypher -r <repo-label>`** — Markdown/file/content lookup. Use for finding relevant files, symbols, or content patterns.
+- **`gitnexus context -r <repo-label>`** — Symbol-level context. Use for understanding the surroundings of a specific function, class, or module.
+- **`gitnexus impact -r <repo-label>`** — Impact analysis. Use for assessing blast radius before proposing changes that touch shared surfaces.
+
+### Best-Effort / Experimental
+
+- **`gitnexus query`** — Best-effort/experimental only. Current versions can emit read-only FTS warnings or return empty markdown-heavy results. Use only when the stable commands above do not cover the need, and treat results as supplementary.
+
+### Integration Points
+
+- **Phase 1 (Gather Context):** After local research, if GitNexus is available, run `gitnexus cypher` or `gitnexus context` for the key components identified in the planning context summary. Include findings in the `### Relevant Code and Patterns` section of the plan.
+- **Phase 1.5 (Flow and Edge-Case Analysis):** For Standard or Deep plans touching shared surfaces, `gitnexus impact` can help identify cross-layer callers or consumers that local grep might miss.
+- **Phase 3 (Structure the Plan):** GitNexus findings are guidance only, never primary evidence. Always cross-check with actual source files. Do not treat GitNexus output as a substitute for reading code.
+
+### License Caution
+
+`gitnexus` currently advertises `PolyForm-Noncommercial-1.0.0`; production/company usage needs commercial/legal review. P0 remains optional/local.
+
+### Boundary Note
+
+GitNexus is optional code intelligence for `gh:plan`. It is not a mandatory runtime dependency, not a GitHub fact source, and not HKTMemory. Downstream `gh:work` and `gh:debug` must re-check code and tests independently.
+
 ## Core Principles
 
 1. **Use requirements as the source of truth** - If `gh:brainstorm` produced a requirements document, planning should build from it rather than re-inventing behavior.

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -436,6 +436,47 @@ After the work is complete and the shipping workflow has finished (PR created or
 **Note:** This creates a searchable record of completed work for future reference when similar tasks arise.
 <!-- /HKT-PATCH:phase-4.5 -->
 
+## GitNexus Context (Optional Code Intelligence)
+
+`gh:work` may optionally use GitNexus to enrich execution context when the local repo has a GitNexus index. GitNexus provides code-structure awareness, likely file/module hints, and impact analysis that can improve implementation quality. It is **never required** — missing `gitnexus`, a stale index, timeout, or command failure must not block execution.
+
+### Detecting GitNexus Availability
+
+Before using GitNexus, verify the repo is indexed:
+
+```bash
+# Check if gitnexus is available and the repo has an index
+gitnexus list 2>/dev/null && echo "GitNexus available" || echo "GitNexus unavailable — proceeding without it"
+```
+
+For multi-repo environments, use explicit repo labels: `gitnexus list -r <repo-label>`.
+
+### Stable Commands (Preferred)
+
+When GitNexus is available, prefer these stable commands:
+
+- **`gitnexus cypher -r <repo-label>`** — Markdown/file/content lookup. Use for finding relevant files, symbols, or content patterns before implementing changes.
+- **`gitnexus context -r <repo-label>`** — Symbol-level context. Use for understanding the surroundings of a specific function, class, or module being modified.
+- **`gitnexus impact -r <repo-label>`** — Impact analysis. Use for assessing blast radius before changes that touch shared surfaces, callbacks, or exported APIs.
+
+### Best-Effort / Experimental
+
+- **`gitnexus query`** — Best-effort/experimental only. Current versions can emit read-only FTS warnings or return empty markdown-heavy results. Use only when the stable commands above do not cover the need, and treat results as supplementary.
+
+### Integration Points
+
+- **Phase 0 (Input Triage):** After scanning the work area, if GitNexus is available, run `gitnexus cypher` for the key components identified in the prompt or plan. Use findings to refine the task list and identify files likely to change.
+- **Phase 2 (Execute):** Before implementing a unit that touches shared surfaces, `gitnexus impact` can surface callers or consumers that local grep might miss. Cross-check with actual source files — GitNexus findings are guidance only, never primary evidence.
+- **Test Discovery:** When a plan specifies test files, `gitnexus context` around the test entry points can help identify related test utilities or fixtures.
+
+### License Caution
+
+`gitnexus` currently advertises `PolyForm-Noncommercial-1.0.0`; production/company usage needs commercial/legal review. P0 remains optional/local.
+
+### Boundary Note
+
+GitNexus is optional code intelligence for `gh:work`. It is not a mandatory runtime dependency, not a GitHub fact source, and not HKTMemory. Always re-check code and tests independently.
+
 ## Key Principles
 
 ### Start Fast, Execute Faster


### PR DESCRIPTION
Adds optional GitNexus Context sections to three GaleHarness source skills:

- **gh-plan**: enrichment during planning context gathering (Phase 1 / 1.5)
- **gh-work**: enrichment during execution triage and shared-surface changes (Phase 0 / 2)
- **gh-debug**: enrichment during investigation and root-cause analysis (Phase 1 / 2 / 3)

**Stable commands**: `gitnexus cypher`, `gitnexus context`, `gitnexus impact`
**Best-effort only**: `gitnexus query`

Includes license caution (PolyForm-Noncommercial-1.0.0) and boundary note that GitNexus is optional code intelligence, not a mandatory dependency.

Closes #115