### PR TITLE
fix(galeharness-cli): document upstream capability sync

### DIFF
--- a/plugins/galeharness-cli/README.md
+++ b/plugins/galeharness-cli/README.md
@@ -48,6 +48,10 @@ language: zh-CN  # zh-CN (Chinese, default) or en (English)
 | Agents | 50+ |
 | Skills | 42 |
 
+## Recent upstream-sync highlights
+
+The latest upstream capability sync improves long-lived PR feedback handling, cross-runtime web research, document-review auto-fix confidence, macOS Bash compatibility, worktree script resolution, and Codex `$CODEX_HOME` support.
+
 ## Skills
 
 ### Core Workflow


### PR DESCRIPTION
## Summary\n\nAdds user-facing README highlights for the upstream compound capability sync so release-please treats the GaleHarnessCLI changes as a patch release candidate.\n\n## Validation\n\n- bun run release:validate\n- git diff --check\n\n## Notes\n\nNo manual version or changelog edits; release automation remains the version owner.