### PR TITLE
feat(workflow): sync upstream v3.12 ideation model

### DIFF
--- a/docs/solutions/workflow/upstream-compound-v3-12-0-sync-2026-06-13.md
+++ b/docs/solutions/workflow/upstream-compound-v3-12-0-sync-2026-06-13.md
@@ -1,0 +1,38 @@
+---
+title: "Upstream Compound Engineering v3.12.0 workflow sync mapping"
+date: 2026-06-13
+category: workflow
+module: galeharness-cli
+upstream_repo: EveryInc/compound-engineering-plugin
+upstream_release: compound-engineering-v3.12.0
+upstream_release_commit: 4719dc5
+upstream_feature_commit: e74e29864fbfa2f800fc3e08509e2966e4947f1e
+upstream_fix_commit: b6250490bec4c0488d68ad66d72bd99f6edb95fd
+sync_scope: selected-workflow-adaptation
+---
+
+# Upstream Compound Engineering v3.12.0 workflow sync mapping
+
+## Context
+
+The upstream Compound Engineering repository latest published release checked for this sync was `compound-engineering-v3.12.0`, tagged at release commit `4719dc5` on 2026-06-09. The release notes called out two relevant source commits:
+
+- `e74e29864fbfa2f800fc3e08509e2966e4947f1e` — HTML-first ideation docs and a status-free plan model.
+- `b6250490bec4c0488d68ad66d72bd99f6edb95fd` — `ce-release-notes` placeholder links.
+
+The local shell environment could not clone or fetch GitHub directly because HTTPS requests failed with a `CONNECT tunnel failed, response 403` error. This sync therefore used the GitHub web-rendered release and commit diff as the upstream source of truth and adapted the workflow behavior manually into GaleHarnessCLI's `gh:` namespace.
+
+## Local Adaptation
+
+This PR maps the upstream workflow changes into GaleHarnessCLI as follows:
+
+| Upstream intent | GaleHarnessCLI adaptation |
+|---|---|
+| Ideation artifacts are HTML-first and human-facing by default. | `gh:ideate` now defaults to a single self-contained HTML artifact, with `output:md` as the explicit markdown escape hatch. |
+| HTML and markdown outputs are mutually exclusive per run. | The ideation workflow and rendering references instruct agents to write exactly one artifact for the selected mode. |
+| Ideation handoff should not depend on status markers. | `gh:ideate` passes selected idea substance directly into `gh:brainstorm`; legacy `Status:` markers are no longer the handoff contract. |
+| Plans are decision artifacts, not execution state. | New `gh:plan` templates omit `status: active`; `gh:work` and `gh:work-beta` leave plan frontmatter/body read-only and derive shipped state from git, PR metadata, and task-board events. |
+
+## Baseline Note
+
+`.upstream-ref` remains unchanged in this PR. The changes are a selected workflow adaptation from the latest upstream release, not a full replay of every upstream commit since the current recorded baseline. Keeping `.upstream-ref` unchanged preserves the integrity of the per-commit sync tooling, which expects that file to mean every upstream commit through that SHA has been processed.

--- a/plugins/galeharness-cli/README.md
+++ b/plugins/galeharness-cli/README.md
@@ -77,7 +77,7 @@ Use the horizontal skills (`/gh:debug`, `/gh:optimize`, `/gh:simplify-code`, `/g
 
 | Skill | When to use it | Output / value |
 |-------|----------------|----------------|
-| `/gh:ideate` | You want grounded improvement ideas or alternative directions before committing to a requirement. | Ranked ideas with constraints, risks, and next-step candidates. |
+| `/gh:ideate` | You want grounded improvement ideas or alternative directions before committing to a requirement. | Ranked ideas in a self-contained HTML artifact by default (`output:md` when markdown is required), with constraints, risks, and next-step candidates. |
 | `/gh:brainstorm` | A request is still fuzzy and needs problem framing, assumptions, non-goals, and success criteria. | A requirement-quality brief that can feed `/gh:plan`. |
 | `/gh:plan` | A requirement is ready to decompose into implementation steps or an existing plan needs deepening. | A structured plan with files, risks, tests, and confidence checks. |
 | `/gh:work` | Execute a scoped development task or plan with normal quality gates. | Implemented code plus verification evidence. |

--- a/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "[feature, focus area, or constraint]"
 - `gh:brainstorm` answers: "What exactly should one chosen idea mean?"
 - `gh:plan` answers: "How should it be built?"
 
-This workflow produces a ranked ideation artifact in `docs/ideation/`. It does **not** produce requirements, plans, or code.
+This workflow produces a ranked ideation artifact in `docs/ideation/`. By default it writes one self-contained HTML file for human review; pass `output:md` (or configure `ideate_output: md`) when a markdown artifact is required. It does **not** produce requirements, plans, or code.
 
 ## Interaction Method
 
@@ -32,6 +32,7 @@ Interpret any provided argument as optional context. It may be:
 - a path such as `plugins/galeharness-cli/skills/`
 - a constraint such as `low-complexity quick wins`
 - a volume hint such as `top 3`, `100 ideas`, or `raise the bar`
+- an output-mode hint: `output:html` (default) or `output:md`
 
 If no argument is provided, treat the subject as unsettled and run the subject-identification gate before any dispatch.
 
@@ -46,6 +47,13 @@ At the start of execution, use your native file-read tool to read `.compound-eng
 
 If the config file contains `language: en`, write documents in English.
 If the file is missing, contains `language: zh-CN`, or has no language key, write documents in Chinese (default).
+
+
+## Output Mode
+
+Default to `output:html`: write exactly one self-contained `.html` ideation artifact optimized for human reading in a browser. Use `output:md` only when the user explicitly asks for markdown or `.compound-engineering/config.local.yaml` sets `ideate_output: md`. If both prompt and config specify a mode, the prompt wins. HTML and markdown are mutually exclusive for a single run -- do not write both.
+
+When output mode is HTML, load `references/html-rendering.md` before writing the artifact. When output mode is markdown, load `references/markdown-rendering.md` before writing the artifact.
 
 ## Execution Flow
 
@@ -69,7 +77,7 @@ Treat a prior ideation doc as relevant when:
 - the topic matches the requested focus
 - the path or subsystem overlaps the requested focus
 - the request is open-ended and there is an obvious recent open ideation doc
-- the issue-grounded status matches: do not offer to resume a non-issue ideation when the current argument indicates issue-tracker intent, or vice versa — treat these as distinct topics
+- the issue-grounded mode matches: do not offer to resume a non-issue ideation when the current argument indicates issue-tracker intent, or vice versa — treat these as distinct topics
 
 If a relevant doc exists, ask whether to:
 1. continue from it
@@ -78,7 +86,7 @@ If a relevant doc exists, ask whether to:
 If continuing:
 - read the document
 - summarize what has already been explored
-- preserve previous idea statuses
+- preserve any existing legacy idea notes, but do not use status markers as the handoff contract
 - update the existing file instead of creating a duplicate
 
 #### 0.2 Subject-Identification Gate

--- a/plugins/galeharness-cli/skills/gh-ideate/references/html-rendering.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/references/html-rendering.md
@@ -1,0 +1,35 @@
+# Ideation HTML Rendering
+
+Use this reference when `gh:ideate` writes the default `output:html` artifact.
+
+## Invariant
+
+Write exactly one self-contained `.html` file. Do not also write a markdown artifact unless the user explicitly requested `output:md`.
+
+## File Shape
+
+- Path: `docs/ideation/YYYY-MM-DD-<topic>-ideation.html` (or the resolved `gale-knowledge` ideation directory plus the dual-write copy).
+- Include `<!doctype html>`, `<html lang="...">`, `<meta charset="utf-8">`, a responsive viewport, and a `<title>` matching the artifact title.
+- Inline CSS in a `<style>` block; do not reference external stylesheets, scripts, fonts, images, or CDN assets.
+- Keep the artifact readable as a standalone file opened directly from disk.
+
+## Content Shape
+
+Render the same information as the markdown contract:
+
+1. A concise header with title, date, topic, focus, output mode, and source context.
+2. Codebase Context / grounding summary.
+3. Ranked survivor cards with title, description, warrant, rationale, downsides, confidence, and complexity.
+4. Rejection Summary table.
+5. Next steps: brainstorm one idea, iterate on one idea, discard, or done.
+
+Use semantic HTML (`<main>`, `<section>`, `<article>`, `<table>`) and plain text content. Escape all user-supplied or repository-derived text so it cannot become executable markup.
+
+## Chat Summary
+
+After writing the HTML file, do not paste the full artifact into chat. Report:
+
+- the absolute path,
+- the top 5-7 survivor titles with one-line rationales,
+- any notable rejected class,
+- the next-step menu.

--- a/plugins/galeharness-cli/skills/gh-ideate/references/markdown-rendering.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/references/markdown-rendering.md
@@ -1,0 +1,19 @@
+# Ideation Markdown Rendering
+
+Use this reference only when the user explicitly requests `output:md` or local config sets `ideate_output: md`.
+
+## Invariant
+
+Write exactly one markdown file. Do not also write an HTML artifact unless the user explicitly asks for a conversion after the markdown run.
+
+## File Shape
+
+- Path: `docs/ideation/YYYY-MM-DD-<topic>-ideation.md` (or the resolved `gale-knowledge` ideation directory plus the dual-write copy).
+- Include YAML frontmatter with `date`, `topic`, `focus` when present, and `output: md`.
+- Keep section headers in English even when prose is localized.
+
+## Content Shape
+
+Use the existing markdown artifact template from `post-ideation-workflow.md`, including Codebase Context, Ranked Ideas, and Rejection Summary.
+
+Markdown mode is primarily for downstream tools that require markdown, including Proof sharing and document review. For human review, prefer the default self-contained HTML artifact.

--- a/plugins/galeharness-cli/skills/gh-ideate/references/post-ideation-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-ideate/references/post-ideation-workflow.md
@@ -32,7 +32,7 @@ Target output:
 
 ## Phase 4: Present the Survivors
 
-Present the surviving ideas to the user before writing the durable artifact. This is a review checkpoint, not the final archived result.
+Present a concise survivor summary to the user before writing the durable artifact. This is a review checkpoint, not the final archived result. In default HTML mode, avoid wall-of-text terminal output: the full rich artifact will be written to disk and summarized in chat.
 
 Present only the surviving ideas in structured form:
 
@@ -48,16 +48,11 @@ Then include a brief rejection summary so the user can see what was considered a
 
 Keep the presentation concise. The durable artifact holds the full record.
 
-Allow brief follow-up questions and lightweight clarification before writing the artifact.
-
-Do not write the ideation doc yet unless:
-- the user indicates the candidate set is good enough to preserve
-- the user asks to refine and continue in a way that should be recorded
-- the workflow is about to hand off to `gh:brainstorm`, Proof sharing, or session end
+Allow brief follow-up questions and lightweight clarification, then write the artifact automatically before the next-step menu. The artifact is the review surface; the user can discard it in Phase 6 if the run was exploratory and should not be kept.
 
 ## Phase 5: Write the Ideation Artifact
 
-Write the ideation artifact after the candidate set has been reviewed enough to preserve.
+Write the ideation artifact after the candidate set has been reviewed enough to preserve. Default to a self-contained HTML artifact unless `output:md` was explicitly selected.
 
 **Document Language** — When the skill's config contains `language: zh-CN` (or no language config, defaulting to zh-CN):
 - Write all prose content in Chinese: paragraphs, list items, table content
@@ -73,12 +68,13 @@ Always write or update the artifact before:
 To write the artifact:
 
 1. Ensure `docs/ideation/` exists
-2. Choose the file path:
-   - `docs/ideation/YYYY-MM-DD-<topic>-ideation.md`
-   - `docs/ideation/YYYY-MM-DD-open-ideation.md` when no focus exists
-3. Write or update the ideation document
+2. Resolve output mode:
+   - default `output:html` -> load `references/html-rendering.md` and write `docs/ideation/YYYY-MM-DD-<topic>-ideation.html`
+   - explicit `output:md` -> load `references/markdown-rendering.md` and write `docs/ideation/YYYY-MM-DD-<topic>-ideation.md`
+   - use `docs/ideation/YYYY-MM-DD-open-ideation.<ext>` when no focus exists
+3. Write or update exactly one ideation artifact for this run; HTML and markdown are mutually exclusive unless the user asks for a later conversion
 
-Use this structure and omit clearly irrelevant fields only when necessary:
+For markdown mode, use this structure and omit clearly irrelevant fields only when necessary:
 
 ```markdown
 ---
@@ -101,7 +97,6 @@ focus: <optional focus hint>
 **Downsides:** [Tradeoffs or costs]
 **Confidence:** [0-100%]
 **Complexity:** [Low / Medium / High]
-**Status:** [Unexplored / Explored]
 
 ## Rejection Summary
 
@@ -112,23 +107,25 @@ focus: <optional focus hint>
 
 If resuming:
 - update the existing file in place
-- preserve explored markers
+- preserve existing notes; legacy `Status:` markers may remain but are not the source of truth for handoff
 
 ## Phase 6: Refine or Hand Off
 
-After presenting the results, ask what should happen next.
+After presenting the results and writing the artifact, ask what should happen next.
 
 Offer these options:
 1. brainstorm a selected idea
-2. refine the ideation
-3. share to Proof
-4. end the session
+2. iterate on one idea in this session
+3. share to Proof (markdown output only; if the artifact is HTML, offer to rerun or convert with explicit user approval)
+4. discard the saved artifact
+5. end the session
 
 ### 6.1 Brainstorm a Selected Idea
 
 If the user selects an idea:
-- write or update the ideation doc first
-- mark that idea as `Explored`
+- write or update the ideation artifact first
+- pass the selected idea's substance to `gh:brainstorm` as the seed: title, description, warrant, rationale, downsides, confidence, complexity, and any relevant rejection context
+- do not rely on a status marker as the handoff contract; the saved file is evidence, and the brainstorm seed carries the actionable content
 - note the brainstorm date in the session log
 - invoke `gh:brainstorm` with the selected idea as the seed
 
@@ -148,7 +145,9 @@ After each refinement:
 
 ### 6.3 Share to Proof
 
-If requested, invoke HITL review mode by loading `references/hitl-review.md` from the `proof` skill with:
+If requested, first confirm the artifact is markdown. Proof cannot ingest the default HTML artifact. If the current run wrote HTML, ask whether to create a markdown conversion before sharing; do not silently create a second artifact.
+
+Then invoke HITL review mode by loading `references/hitl-review.md` from the `proof` skill with:
 - `localPath`: the ideation document path
 - `title`: from the document's H1 or filename
 
@@ -157,7 +156,9 @@ Handle the HITL return (sync or warn) and return to the next-step options.
 ### 6.4 End the Session
 
 When ending:
-- offer to commit only the ideation doc
+- report the saved artifact path
+- if the user says to discard it, delete the artifact and say so
+- otherwise offer to commit only the ideation artifact
 - do not create a branch
 - do not push
 - if the user declines, leave the file uncommitted

--- a/plugins/galeharness-cli/skills/gh-plan/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-plan/SKILL.md
@@ -128,7 +128,7 @@ If the user references an existing plan file or there is an obvious recent match
 
 Words like "strengthen", "confidence", "gaps", and "rigor" are NOT sufficient on their own to trigger deepening. These words appear in normal editing requests ("strengthen that section about the diagram", "there are gaps in the test scenarios") and should not cause a holistic deepening pass. Only treat them as deepening intent when the request clearly targets the plan as a whole and does not name a specific section or content area to change — and even then, prefer to confirm with the user before entering the deepening flow.
 
-Once the plan is identified and appears complete (all major sections present, implementation units defined, `status: active`):
+Once the plan is identified and appears complete (all major sections present, implementation units defined):
 - If the plan lacks YAML frontmatter (non-software plans use a simple `# Title` heading with `Created:` date instead of frontmatter), route to `references/universal-planning.md` for editing or deepening instead of Phase 5.3. Non-software plans do not use the software confidence check.
 - Otherwise, short-circuit to Phase 5.3 (Confidence Check and Deepening) in **interactive mode**. This avoids re-running the full planning workflow and gives the user control over which findings are integrated.
 
@@ -605,7 +605,6 @@ Omit clearly inapplicable optional sections, especially for Lightweight plans.
 ---
 title: [Plan Title]
 type: [feat|fix|refactor]
-status: active
 date: YYYY-MM-DD
 origin: docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md  # include when planning from a requirements doc
 deepened: YYYY-MM-DD  # optional, set when the confidence check substantively strengthens the plan

--- a/plugins/galeharness-cli/skills/gh-work-beta/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work-beta/SKILL.md
@@ -111,7 +111,7 @@ For any non-trivial bare prompt, form a lightweight execution contract before im
    - If anything is unclear or ambiguous, ask clarifying questions now
    - If clarifying questions were needed above, get user approval on the resolved answers. If no clarifications were needed, proceed without a separate approval step — plan scope is the plan's authority, not something to renegotiate
    - **Do not skip this** - better to ask questions now than build the wrong thing
-   - **Do not edit the plan body during execution.** The plan is a decision artifact; progress lives in git commits and the task tracker. The only plan mutation during gh:work is the final `status: active` -> `status: completed` flip at shipping (see `references/shipping-workflow.md` Phase 4 Step 2). Legacy plans may contain `- [ ]` / `- [x]` marks on unit headings — ignore them as state; per-unit completion is determined during execution by reading the current file state.
+   - **Do not edit the plan body or frontmatter during execution.** The plan is a decision artifact; progress and shipped state live in git commits, PRs, and the task tracker. Legacy plans may contain `status:` frontmatter or `- [ ]` / `- [x]` marks on unit headings — ignore them as state; per-unit completion is determined during execution by reading the current file state.
    - For non-trivial work, establish the execution contract before editing: current assumptions, minimal change, explicit non-goals, and verification criteria. Derive it from the plan when available; if the plan is thin, state it briefly from the prompt and repo scan.
 
 2. **Setup Environment**

--- a/plugins/galeharness-cli/skills/gh-work-beta/references/non-code-execution.md
+++ b/plugins/galeharness-cli/skills/gh-work-beta/references/non-code-execution.md
@@ -10,7 +10,7 @@ Do not run code-shipping machinery for knowledge-work plans:
 - No implementation-unit task list keyed on `Files:`.
 - No Codex delegation batch.
 - No Test Discovery or system-wide test check.
-- No incremental code commits, PR flow, or `references/shipping-workflow.md` status flip.
+- No incremental code commits, PR flow, or plan-status mutation.
 
 ## Execute The Production Plan
 

--- a/plugins/galeharness-cli/skills/gh-work-beta/references/shipping-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-work-beta/references/shipping-workflow.md
@@ -58,12 +58,9 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    Note whether the completed work has observable behavior (UI rendering, CLI output, API/library behavior with a runnable example, generated artifacts, or workflow output). The `git-commit-push-pr` skill will ask whether to capture evidence only when evidence is possible.
 
-2. **Update Plan Status**
+2. **Leave The Plan Read-Only**
 
-   If the input document has YAML frontmatter with a `status` field, update it to `completed`:
-   ```
-   status: active  ->  status: completed
-   ```
+   Do not update plan frontmatter or body state during shipping. The plan is a decision artifact; shipped state is derived from git commits, PR metadata, and task-board events. If a legacy plan has `status:` frontmatter, leave it unchanged rather than rewriting history.
 
 3. **Commit and Create Pull Request**
 

--- a/plugins/galeharness-cli/skills/gh-work/SKILL.md
+++ b/plugins/galeharness-cli/skills/gh-work/SKILL.md
@@ -137,7 +137,7 @@ In addition to vector retrieval, query related historical work session records:
    - If anything is unclear or ambiguous, ask clarifying questions now
    - If clarifying questions were needed above, get user approval on the resolved answers. If no clarifications were needed, proceed without a separate approval step — plan scope is the plan's authority, not something to renegotiate
    - **Do not skip this** - better to ask questions now than build the wrong thing
-   - **Do not edit the plan body during execution.** The plan is a decision artifact; progress lives in git commits and the task tracker. The only plan mutation during gh:work is the final `status: active` -> `status: completed` flip at shipping (see `references/shipping-workflow.md` Phase 4 Step 2). Legacy plans may contain `- [ ]` / `- [x]` marks on unit headings — ignore them as state; per-unit completion is determined during execution by reading the current file state.
+   - **Do not edit the plan body or frontmatter during execution.** The plan is a decision artifact; progress and shipped state live in git commits, PRs, and the task tracker. Legacy plans may contain `status:` frontmatter or `- [ ]` / `- [x]` marks on unit headings — ignore them as state; per-unit completion is determined during execution by reading the current file state.
    - For non-trivial work, establish the execution contract before editing: current assumptions, minimal change, explicit non-goals, and verification criteria. Derive it from the plan when available; if the plan is thin, state it briefly from the prompt and repo scan.
 
 2. **Setup Environment**

--- a/plugins/galeharness-cli/skills/gh-work/references/non-code-execution.md
+++ b/plugins/galeharness-cli/skills/gh-work/references/non-code-execution.md
@@ -9,7 +9,7 @@ Do not run code-shipping machinery for knowledge-work plans:
 - No branch/worktree setup.
 - No implementation-unit task list keyed on `Files:`.
 - No Test Discovery or system-wide test check.
-- No incremental code commits, PR flow, or `references/shipping-workflow.md` status flip.
+- No incremental code commits, PR flow, or plan-status mutation.
 
 ## Execute The Production Plan
 

--- a/plugins/galeharness-cli/skills/gh-work/references/shipping-workflow.md
+++ b/plugins/galeharness-cli/skills/gh-work/references/shipping-workflow.md
@@ -58,12 +58,9 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    Note whether the completed work has observable behavior (UI rendering, CLI output, API/library behavior with a runnable example, generated artifacts, or workflow output). The `git-commit-push-pr` skill will ask whether to capture evidence only when evidence is possible.
 
-2. **Update Plan Status**
+2. **Leave The Plan Read-Only**
 
-   If the input document has YAML frontmatter with a `status` field, update it to `completed`:
-   ```
-   status: active  ->  status: completed
-   ```
+   Do not update plan frontmatter or body state during shipping. The plan is a decision artifact; shipped state is derived from git commits, PR metadata, and task-board events. If a legacy plan has `status:` frontmatter, leave it unchanged rather than rewriting history.
 
 3. **Commit and Create Pull Request**
 


### PR DESCRIPTION
### Motivation
- Incorporate selected upstream Compound Engineering v3.12 workflow semantics (HTML-first ideation and status-free plan semantics) into the GaleHarnessCLI workflow while preserving Gale-specific naming and HKTMemory hooks.
- Make `gh:ideate` produce a durable, human-facing artifact by default and reduce fragile status-based handoffs between ideation → brainstorm → plan.

### Description
- Make `gh:ideate` default to a single self-contained HTML artifact and add an explicit `output:md` escape hatch, with mutually-exclusive-per-run artifact semantics; new rendering references added at `plugins/galeharness-cli/skills/gh-ideate/references/{html-rendering,markdown-rendering}.md` and `gh:ideate` SKILL.md updated to surface `output` handling and write-path behavior.
- Change post-ideation handoff and artifact policy so runs write exactly one artifact (HTML by default) before the next-step menu and pass the selected idea substance directly into `gh:brainstorm` instead of relying on legacy status markers; update `post-ideation-workflow.md` accordingly.
- Treat plans as read-only decision artifacts at execution time: `gh:plan` templates no longer require `status: active`, and both `gh:work` and `gh:work-beta` are updated to avoid mutating plan frontmatter/body during shipping; shipping workflow references now instruct the runtime to derive shipped state from git/PR/task metadata instead of editing plan files.
- Add a short solution doc recording the upstream mapping and the rationale for this selective adaptation under `docs/solutions/workflow/`; update plugin `README.md` and other skill docs to reflect the new ideation output model and the chosen adaptation approach.

### Testing
- Ran release metadata validation: `bun run release:validate` — success.
- Ran focused test sets that exercise the modified workflow surfaces: `bun test tests/pipeline-review-contract.test.ts tests/upstream-capability-skills.test.ts` and the trio `tests/upstream-capability-skills.test.ts tests/agent-reference-contract.test.ts tests/hkt-memory-compounding.test.ts` — these targeted checks passed.
- Executed the full test suite (`bun test`) as an environment-level smoke check; the run exposed unrelated environment/network issues (HKTMemory / external network fetches and a Codex home expectation) that caused several unrelated smoke failures, but the plugin/workflow-focused tests above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c9ca242308321a331c06898fb8e5b)