### PR TITLE
fix(galeharness-cli): preserve engineering discipline overlay

### DIFF
--- a/plugins/galeharness-cli/skills/agent-native-architecture/SKILL.md
+++ b/plugins/galeharness-cli/skills/agent-native-architecture/SKILL.md
@@ -18,6 +18,10 @@ This opens up a new field: software that works the way Claude Code works, applie
 <core_principles>
 ## Core Principles
 
+### Engineering discipline guardrail
+
+When evaluating an agent-native system, also apply the deep-module vocabulary from `references/engineering-discipline-from-mattpocock-skills.md`: module, interface, implementation, depth, seam, adapter, locality, and leverage. Prefer deep modules with small interfaces and large hidden implementation leverage. Treat shallow modules, pass-through helpers, fake seams, and mirror logic as architecture smells. Use the deletion test: if deleting a proposed abstraction barely changes the system or only removes a name, it is probably shallow.
+
 ### 1. Parity
 
 **Whatever the user can do through the UI, the agent should be able to achieve through tools.**

--- a/plugins/galeharness-cli/skills/agent-native-architecture/references/engineering-discipline-from-mattpocock-skills.md
+++ b/plugins/galeharness-cli/skills/agent-native-architecture/references/engineering-discipline-from-mattpocock-skills.md
@@ -1,0 +1,114 @@
+# Engineering discipline rules from mattpocock/skills
+
+Source: https://github.com/mattpocock/skills
+Snapshot evaluated: 2026-05-17
+License: MIT
+Demand-pool issue: https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/275
+
+This is a reference-only extraction. It is **not** a vendor copy, submodule, or runtime dependency. Do not import `.claude-plugin`, `~/.claude/skills`, or Claude-only slash semantics into Hermes.
+
+## Absorption boundary
+
+Allowed:
+
+- Small Hermes-owned checklists or decision gates.
+- Thin patches to existing general engineering skills.
+- Links from `SKILL.md` to this reference for details.
+
+Not allowed:
+
+- Bulk-copying upstream `SKILL.md` files.
+- Creating a parallel `diagnose/tdd/triage/...` skill family.
+- Changing `gh compound` or `gstack` internals as part of this extraction.
+- Treating this reference as a substitute for completion guard, active readback, or fact-source governance.
+
+## Rule 1 — Feedback loop first
+
+Before a non-trivial bug fix, build or identify the fastest deterministic pass/fail loop that reproduces the user-visible symptom.
+
+Preferred loop order:
+
+1. Failing test at the closest correct seam.
+2. CLI or script with fixture input and explicit expected output.
+3. HTTP/curl script against a running service.
+4. Browser smoke/assertion that checks DOM, console, or network evidence.
+5. Captured trace/HAR/log replay.
+6. Manual HITL evidence only when automation is genuinely unavailable.
+
+Minimum closeout:
+
+- Original symptom reproduced or explicitly marked not reproducible with attempted evidence.
+- Same loop passes after the fix.
+- Temporary instrumentation is removed or clearly marked as intentional.
+
+## Rule 2 — Vertical red-green-refactor
+
+For feature or bug work that changes behavior, avoid horizontal slicing.
+
+Bad pattern:
+
+- Write a batch of imagined tests.
+- Implement a batch of code.
+- Retrospectively make everything green.
+
+Preferred pattern:
+
+1. Pick one observable behavior.
+2. Write one failing behavior-level test or smoke.
+3. Implement the minimal change.
+4. Watch it pass.
+5. Repeat for the next behavior.
+6. Refactor only while green.
+
+Tests should exercise public interfaces and observable behavior, not private implementation details.
+
+## Rule 3 — Deep module architecture vocabulary
+
+Use these terms in architecture review and refactor proposals:
+
+- **Module**: anything with an interface and implementation.
+- **Interface**: everything callers must know to use the module, including invariants, errors, ordering, and configuration.
+- **Implementation**: the code hidden behind the interface.
+- **Depth**: how much useful behavior is behind a simple interface.
+- **Seam**: a place behavior can change without editing callers in place.
+- **Adapter**: a concrete implementation at a seam.
+- **Locality**: whether related change and bugs stay concentrated.
+- **Leverage**: how much value callers get from the interface.
+
+Architecture smells to flag:
+
+- **Shallow module**: interface complexity is close to implementation complexity.
+- **Pass-through helper**: deleting it removes complexity instead of concentrating it.
+- **Fake seam**: only one adapter exists and no realistic second adapter is expected.
+- **Mirror logic**: one business rule appears in lib/sync/UI inline/tests or multiple runtime paths.
+
+Use the deletion test: if the module disappeared, would complexity vanish, or would it spread back into many callers?
+
+## Rule 4 — Tracer-bullet task slicing
+
+A work item should produce a narrow, independently verifiable end-to-end path.
+
+Prefer:
+
+- A thin vertical slice through data/model/API/UI/smoke where relevant.
+- A slice that can be demoed or black-box verified alone.
+- Explicit AFK vs HITL distinction.
+
+Avoid:
+
+- Separate schema/API/UI issues that cannot prove user value independently.
+- Stories whose only acceptance is “files changed” or “PR merged”.
+
+## Rule 5 — Progressive disclosure for skills
+
+To avoid skill bloat:
+
+- `SKILL.md` holds trigger conditions, core workflow, and short operational gates.
+- Long explanations, examples, and evaluation matrices live in `references/`.
+- Deterministic repeated operations live in `scripts/`.
+- Patch an existing skill before creating a new synonym skill.
+- Keep trigger descriptions narrow enough that unrelated tasks do not load the skill.
+
+## Upstream-sync policy
+
+Future updates from `mattpocock/skills` should be handled by re-scanning the source repo and comparing against this Hermes-owned reference. Do not merge upstream files directly. Update only the internal delta rules that are still relevant to our active pain points.

--- a/plugins/galeharness-cli/skills/gh-debug/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-debug/SKILL.md
@@ -55,10 +55,11 @@ GitNexus is optional code intelligence for `gh:debug`. It is not a mandatory run
 
 These principles govern every phase. They are repeated at decision points because they matter most when the pressure to skip them is highest.
 
-1. **Investigate before fixing.** Do not propose a fix until you can explain the full causal chain from trigger to symptom with no gaps. "Somehow X leads to Y" is a gap.
-2. **Predictions for uncertain links.** When the causal chain has uncertain or non-obvious links, form a prediction — something in a different code path or scenario that must also be true. If the prediction is wrong but a fix "works," you found a symptom, not the cause. When the chain is obvious (missing import, clear null reference), the chain explanation itself is sufficient.
-3. **One change at a time.** Test one hypothesis, change one thing. If you're changing multiple things to "see if it helps," stop — that is shotgun debugging.
-4. **When stuck, diagnose why — don't just try harder.**
+1. **Feedback loop first.** Before changing code, name the shortest reliable feedback loop that can prove or disprove the hypothesis: failing test, focused CLI/script, HTTP/API probe, browser smoke, trace replay, then HITL only when necessary. Prefer the tightest loop that exercises the real failing path. See `../agent-native-architecture/references/engineering-discipline-from-mattpocock-skills.md`.
+2. **Investigate before fixing.** Do not propose a fix until you can explain the full causal chain from trigger to symptom with no gaps. "Somehow X leads to Y" is a gap.
+3. **Predictions for uncertain links.** When the causal chain has uncertain or non-obvious links, form a prediction — something in a different code path or scenario that must also be true. If the prediction is wrong but a fix "works," you found a symptom, not the cause. When the chain is obvious (missing import, clear null reference), the chain explanation itself is sufficient.
+4. **One change at a time.** Test one hypothesis, change one thing. If you're changing multiple things to "see if it helps," stop — that is shotgun debugging.
+5. **When stuck, diagnose why — don't just try harder.**
 
 ## Execution Flow
 

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -12,6 +12,8 @@ Execute work efficiently while maintaining quality and finishing features.
 
 This command takes a work document (plan or specification) or a bare prompt describing the work, and executes it systematically. The focus is on **shipping complete features** by understanding requirements quickly, following existing patterns, and maintaining quality throughout.
 
+**Engineering discipline overlay:** For non-trivial engineering work, bias toward vertical red-green-refactor: choose one observable behavior, create or identify a failing check for that behavior, make the smallest implementation change to pass it, then refactor. Avoid horizontal slices that separately "finish schema/API/UI" without an end-to-end proof. See `../agent-native-architecture/references/engineering-discipline-from-mattpocock-skills.md`.
+
 ## Input Document
 
 <input_document> #$ARGUMENTS </input_document>


### PR DESCRIPTION
## Summary
- Mirrors the reference-only engineering discipline overlay into the GaleHarness plugin source for the same colliding skill names already patched in Hermes core skills.
- Adds the mattpocock/skills extraction as a co-located reference under `agent-native-architecture/references/`.
- Keeps the patch thin: no bulk import, no Claude plugin/runtime import, no gh:compound or gstack workflow changes.

## Why
Hermes active skills now contain this overlay, but GaleHarness publishes skills with the same names (`gh-debug`, `gh-work`, `agent-native-architecture`). If a future GaleHarness install/export overwrites `~/.hermes/skills` by name, the active-only/core-only patch can be lost. This PR moves the same durable source into the release-owned GaleHarness plugin surface.

## Validation
- `bun install --frozen-lockfile`
- `bun run release:validate` → PASS (`49 agents, 42 skills, 0 MCP servers`)
- `bun test` → PASS (`1385 pass, 3 skip, 0 fail`)

## Related
- Demand-pool issue: https://github.com/wangrenzhu-ola/ai-infra-demand-pool/issues/275
- Hermes core-skills PRs: https://github.com/wangrenzhu-ola/infra-hermes-core-skills/pull/481, https://github.com/wangrenzhu-ola/infra-hermes-core-skills/pull/482