### PR TITLE
feat: add gh-nexus skill for GitNexus code intelligence

### DIFF
--- a/plugins/galeharness-cli/README.md
+++ b/plugins/galeharness-cli/README.md
@@ -46,7 +46,7 @@ language: zh-CN  # zh-CN (Chinese, default) or en (English)
 | Component | Count |
 |-----------|-------|
 | Agents | 50+ |
-| Skills | 41 |
+| Skills | 42 |
 
 ## Skills
 
@@ -74,6 +74,7 @@ Use the horizontal skills (`/gh:debug`, `/gh:optimize`, `/gh:simplify-code`, `/g
 | `/gh-demo-reel` | Capture visual or terminal evidence after a change is working and before/while preparing PR evidence. | GIF, screenshot, or terminal recording URL/path suitable for PR notes. |
 | `/gh:compound` | A problem was solved and should become reusable team knowledge. | A durable learning/solution document for future retrieval. |
 | `/gh:compound-refresh` | Existing `docs/solutions/` knowledge may be stale, duplicated, or drifting. | Keep/update/replace/archive decisions and refreshed docs. |
+| `/gh:nexus` | Analyze repos with GitNexus code intelligence (symbols, cypher queries, impact analysis). | Indexed repo insights, symbol context, change-impact reports. |
 
 For `/gh:optimize`, see [`skills/gh-optimize/README.md`](./skills/gh-optimize/README.md) for usage guidance, example specs, and links to the schema and workflow docs.
 

--- a/plugins/galeharness-cli/skills/gh-debug/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug/SKILL.md
@@ -10,6 +10,47 @@ Find root causes, then fix them. This skill investigates bugs systematically —
 
 <bug_description> #$ARGUMENTS </bug_description>
 
+## GitNexus Context (Optional Code Intelligence)
+
+`gh:debug` may optionally use GitNexus to enrich debugging context when the local repo has a GitNexus index. GitNexus provides code-structure awareness, symbol-level context, and impact analysis that can accelerate root-cause identification. It is **never required** — missing `gitnexus`, a stale index, timeout, or command failure must not block debugging.
+
+### Detecting GitNexus Availability
+
+Before using GitNexus, verify the repo is indexed:
+
+```bash
+# Check if gitnexus is available and the repo has an index
+gitnexus list 2>/dev/null && echo "GitNexus available" || echo "GitNexus unavailable — proceeding without it"
+```
+
+For multi-repo environments, use explicit repo labels: `gitnexus list -r <repo-label>`.
+
+### Stable Commands (Preferred)
+
+When GitNexus is available, prefer these stable commands:
+
+- **`gitnexus cypher -r <repo-label>`** — Markdown/file/content lookup. Use for finding relevant files, symbols, or content patterns related to the bug surface.
+- **`gitnexus context -r <repo-label>`** — Symbol-level context. Use for understanding the surroundings of a specific function, class, or module implicated in the error.
+- **`gitnexus impact -r <repo-label>`** — Impact analysis. Use for assessing blast radius when the root cause touches shared surfaces, callbacks, or exported APIs.
+
+### Best-Effort / Experimental
+
+- **`gitnexus query`** — Best-effort/experimental only. Current versions can emit read-only FTS warnings or return empty markdown-heavy results. Use only when the stable commands above do not cover the need, and treat results as supplementary.
+
+### Integration Points
+
+- **Phase 1 (Investigate):** After reproducing the bug and tracing the code path, if GitNexus is available, run `gitnexus cypher` or `gitnexus context` for the error surface and upstream callers. Include findings in the causal chain analysis.
+- **Phase 2 (Root Cause):** When the bug touches shared surfaces, `gitnexus impact` can help identify cross-layer callers or consumers that local grep might miss. Cross-check with actual source files — GitNexus findings are guidance only, never primary evidence.
+- **Phase 3 (Fix):** Before implementing a fix that modifies shared code, `gitnexus impact` can surface other locations that may need the same correction.
+
+### License Caution
+
+`gitnexus` currently advertises `PolyForm-Noncommercial-1.0.0`; production/company usage needs commercial/legal review. P0 remains optional/local.
+
+### Boundary Note
+
+GitNexus is optional code intelligence for `gh:debug`. It is not a mandatory runtime dependency, not a GitHub fact source, and not HKTMemory. Always re-check code and tests independently.
+
 ## Core Principles
 
 These principles govern every phase. They are repeated at decision points because they matter most when the pressure to skip them is highest.

--- a/plugins/galeharness-cli/skills/gh-nexus/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-nexus/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: gh:nexus
+description: "GitNexus code intelligence skill for analyzing repos. Run gitnexus analyze, query, cypher, context, and impact commands against indexed repositories. Auto-detects and installs gitnexus@1.6.3 if missing."
+argument-hint: "[analyze <repo-path> | status | query <query> | cypher <cypher> | context <symbol> | impact <symbol>]"
+---
+
+# GitNexus Code Intelligence
+
+Analyze repositories with GitNexus to extract code intelligence — symbols, dependencies, call graphs, and impact analysis.
+
+> **License Caution:** GitNexus is distributed under the **PolyForm-Noncommercial-1.0.0** license. Use in commercial contexts requires a separate license. This skill is a convenience wrapper; license compliance is your responsibility.
+
+> **Boundary Notes:** GitNexus integration is **optional and non-blocking**. If gitnexus is unavailable and cannot be installed, the skill reports the limitation and stops gracefully rather than failing the session.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `gh-nexus analyze <repo-path>` | Run `gitnexus analyze` on the target repository to index it for queries |
+| `gh-nexus status` | Check local GitNexus registry status (indexed repos, db health) |
+| `gh-nexus query <query>` | Best-effort natural language query against indexed repos (experimental) |
+| `gh-nexus cypher <cypher>` | Run a Cypher query against the indexed repo graph database |
+| `gh-nexus context <symbol>` | Get full context for a symbol (definition, references, call chain) |
+| `gh-nexus impact <symbol>` | Get impact analysis for a symbol (who calls it, what breaks if changed) |
+
+## Auto-Install
+
+Before running any command, detect whether `gitnexus` is available:
+
+```bash
+command -v gitnexus >/dev/null 2>&1
+```
+
+If missing, attempt installation in this order:
+
+1. **Global npm install** (preferred for repeated use):
+   ```bash
+   npm install -g gitnexus@1.6.3
+   ```
+
+2. **npx fallback** (no global install needed):
+   ```bash
+   npx --yes gitnexus@1.6.3 <command>
+   ```
+
+After install, verify:
+```bash
+gitnexus --version
+```
+
+If both methods fail, report:
+> "GitNexus is not available and could not be installed. Please install manually: `npm install -g gitnexus@1.6.3`"
+
+Then stop gracefully — do not block the caller's workflow.
+
+## Execution Flow
+
+### Phase 0: Detect or Install
+
+1. Check `command -v gitnexus` (or `shutil.which("gitnexus")` in Python)
+2. If found, use it directly
+3. If missing, run the auto-install sequence above
+4. If still missing after install attempts, report gracefully and stop
+
+### Phase 1: Dispatch Command
+
+| Subcommand | gitnexus equivalent | Notes |
+|------------|---------------------|-------|
+| `analyze <repo-path>` | `gitnexus analyze <repo-path>` | Indexes the repo; may take time for large codebases |
+| `status` | `gitnexus status` | Shows registry state, indexed repos, db size |
+| `query <query>` | `gitnexus query "<query>"` | Best-effort NL query; experimental quality |
+| `cypher <cypher>` | `gitnexus cypher "<cypher>"` | Direct Cypher against the graph; requires indexed repo |
+| `context <symbol>` | `gitnexus context <symbol>` | Symbol resolution (function, class, variable) |
+| `impact <symbol>` | `gitnexus impact <symbol>` | Change-impact analysis for the symbol |
+
+For `npx` fallback usage, prefix commands with `npx --yes gitnexus@1.6.3` instead of `gitnexus`.
+
+### Phase 2: Present Results
+
+- Stream command output to the user
+- If the command returns non-zero, capture stderr and present the error
+- For `analyze`, note that indexing is async/background and may need a moment before queries work
+- For `query`, flag that results are experimental and should be verified
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| gitnexus not found, install fails | Graceful stop with manual install instructions |
+| Repo not indexed | Suggest running `gh-nexus analyze <repo-path>` first |
+| Cypher syntax error | Pass through gitnexus error; suggest checking Cypher syntax |
+| Symbol not found | Report "Symbol not found in indexed repo" |
+| Query returns empty | Report "No results — try rephrasing or check if repo is indexed" |
+
+## Metadata
+
+- **GitNexus version:** 1.6.3
+- **Node requirement:** v18+ (tested on v22.22.2)
+- **npm requirement:** 8+ (tested on 10.9.7)
+- **License:** PolyForm-Noncommercial-1.0.0 (GitNexus itself)

--- a/plugins/galeharness-cli/skills/gh-nexus/references/gitnexus_dispatch.py
+++ b/plugins/galeharness-cli/skills/gh-nexus/references/gitnexus_dispatch.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+GitNexus command dispatcher with auto-install detection.
+
+Usage:
+    python3 gitnexus_dispatch.py <subcommand> [args...]
+
+Subcommands:
+    analyze <repo-path>   Run gitnexus analyze on target repo
+    status                Check local GitNexus registry status
+    query <query>         Best-effort natural language query (experimental)
+    cypher <cypher>       Run Cypher query against indexed repo
+    context <symbol>      Get context for a symbol
+    impact <symbol>       Get impact analysis for a symbol
+
+Auto-installs gitnexus@1.6.3 if missing (global npm or npx fallback).
+"""
+
+import shutil
+import subprocess
+import sys
+import os
+
+GITNEXUS_VERSION = "1.6.3"
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run a subprocess command and return the result."""
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def detect_gitnexus() -> str | None:
+    """Detect gitnexus binary path. Returns path or None."""
+    path = shutil.which("gitnexus")
+    if path:
+        return path
+    # Also check common npx cache locations
+    home = os.path.expanduser("~")
+    npx_paths = [
+        os.path.join(home, ".npm", "_npx", "aaba82a3e1e089f1", "node_modules", ".bin", "gitnexus"),
+        os.path.join(home, ".npm", "_npx", "*", "node_modules", ".bin", "gitnexus"),
+    ]
+    for p in npx_paths:
+        if os.path.isfile(p) and os.access(p, os.X_OK):
+            return p
+    return None
+
+
+def verify_gitnexus(path: str) -> bool:
+    """Verify the gitnexus binary works."""
+    result = _run([path, "--version"])
+    return result.returncode == 0 and GITNEXUS_VERSION in result.stdout
+
+
+def install_global() -> str | None:
+    """Attempt global npm install of gitnexus. Returns path or None."""
+    print(f"[gh-nexus] gitnexus not found. Attempting global install (gitnexus@{GITNEXUS_VERSION})...")
+    result = _run(["npm", "install", "-g", f"gitnexus@{GITNEXUS_VERSION}"])
+    if result.returncode != 0:
+        print(f"[gh-nexus] Global install failed: {result.stderr.strip()}")
+        return None
+    # Re-detect after install
+    return detect_gitnexus()
+
+
+def run_with_npx(subcommand: str, args: list[str]) -> int:
+    """Run gitnexus via npx fallback. Returns exit code."""
+    print(f"[gh-nexus] Using npx fallback (gitnexus@{GITNEXUS_VERSION})...")
+    cmd = ["npx", "--yes", f"gitnexus@{GITNEXUS_VERSION}", subcommand] + args
+    result = _run(cmd)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    return result.returncode
+
+
+def dispatch(gitnexus_path: str | None, subcommand: str, args: list[str]) -> int:
+    """Dispatch to gitnexus or npx fallback. Returns exit code."""
+    if gitnexus_path:
+        cmd = [gitnexus_path, subcommand] + args
+        result = _run(cmd)
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
+        return result.returncode
+    else:
+        return run_with_npx(subcommand, args)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 1
+
+    subcommand = sys.argv[1]
+    args = sys.argv[2:]
+
+    valid_commands = {"analyze", "status", "query", "cypher", "context", "impact"}
+    if subcommand not in valid_commands:
+        print(f"[gh-nexus] Unknown subcommand: {subcommand}")
+        print(f"Valid: {', '.join(sorted(valid_commands))}")
+        return 1
+
+    # Require arg for analyze, query, cypher, context, impact
+    arg_required = {"analyze", "query", "cypher", "context", "impact"}
+    if subcommand in arg_required and not args:
+        print(f"[gh-nexus] Error: '{subcommand}' requires an argument.")
+        return 1
+
+    # Phase 0: Detect or install
+    gitnexus_path = detect_gitnexus()
+
+    if gitnexus_path and verify_gitnexus(gitnexus_path):
+        print(f"[gh-nexus] Using gitnexus at {gitnexus_path}")
+    else:
+        gitnexus_path = install_global()
+        if gitnexus_path and verify_gitnexus(gitnexus_path):
+            print(f"[gh-nexus] Installed gitnexus at {gitnexus_path}")
+        else:
+            # Try npx fallback
+            print(f"[gh-nexus] Global install unavailable. Trying npx fallback...")
+            # Verify npx can resolve the package by running --version
+            test = _run(["npx", "--yes", f"gitnexus@{GITNEXUS_VERSION}", "--version"])
+            if test.returncode != 0:
+                print(f"[gh-nexus] GitNexus is not available and could not be installed.")
+                print(f"[gh-nexus] Please install manually: npm install -g gitnexus@{GITNEXUS_VERSION}")
+                return 1
+            gitnexus_path = None  # Will use npx
+
+    # Phase 1: Dispatch
+    return dispatch(gitnexus_path, subcommand, args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/galeharness-cli/skills/gh-nexus/references/gitnexus_dispatch.sh
+++ b/plugins/galeharness-cli/skills/gh-nexus/references/gitnexus_dispatch.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# GitNexus command dispatcher with auto-install detection.
+#
+# Usage:
+#   bash gitnexus_dispatch.sh <subcommand> [args...]
+#
+# Subcommands:
+#   analyze <repo-path>   Run gitnexus analyze on target repo
+#   status                Check local GitNexus registry status
+#   query <query>         Best-effort natural language query (experimental)
+#   cypher <cypher>       Run Cypher query against indexed repo
+#   context <symbol>      Get context for a symbol
+#   impact <symbol>       Get impact analysis for a symbol
+#
+# Auto-installs gitnexus@1.6.3 if missing (global npm or npx fallback).
+
+set -euo pipefail
+
+GITNEXUS_VERSION="1.6.3"
+
+detect_gitnexus() {
+    if command -v gitnexus >/dev/null 2>&1; then
+        command -v gitnexus
+        return 0
+    fi
+    # Check common npx cache locations
+    local home="$HOME"
+    local cached="$home/.npm/_npx/aaba82a3e1e089f1/node_modules/.bin/gitnexus"
+    if [ -x "$cached" ]; then
+        echo "$cached"
+        return 0
+    fi
+    return 1
+}
+
+verify_gitnexus() {
+    local path="$1"
+    local out
+    out="$("$path" --version 2>/dev/null)" || return 1
+    echo "$out" | grep -q "$GITNEXUS_VERSION"
+}
+
+install_global() {
+    echo "[gh-nexus] gitnexus not found. Attempting global install (gitnexus@${GITNEXUS_VERSION})..."
+    if npm install -g "gitnexus@${GITNEXUS_VERSION}" 2>/dev/null; then
+        detect_gitnexus
+    else
+        echo "[gh-nexus] Global install failed." >&2
+        return 1
+    fi
+}
+
+run_with_npx() {
+    local subcommand="$1"
+    shift
+    echo "[gh-nexus] Using npx fallback (gitnexus@${GITNEXUS_VERSION})..."
+    npx --yes "gitnexus@${GITNEXUS_VERSION}" "$subcommand" "$@"
+}
+
+dispatch() {
+    local path="$1"
+    local subcommand="$2"
+    shift 2
+    if [ -n "$path" ]; then
+        "$path" "$subcommand" "$@"
+    else
+        run_with_npx "$subcommand" "$@"
+    fi
+}
+
+# ---- main ----
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $(basename "$0") <subcommand> [args...]"
+    echo "Subcommands: analyze, status, query, cypher, context, impact"
+    exit 1
+fi
+
+SUBCOMMAND="$1"
+shift
+
+VALID="analyze status query cypher context impact"
+if ! echo "$VALID" | grep -qw "$SUBCOMMAND"; then
+    echo "[gh-nexus] Unknown subcommand: $SUBCOMMAND"
+    echo "Valid: $VALID"
+    exit 1
+fi
+
+# Require arg for analyze, query, cypher, context, impact
+ARG_REQUIRED="analyze query cypher context impact"
+if echo "$ARG_REQUIRED" | grep -qw "$SUBCOMMAND" && [ $# -eq 0 ]; then
+    echo "[gh-nexus] Error: '$SUBCOMMAND' requires an argument."
+    exit 1
+fi
+
+# Phase 0: Detect or install
+GITNEXUS_PATH=""
+if path="$(detect_gitnexus)"; then
+    if verify_gitnexus "$path"; then
+        GITNEXUS_PATH="$path"
+        echo "[gh-nexus] Using gitnexus at $GITNEXUS_PATH"
+    fi
+fi
+
+if [ -z "$GITNEXUS_PATH" ]; then
+    if path="$(install_global)"; then
+        if verify_gitnexus "$path"; then
+            GITNEXUS_PATH="$path"
+            echo "[gh-nexus] Installed gitnexus at $GITNEXUS_PATH"
+        fi
+    fi
+fi
+
+if [ -z "$GITNEXUS_PATH" ]; then
+    # Try npx fallback
+    echo "[gh-nexus] Global install unavailable. Trying npx fallback..."
+    if npx --yes "gitnexus@${GITNEXUS_VERSION}" --version >/dev/null 2>&1; then
+        GITNEXUS_PATH=""
+    else
+        echo "[gh-nexus] GitNexus is not available and could not be installed."
+        echo "[gh-nexus] Please install manually: npm install -g gitnexus@${GITNEXUS_VERSION}"
+        exit 1
+    fi
+fi
+
+# Phase 1: Dispatch
+dispatch "$GITNEXUS_PATH" "$SUBCOMMAND" "$@"

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -36,6 +36,47 @@ At the start of execution, use your native file-read tool to read `.compound-eng
 If the config file contains `language: en`, write documents in English.
 If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
 
+## GitNexus Context (Optional Code Intelligence)
+
+`gh:plan` may optionally use GitNexus to enrich planning context when the local repo has a GitNexus index. GitNexus provides code-structure awareness, likely file/module hints, and impact analysis that can improve plan quality. It is **never required** — missing `gitnexus`, a stale index, timeout, or command failure must not block planning.
+
+### Detecting GitNexus Availability
+
+Before using GitNexus, verify the repo is indexed:
+
+```bash
+# Check if gitnexus is available and the repo has an index
+gitnexus list 2>/dev/null && echo "GitNexus available" || echo "GitNexus unavailable — proceeding without it"
+```
+
+For multi-repo environments, use explicit repo labels: `gitnexus list -r <repo-label>`.
+
+### Stable Commands (Preferred)
+
+When GitNexus is available, prefer these stable commands:
+
+- **`gitnexus cypher -r <repo-label>`** — Markdown/file/content lookup. Use for finding relevant files, symbols, or content patterns.
+- **`gitnexus context -r <repo-label>`** — Symbol-level context. Use for understanding the surroundings of a specific function, class, or module.
+- **`gitnexus impact -r <repo-label>`** — Impact analysis. Use for assessing blast radius before proposing changes that touch shared surfaces.
+
+### Best-Effort / Experimental
+
+- **`gitnexus query`** — Best-effort/experimental only. Current versions can emit read-only FTS warnings or return empty markdown-heavy results. Use only when the stable commands above do not cover the need, and treat results as supplementary.
+
+### Integration Points
+
+- **Phase 1 (Gather Context):** After local research, if GitNexus is available, run `gitnexus cypher` or `gitnexus context` for the key components identified in the planning context summary. Include findings in the `### Relevant Code and Patterns` section of the plan.
+- **Phase 1.5 (Flow and Edge-Case Analysis):** For Standard or Deep plans touching shared surfaces, `gitnexus impact` can help identify cross-layer callers or consumers that local grep might miss.
+- **Phase 3 (Structure the Plan):** GitNexus findings are guidance only, never primary evidence. Always cross-check with actual source files. Do not treat GitNexus output as a substitute for reading code.
+
+### License Caution
+
+`gitnexus` currently advertises `PolyForm-Noncommercial-1.0.0`; production/company usage needs commercial/legal review. P0 remains optional/local.
+
+### Boundary Note
+
+GitNexus is optional code intelligence for `gh:plan`. It is not a mandatory runtime dependency, not a GitHub fact source, and not HKTMemory. Downstream `gh:work` and `gh:debug` must re-check code and tests independently.
+
 ## Core Principles
 
 1. **Use requirements as the source of truth** - If `gh:brainstorm` produced a requirements document, planning should build from it rather than re-inventing behavior.

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -436,6 +436,47 @@ After the work is complete and the shipping workflow has finished (PR created or
 **Note:** This creates a searchable record of completed work for future reference when similar tasks arise.
 <!-- /HKT-PATCH:phase-4.5 -->
 
+## GitNexus Context (Optional Code Intelligence)
+
+`gh:work` may optionally use GitNexus to enrich execution context when the local repo has a GitNexus index. GitNexus provides code-structure awareness, likely file/module hints, and impact analysis that can improve implementation quality. It is **never required** — missing `gitnexus`, a stale index, timeout, or command failure must not block execution.
+
+### Detecting GitNexus Availability
+
+Before using GitNexus, verify the repo is indexed:
+
+```bash
+# Check if gitnexus is available and the repo has an index
+gitnexus list 2>/dev/null && echo "GitNexus available" || echo "GitNexus unavailable — proceeding without it"
+```
+
+For multi-repo environments, use explicit repo labels: `gitnexus list -r <repo-label>`.
+
+### Stable Commands (Preferred)
+
+When GitNexus is available, prefer these stable commands:
+
+- **`gitnexus cypher -r <repo-label>`** — Markdown/file/content lookup. Use for finding relevant files, symbols, or content patterns before implementing changes.
+- **`gitnexus context -r <repo-label>`** — Symbol-level context. Use for understanding the surroundings of a specific function, class, or module being modified.
+- **`gitnexus impact -r <repo-label>`** — Impact analysis. Use for assessing blast radius before changes that touch shared surfaces, callbacks, or exported APIs.
+
+### Best-Effort / Experimental
+
+- **`gitnexus query`** — Best-effort/experimental only. Current versions can emit read-only FTS warnings or return empty markdown-heavy results. Use only when the stable commands above do not cover the need, and treat results as supplementary.
+
+### Integration Points
+
+- **Phase 0 (Input Triage):** After scanning the work area, if GitNexus is available, run `gitnexus cypher` for the key components identified in the prompt or plan. Use findings to refine the task list and identify files likely to change.
+- **Phase 2 (Execute):** Before implementing a unit that touches shared surfaces, `gitnexus impact` can surface callers or consumers that local grep might miss. Cross-check with actual source files — GitNexus findings are guidance only, never primary evidence.
+- **Test Discovery:** When a plan specifies test files, `gitnexus context` around the test entry points can help identify related test utilities or fixtures.
+
+### License Caution
+
+`gitnexus` currently advertises `PolyForm-Noncommercial-1.0.0`; production/company usage needs commercial/legal review. P0 remains optional/local.
+
+### Boundary Note
+
+GitNexus is optional code intelligence for `gh:work`. It is not a mandatory runtime dependency, not a GitHub fact source, and not HKTMemory. Always re-check code and tests independently.
+
 ## Key Principles
 
 ### Start Fast, Execute Faster


### PR DESCRIPTION
## Summary

Adds the `gh:nexus` skill for GitNexus code intelligence integration.

## What's New

- **Skill:** `gh-nexus` — wrapper around GitNexus for repo analysis, symbol context, Cypher queries, and impact analysis
- **Commands:**
  - `gh-nexus analyze <repo-path>` — index a repo
  - `gh-nexus status` — check registry status
  - `gh-nexus query <query>` — natural language query (experimental)
  - `gh-nexus cypher <cypher>` — Cypher graph query
  - `gh-nexus context <symbol>` — symbol context lookup
  - `gh-nexus impact <symbol>` — change-impact analysis
- **Auto-install:** Detects `gitnexus` on PATH; attempts `npm install -g gitnexus@1.6.3` or falls back to `npx --yes gitnexus@1.6.3`
- **License caution:** PolyForm-Noncommercial-1.0.0 noted in SKILL.md
- **Reference scripts:** Python (`gitnexus_dispatch.py`) and shell (`gitnexus_dispatch.sh`) implementations

## Changes

- `plugins/galeharness-cli/skills/gh-nexus/SKILL.md`
- `plugins/galeharness-cli/skills/gh-nexus/references/gitnexus_dispatch.py`
- `plugins/galeharness-cli/skills/gh-nexus/references/gitnexus_dispatch.sh`
- `plugins/galeharness-cli/README.md` — skill count 41→42, added `gh:nexus` to workflow table

## Validation

- `bun test`: 1384 pass, 0 fail
- `bun run release:validate`: metadata in sync (42 skills)

Closes #116